### PR TITLE
38-begin-interpreter-cleaning

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -211,7 +211,7 @@ ComposablePresenter >> aboutText: aString [
 
 { #category : #api }
 ComposablePresenter >> adapterFrom: aSpecLayout model: aModel [
-	^ SpecInterpreter interpretASpec: aSpecLayout model: aModel
+	^ SpecInterpreter interpretASpec: aSpecLayout presenter: aModel
 ]
 
 { #category : #private }

--- a/src/Spec-Core/ContainerPresenter.class.st
+++ b/src/Spec-Core/ContainerPresenter.class.st
@@ -27,14 +27,12 @@ ContainerPresenter class >> defaultSpec [
 { #category : #api }
 ContainerPresenter >> buildAdapterWithSpec [
 	"Build the widget using the spec name provided as argument"
-	| adapter widget aSpecLayout |	
-	aSpecLayout := (self retrieveSpec: self defaultSpecSelector).
-	adapter := SpecInterpreter 
-		private_interpretASpec: aSpecLayout
-		model: self
-		selector: self defaultSpecSelector.
+
+	| adapter widget aSpecLayout |
+	aSpecLayout := self retrieveSpec: self defaultSpecSelector.
+	adapter := SpecInterpreter interpretASpec: aSpecLayout model: self selector: self defaultSpecSelector.
 	widget := adapter widget.
-	self setExtentAndBindingTo: widget. 
+	self setExtentAndBindingTo: widget.
 	^ adapter
 ]
 

--- a/src/Spec-Core/ContainerPresenter.class.st
+++ b/src/Spec-Core/ContainerPresenter.class.st
@@ -30,7 +30,10 @@ ContainerPresenter >> buildAdapterWithSpec [
 
 	| adapter widget aSpecLayout |
 	aSpecLayout := self retrieveSpec: self defaultSpecSelector.
-	adapter := SpecInterpreter interpretASpec: aSpecLayout model: self selector: self defaultSpecSelector.
+	adapter := SpecInterpreter
+		interpretASpec: aSpecLayout
+		presenter: self
+		selector: self defaultSpecSelector.
 	widget := adapter widget.
 	self setExtentAndBindingTo: widget.
 	^ adapter

--- a/src/Spec-Core/CurrentSpecDefaultBindings.class.st
+++ b/src/Spec-Core/CurrentSpecDefaultBindings.class.st
@@ -1,8 +1,13 @@
 "
-Dynamic variable for Spec on which of the bindings (Morphic or other) should be used as default
+Use my superclass. I am deprecated.
 "
 Class {
 	#name : #CurrentSpecDefaultBindings,
-	#superclass : #DynamicVariable,
+	#superclass : #SpecBindings,
 	#category : #'Spec-Core-Support'
 }
+
+{ #category : #deprecation }
+CurrentSpecDefaultBindings class >> isDeprecated [
+	^ true
+]

--- a/src/Spec-Core/ManifestSpecCore.class.st
+++ b/src/Spec-Core/ManifestSpecCore.class.st
@@ -48,11 +48,6 @@ ManifestSpecCore class >> ruleSubclassResponsibilityNotDefinedRuleV1FalsePositiv
 ]
 
 { #category : #'code-critics' }
-ManifestSpecCore class >> ruleUnwindBlocksRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#'SpecInterpreter class' #interpretASpec:model:selector: #true)) #'2016-07-01T15:56:13.479538+02:00') )
-]
-
-{ #category : #'code-critics' }
 ManifestSpecCore class >> ruleUsesTrueRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'DiffPresenter class' #exampleWithOptions #true)) #'2016-07-01T15:56:13.475288+02:00') )
 ]

--- a/src/Spec-Core/SpecBindings.class.st
+++ b/src/Spec-Core/SpecBindings.class.st
@@ -1,0 +1,16 @@
+"
+Dynamic variable for Spec on which of the bindings (Morphic or other) should be used as default.
+
+
+Example: 
+------------
+
+```
+	SpecBindings value: #MorphicAdapterBindings during: [ monUI openWithSpec ].
+```
+"
+Class {
+	#name : #SpecBindings,
+	#superclass : #DynamicVariable,
+	#category : #'Spec-Core-Support'
+}

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -5,10 +5,10 @@ Class {
 	#name : #SpecInterpreter,
 	#superclass : #Object,
 	#instVars : [
-		'model',
 		'spec',
 		'arrayToInterpret',
-		'index'
+		'index',
+		'presenter'
 	],
 	#category : #'Spec-Core-Utilities'
 }
@@ -73,9 +73,9 @@ SpecInterpreter >> computeSpecFrom: aSymbol selector: aSelector [
 			result := self convertSymbolOfClassToInstance: aSymbol.
 			result isSpecContainer
 				ifTrue: [ result := result buildAdapterWithSpec.
-					model addDependent: result ].
+					self presenter addDependent: result ].
 			result ]
-		ifFalse: [ self class interpretASpec: aSymbol model: model selector: aSelector ].
+		ifFalse: [ self class interpretASpec: aSymbol model: self presenter selector: aSelector ].
 		
 	^ SpecWrapper instance: instance selector: aSelector
 ]
@@ -105,15 +105,14 @@ SpecInterpreter >> extractArrayToInterpretFrom: aFragment [
 	(aFragment isString or: [ aFragment isText ])
 		ifTrue: [ 
 			^ aFragment == #model
-				ifTrue: [ model ]
+				ifTrue: [ self presenter ]
 				ifFalse: [ self convertSymbolOfClassToInstance: aFragment ] ].
 	^ nil
 ]
 
 { #category : #interpreting }
-SpecInterpreter >> interpretASpec: aPresenter model: aModel  selector: aSelector [
-	
-	self model: aModel.
+SpecInterpreter >> interpretASpec: aPresenter model: aModel selector: aSelector [
+	self presenter: aModel.
 	^ self interpretASpec: aPresenter selector: aSelector
 ]
 
@@ -140,20 +139,21 @@ SpecInterpreter >> interpretASpec: aPresenter selector: aSelector [
 	"If you get here, there is a problem. Must probably it comes from the Spec which is wrongly defined"
 	self assert: arrayToInterpret size < 2.
 	
-	(model respondsTo: #spec:)
-		ifTrue: [ model spec: spec ].
+	self presenter spec: spec.
 		
 	^ spec instance
 ]
 
 { #category : #accessing }
 SpecInterpreter >> model [
-	^ model
+	self deprecated: 'Use #presenter instead' transformWith: '`@receiver model' -> '`@receiver presenter'.
+	^ self presenter
 ]
 
 { #category : #accessing }
 SpecInterpreter >> model: anObject [
-	model := anObject
+	self deprecated: 'Use #presenter: instead' transformWith: '`@receiver model: `@statment1' -> '`@receiver presenter: `@statment1'.
+	self presenter: anObject
 ]
 
 { #category : #'interpreting-private' }
@@ -174,39 +174,50 @@ SpecInterpreter >> performNextSelectorAndIncrementIndex [
 			numArgs := 0.
 			args := array allButFirst ].
 	
-	args := args collect: [ :each | self class interpretASpec: each model: model selector: spec selector ].
+	args := args collect: [ :each | self class interpretASpec: each model: self presenter selector: spec selector ].
 
 	index := index + numArgs + 1.
 	^ self actionToPerformWithSelector: selector arguments: args
 ]
 
+{ #category : #accessing }
+SpecInterpreter >> presenter [
+	^ presenter
+]
+
+{ #category : #accessing }
+SpecInterpreter >> presenter: anObject [
+	presenter := anObject
+]
+
 { #category : #'interpreting-private' }
 SpecInterpreter >> retrieveSpecFrom: aPresenter selector: aSelector [
-
-	((self model respondsTo: #needRebuild) and: [ self model needRebuild not and: [ self model spec notNil ] ])
-		ifTrue: [
-			spec := self model spec.
-			self model needRebuild: true.
-			((spec respondsTo: #isRedrawable) and: [ spec instance isSpecAdapter ])
-				ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ]
-				ifTrue: [ 
-					spec isRedrawable
+	((self presenter respondsTo: #needRebuild)
+		and: [ self presenter needRebuild not and: [ self presenter spec notNil ] ])
+		ifTrue: [ spec := self presenter spec.
+			self presenter needRebuild: true.
+			((spec respondsTo: #isRedrawable)
+				and: [ spec instance isSpecAdapter ])
+				ifFalse: [ spec := self
+						computeSpecFrom: arrayToInterpret first
+						selector: aSelector ]
+				ifTrue: [ spec isRedrawable
 						ifTrue: [ spec removeSubWidgets ]
 						ifFalse: [ ^ spec instance ] ] ]
-		ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ].
-	
+		ifFalse: [ spec := self
+				computeSpecFrom: arrayToInterpret first
+				selector: aSelector ].
 	aSelector
-		ifNil: [ aPresenter isSpecLayout ifTrue: [ spec selector: aPresenter selector ] ]
+		ifNil: [ aPresenter isSpecLayout
+				ifTrue: [ spec selector: aPresenter selector ] ]
 		ifNotNil: [ spec selector: aSelector ].
-		
 	^ nil
 ]
 
 { #category : #'interpreting-private' }
 SpecInterpreter >> returnInterpretationOf: newInstance [
 	| result |
-	(model respondsTo: #spec:)
-		ifTrue: [ model spec: spec ].
+	self presenter spec: spec.
 	result := self class interpretASpec: newInstance model: spec instance selector: spec selector.
 	^ (result isKindOf: ComposablePresenter)
 		ifTrue: [ result private_buildWithSpec ]

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -36,21 +36,42 @@ SpecInterpreter class >> hardResetBindings [
 
 { #category : #protocol }
 SpecInterpreter class >> interpretASpec: aSpec model: aPresenter [
-	^ self interpretASpec: aSpec model: aPresenter selector: nil
+	self
+		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter` instead'
+		transformWith:
+			'`@receiver interpretASpec: `@statements1 model: `@statements2'
+				-> '`@receiver interpretASpec: `@statements1 presenter: `@statements2'.
+	^ self interpretASpec: aSpec presenter: aPresenter selector: nil
 ]
 
 { #category : #protocol }
 SpecInterpreter class >> interpretASpec: aSpec model: aPresenter selector: aSelector [
+	self
+		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter selector: aSelector` instead'
+		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2 selector: `@statements3' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2 selector: `@statements3'.
+		
+	^ self interpretASpec: aSpec presenter: aPresenter selector: aSelector
+]
+
+{ #category : #protocol }
+SpecInterpreter class >> interpretASpec: aSpec presenter: aPresenter [
+	^ self interpretASpec: aSpec presenter: aPresenter selector: nil
+]
+
+{ #category : #protocol }
+SpecInterpreter class >> interpretASpec: aSpec presenter: aPresenter selector: aSelector [
 	^ self new
 		interpretASpec: aSpec
-		model: aPresenter
+		presenter: aPresenter
 		selector: aSelector
 ]
 
 { #category : #private }
 SpecInterpreter class >> private_buildWidgetFor: aComposablePresenter withSpec: aSymbol [
-	
-	^ self interpretASpec: (aComposablePresenter retrieveSpec: aSymbol) model: aComposablePresenter selector: aSymbol
+	^ self
+		interpretASpec: (aComposablePresenter retrieveSpec: aSymbol)
+		presenter: aComposablePresenter
+		selector: aSymbol
 ]
 
 { #category : #'interpreting-private' }
@@ -75,8 +96,10 @@ SpecInterpreter >> computeSpecFrom: aSymbol selector: aSelector [
 				ifTrue: [ result := result buildAdapterWithSpec.
 					self presenter addDependent: result ].
 			result ]
-		ifFalse: [ self class interpretASpec: aSymbol model: self presenter selector: aSelector ].
-		
+		ifFalse: [ self class
+				interpretASpec: aSymbol
+				presenter: self presenter
+				selector: aSelector ].
 	^ SpecWrapper instance: instance selector: aSelector
 ]
 
@@ -112,6 +135,15 @@ SpecInterpreter >> extractArrayToInterpretFrom: aFragment [
 
 { #category : #interpreting }
 SpecInterpreter >> interpretASpec: aSpec model: aPresenter selector: aSelector [
+	self
+		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter selector: aSelector` instead'
+		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2 selector: `@statements3' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2 selector: `@statements3'.
+
+	^ self interpretASpec: aSpec presenter: aPresenter selector: aSelector
+]
+
+{ #category : #interpreting }
+SpecInterpreter >> interpretASpec: aSpec presenter: aPresenter selector: aSelector [
 	self presenter: aPresenter.
 	^ self interpretASpec: aSpec selector: aSelector
 ]
@@ -159,23 +191,23 @@ SpecInterpreter >> model: anObject [
 { #category : #'interpreting-private' }
 SpecInterpreter >> performNextSelectorAndIncrementIndex [
 	| args numArgs selector |
-
-	selector := (arrayToInterpret at: index).
+	selector := arrayToInterpret at: index.
 	selector isArray not
-		ifTrue: [ 
-			selector := selector asSymbol.
+		ifTrue: [ selector := selector asSymbol.
 			numArgs := selector numArgs.
 			args := arrayToInterpret copyFrom: index + 1 to: index + numArgs ]
-		ifFalse: [ 
-			"Here I assume that if it's not a symbol, it's a collection"
+		ifFalse: [ "Here I assume that if it's not a symbol, it's a collection"
 			| array |
 			array := selector.
 			selector := array first.
 			numArgs := 0.
 			args := array allButFirst ].
-	
-	args := args collect: [ :each | self class interpretASpec: each model: self presenter selector: spec selector ].
-
+	args := args
+		collect: [ :each | 
+			self class
+				interpretASpec: each
+				presenter: self presenter
+				selector: spec selector ].
 	index := index + numArgs + 1.
 	^ self actionToPerformWithSelector: selector arguments: args
 ]
@@ -186,8 +218,8 @@ SpecInterpreter >> presenter [
 ]
 
 { #category : #accessing }
-SpecInterpreter >> presenter: anObject [
-	presenter := anObject
+SpecInterpreter >> presenter: aPresenter [
+	presenter := aPresenter
 ]
 
 { #category : #'interpreting-private' }
@@ -212,7 +244,10 @@ SpecInterpreter >> retrieveSpecFrom: aSpec selector: aSelector [
 SpecInterpreter >> returnInterpretationOf: newInstance [
 	| result |
 	self presenter spec: spec.
-	result := self class interpretASpec: newInstance model: spec instance selector: spec selector.
+	result := self class
+		interpretASpec: newInstance
+		presenter: spec instance
+		selector: spec selector.
 	^ (result isKindOf: ComposablePresenter)
 		ifTrue: [ result private_buildWithSpec ]
 		ifFalse: [ result ]

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -35,15 +35,15 @@ SpecInterpreter class >> hardResetBindings [
 ]
 
 { #category : #protocol }
-SpecInterpreter class >> interpretASpec: aSpec model: aModel [
-	^ self interpretASpec: aSpec model: aModel selector: nil
+SpecInterpreter class >> interpretASpec: aSpec model: aPresenter [
+	^ self interpretASpec: aSpec model: aPresenter selector: nil
 ]
 
 { #category : #protocol }
-SpecInterpreter class >> interpretASpec: aPresenter model: aModel selector: aSelector [
+SpecInterpreter class >> interpretASpec: aSpec model: aPresenter selector: aSelector [
 	^ self new
-		interpretASpec: aPresenter
-		model: aModel
+		interpretASpec: aSpec
+		model: aPresenter
 		selector: aSelector
 ]
 
@@ -111,18 +111,18 @@ SpecInterpreter >> extractArrayToInterpretFrom: aFragment [
 ]
 
 { #category : #interpreting }
-SpecInterpreter >> interpretASpec: aPresenter model: aModel selector: aSelector [
-	self presenter: aModel.
-	^ self interpretASpec: aPresenter selector: aSelector
+SpecInterpreter >> interpretASpec: aSpec model: aPresenter selector: aSelector [
+	self presenter: aPresenter.
+	^ self interpretASpec: aSpec selector: aSelector
 ]
 
 { #category : #interpreting }
-SpecInterpreter >> interpretASpec: aPresenter selector: aSelector [
-	aPresenter ifNil: [ ^ nil ].
+SpecInterpreter >> interpretASpec: aSpec selector: aSelector [
+	aSpec ifNil: [ ^ nil ].
 	
-	(self extractArrayToInterpretFrom: aPresenter) ifNotNil: [ :result | ^ result ].
+	(self extractArrayToInterpretFrom: aSpec) ifNotNil: [ :result | ^ result ].
 	
-	(self retrieveSpecFrom: aPresenter selector: aSelector)
+	(self retrieveSpecFrom: aSpec selector: aSelector)
 		ifNotNil: [ :instance | ^ instance ].
 
 	index := 2.
@@ -191,7 +191,7 @@ SpecInterpreter >> presenter: anObject [
 ]
 
 { #category : #'interpreting-private' }
-SpecInterpreter >> retrieveSpecFrom: aPresenter selector: aSelector [
+SpecInterpreter >> retrieveSpecFrom: aSpec selector: aSelector [
 	(self presenter needRebuild not and: [ self presenter spec notNil ])
 		ifTrue: [ spec := self presenter spec.
 			self presenter needRebuild: true.
@@ -202,8 +202,8 @@ SpecInterpreter >> retrieveSpecFrom: aPresenter selector: aSelector [
 						ifFalse: [ ^ spec instance ] ] ]
 		ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ].
 	aSelector
-		ifNil: [ aPresenter isSpecLayout
-				ifTrue: [ spec selector: aPresenter selector ] ]
+		ifNil: [ aSpec isSpecLayout
+				ifTrue: [ spec selector: aSpec selector ] ]
 		ifNotNil: [ spec selector: aSelector ].
 	^ nil
 ]

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -192,21 +192,15 @@ SpecInterpreter >> presenter: anObject [
 
 { #category : #'interpreting-private' }
 SpecInterpreter >> retrieveSpecFrom: aPresenter selector: aSelector [
-	((self presenter respondsTo: #needRebuild)
-		and: [ self presenter needRebuild not and: [ self presenter spec notNil ] ])
+	(self presenter needRebuild not and: [ self presenter spec notNil ])
 		ifTrue: [ spec := self presenter spec.
 			self presenter needRebuild: true.
-			((spec respondsTo: #isRedrawable)
-				and: [ spec instance isSpecAdapter ])
-				ifFalse: [ spec := self
-						computeSpecFrom: arrayToInterpret first
-						selector: aSelector ]
+			((spec respondsTo: #isRedrawable) and: [ spec instance isSpecAdapter ])
+				ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ]
 				ifTrue: [ spec isRedrawable
 						ifTrue: [ spec removeSubWidgets ]
 						ifFalse: [ ^ spec instance ] ] ]
-		ifFalse: [ spec := self
-				computeSpecFrom: arrayToInterpret first
-				selector: aSelector ].
+		ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ].
 	aSelector
 		ifNil: [ aPresenter isSpecLayout
 				ifTrue: [ spec selector: aPresenter selector ] ]

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -10,70 +10,47 @@ Class {
 		'arrayToInterpret',
 		'index'
 	],
-	#classInstVars : [
-		'bindings'
-	],
 	#category : #'Spec-Core-Utilities'
 }
 
 { #category : #accessing }
 SpecInterpreter class >> bindings [
-
-	^ self defaultBindings 
+	^ (SpecBindings value ifNil: [ self environment at: #MorphicAdapterBindings ]) new
 ]
 
 { #category : #accessing }
 SpecInterpreter class >> bindings: anAdapterBinding [
-
-	bindings := anAdapterBinding
+	self deprecated: 'Never worked.'
 ]
 
 { #category : #private }
 SpecInterpreter class >> defaultBindings [
-	
-	^ (CurrentSpecDefaultBindings value ifNil: [ self environment at: #MorphicAdapterBindings]) new
-	
+	self deprecated: 'Use #bindings instead.' transformWith: '`@receiver defaultBindings' -> '`@receiver bindings'.
+	^ self bindings
 ]
 
 { #category : #accessing }
 SpecInterpreter class >> hardResetBindings [
-
-	bindings := nil
+	self deprecated: 'Never worked'
 ]
 
 { #category : #protocol }
 SpecInterpreter class >> interpretASpec: aSpec model: aModel [
-	
-	^ self
-		interpretASpec: aSpec
-		model: aModel
-		selector: nil
+	^ self interpretASpec: aSpec model: aModel selector: nil
 ]
 
 { #category : #protocol }
 SpecInterpreter class >> interpretASpec: aPresenter model: aModel selector: aSelector [
-	| result |
-	
-	 [ result :=  self 
-				private_interpretASpec: aPresenter
-				model: aModel
-				selector: aSelector ] ensure: [ self hardResetBindings ].
-	^ result
+	^ self new
+		interpretASpec: aPresenter
+		model: aModel
+		selector: aSelector
 ]
 
 { #category : #private }
 SpecInterpreter class >> private_buildWidgetFor: aComposablePresenter withSpec: aSymbol [
 	
-	^ self private_interpretASpec: (aComposablePresenter retrieveSpec: aSymbol) model: aComposablePresenter selector: aSymbol
-]
-
-{ #category : #private }
-SpecInterpreter class >> private_interpretASpec: aPresenter model: aModel selector: aSelector [
-	
-	^ self new
-		interpretASpec: aPresenter
-		model: aModel
-		selector: aSelector
+	^ self interpretASpec: (aComposablePresenter retrieveSpec: aSymbol) model: aComposablePresenter selector: aSymbol
 ]
 
 { #category : #'interpreting-private' }
@@ -91,20 +68,16 @@ SpecInterpreter >> bindings [
 { #category : #'interpreting-private' }
 SpecInterpreter >> computeSpecFrom: aSymbol selector: aSelector [
 	| instance |
-
 	instance := (aSymbol isSymbol and: [ aSymbol ~= #model ])
 		ifTrue: [ | result |
 			result := self convertSymbolOfClassToInstance: aSymbol.
 			result isSpecContainer
-				ifTrue: [ 
-					result := result buildAdapterWithSpec.
+				ifTrue: [ result := result buildAdapterWithSpec.
 					model addDependent: result ].
 			result ]
-		ifFalse: [ self class private_interpretASpec: aSymbol model: model selector: aSelector ].
+		ifFalse: [ self class interpretASpec: aSymbol model: model selector: aSelector ].
 		
-	^ SpecWrapper
-		instance: instance
-		selector: aSelector
+	^ SpecWrapper instance: instance selector: aSelector
 ]
 
 { #category : #bindings }
@@ -201,7 +174,7 @@ SpecInterpreter >> performNextSelectorAndIncrementIndex [
 			numArgs := 0.
 			args := array allButFirst ].
 	
-	args := args collect: [ :each | self class private_interpretASpec: each model: model selector: spec selector ].
+	args := args collect: [ :each | self class interpretASpec: each model: model selector: spec selector ].
 
 	index := index + numArgs + 1.
 	^ self actionToPerformWithSelector: selector arguments: args
@@ -234,11 +207,8 @@ SpecInterpreter >> returnInterpretationOf: newInstance [
 	| result |
 	(model respondsTo: #spec:)
 		ifTrue: [ model spec: spec ].
-	result := self class private_interpretASpec: newInstance model: spec instance selector: spec selector.
+	result := self class interpretASpec: newInstance model: spec instance selector: spec selector.
 	^ (result isKindOf: ComposablePresenter)
-		ifTrue: [ 
-			| return |
-			return := result private_buildWithSpec.
-			^ return ]
-		ifFalse: [ ^ result ]
+		ifTrue: [ result private_buildWithSpec ]
+		ifFalse: [ result ]
 ]

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -73,11 +73,9 @@ SpecInterpreterTest >> testDynamicBuild [
 
 { #category : #tests }
 SpecInterpreterTest >> testInterpretASpecModelMorphAssociation [
-
 	| spec model morph |
 	model := AbstractWidgetPresenter new.
-	spec := {#PluggableListMorph. #model:. #model}.
-	morph := specInterpreterClass interpretASpec: spec model: model.
-	
-	self assert: (model widget == morph).
+	spec := {#PluggableListMorph . #model: . #model}.
+	morph := specInterpreterClass interpretASpec: spec presenter: model.
+	self assert: model widget == morph
 ]

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -18,7 +18,7 @@ SpecInterpreterTest >> setUp [
 	super setUp.
 	specInterpreterClass := SpecInterpreter.
 	specInterpreter := specInterpreterClass new.
-	specInterpreter model: TestingComposablePresenter new
+	specInterpreter presenter: TestingComposablePresenter new
 ]
 
 { #category : #running }


### PR DESCRIPTION
- Rename dynamic variable for spec bindings
- Remove useless class instance variable
- Remove default system where the default was always used
- Some more cleanings

Fixes #38 