### PR TITLE
46-remove-selector-from-SpecLayout

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -968,11 +968,7 @@ ComposablePresenter >> resolveSymbol: aSymbol [
 
 { #category : #api }
 ComposablePresenter >> retrieveSpec: aSelector [
-	| layout |
-	
-	layout := self class perform: aSelector.
-	layout isSpecLayout ifTrue: [ layout selector: aSelector ].
-	^ layout
+	^ self class perform: aSelector
 ]
 
 { #category : #api }

--- a/src/Spec-Core/ContainerPresenter.class.st
+++ b/src/Spec-Core/ContainerPresenter.class.st
@@ -30,10 +30,7 @@ ContainerPresenter >> buildAdapterWithSpec [
 
 	| adapter widget aSpecLayout |
 	aSpecLayout := self retrieveSpec: self defaultSpecSelector.
-	adapter := SpecInterpreter
-		interpretASpec: aSpecLayout
-		presenter: self
-		selector: self defaultSpecSelector.
+	adapter := SpecInterpreter interpretASpec: aSpecLayout presenter: self.
 	widget := adapter widget.
 	self setExtentAndBindingTo: widget.
 	^ adapter

--- a/src/Spec-Core/DynamicComposablePresenter.class.st
+++ b/src/Spec-Core/DynamicComposablePresenter.class.st
@@ -107,8 +107,6 @@ DynamicComposablePresenter >> retrieveSpec: aSelector [
 	self layout ifNil: [ ^ super retrieveSpec: aSelector ].
 
 	^ self layout
-		selector: aSelector;
-		yourself
 ]
 
 { #category : #accessing }

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -38,40 +38,28 @@ SpecInterpreter class >> hardResetBindings [
 SpecInterpreter class >> interpretASpec: aSpec model: aPresenter [
 	self
 		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter` instead'
-		transformWith:
-			'`@receiver interpretASpec: `@statements1 model: `@statements2'
-				-> '`@receiver interpretASpec: `@statements1 presenter: `@statements2'.
-	^ self interpretASpec: aSpec presenter: aPresenter selector: nil
+		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2'.
+		
+	^ self interpretASpec: aSpec presenter: aPresenter
 ]
 
 { #category : #protocol }
 SpecInterpreter class >> interpretASpec: aSpec model: aPresenter selector: aSelector [
 	self
-		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter selector: aSelector` instead'
-		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2 selector: `@statements3' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2 selector: `@statements3'.
+		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter` instead'
+		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2 selector: `@statements3' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2'.
 		
-	^ self interpretASpec: aSpec presenter: aPresenter selector: aSelector
+	^ self interpretASpec: aSpec presenter: aPresenter
 ]
 
 { #category : #protocol }
 SpecInterpreter class >> interpretASpec: aSpec presenter: aPresenter [
-	^ self interpretASpec: aSpec presenter: aPresenter selector: nil
-]
-
-{ #category : #protocol }
-SpecInterpreter class >> interpretASpec: aSpec presenter: aPresenter selector: aSelector [
-	^ self new
-		interpretASpec: aSpec
-		presenter: aPresenter
-		selector: aSelector
+	^ self new interpretASpec: aSpec presenter: aPresenter
 ]
 
 { #category : #private }
 SpecInterpreter class >> private_buildWidgetFor: aComposablePresenter withSpec: aSymbol [
-	^ self
-		interpretASpec: (aComposablePresenter retrieveSpec: aSymbol)
-		presenter: aComposablePresenter
-		selector: aSymbol
+	^ self interpretASpec: (aComposablePresenter retrieveSpec: aSymbol) presenter: aComposablePresenter
 ]
 
 { #category : #'interpreting-private' }
@@ -87,7 +75,7 @@ SpecInterpreter >> bindings [
 ]
 
 { #category : #'interpreting-private' }
-SpecInterpreter >> computeSpecFrom: aSymbol selector: aSelector [
+SpecInterpreter >> computeSpecFrom: aSymbol [
 	| instance |
 	instance := (aSymbol isSymbol and: [ aSymbol ~= #model ])
 		ifTrue: [ | result |
@@ -96,11 +84,8 @@ SpecInterpreter >> computeSpecFrom: aSymbol selector: aSelector [
 				ifTrue: [ result := result buildAdapterWithSpec.
 					self presenter addDependent: result ].
 			result ]
-		ifFalse: [ self class
-				interpretASpec: aSymbol
-				presenter: self presenter
-				selector: aSelector ].
-	^ SpecWrapper instance: instance selector: aSelector
+		ifFalse: [ self class interpretASpec: aSymbol presenter: self presenter ].
+	^ SpecWrapper instance: instance
 ]
 
 { #category : #bindings }
@@ -134,28 +119,12 @@ SpecInterpreter >> extractArrayToInterpretFrom: aFragment [
 ]
 
 { #category : #interpreting }
-SpecInterpreter >> interpretASpec: aSpec model: aPresenter selector: aSelector [
-	self
-		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter selector: aSelector` instead'
-		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2 selector: `@statements3' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2 selector: `@statements3'.
-
-	^ self interpretASpec: aSpec presenter: aPresenter selector: aSelector
-]
-
-{ #category : #interpreting }
-SpecInterpreter >> interpretASpec: aSpec presenter: aPresenter selector: aSelector [
-	self presenter: aPresenter.
-	^ self interpretASpec: aSpec selector: aSelector
-]
-
-{ #category : #interpreting }
-SpecInterpreter >> interpretASpec: aSpec selector: aSelector [
+SpecInterpreter >> interpretASpec: aSpec [
 	aSpec ifNil: [ ^ nil ].
 	
 	(self extractArrayToInterpretFrom: aSpec) ifNotNil: [ :result | ^ result ].
 	
-	(self retrieveSpecFrom: aSpec selector: aSelector)
-		ifNotNil: [ :instance | ^ instance ].
+	(self retrieveSpecFrom: aSpec) ifNotNil: [ :instance | ^ instance ].
 
 	index := 2.
 	[ index <= arrayToInterpret size ]
@@ -174,6 +143,21 @@ SpecInterpreter >> interpretASpec: aSpec selector: aSelector [
 	self presenter spec: spec.
 		
 	^ spec instance
+]
+
+{ #category : #interpreting }
+SpecInterpreter >> interpretASpec: aSpec model: aPresenter selector: aSelector [
+	self
+		deprecated: 'Use `interpretASpec: aSpec presenter: aPresenter` instead'
+		transformWith: '`@receiver interpretASpec: `@statements1 model: `@statements2 selector: `@statements3' -> '`@receiver interpretASpec: `@statements1 presenter: `@statements2'.
+
+	^ self interpretASpec: aSpec presenter: aPresenter
+]
+
+{ #category : #interpreting }
+SpecInterpreter >> interpretASpec: aSpec presenter: aPresenter [
+	self presenter: aPresenter.
+	^ self interpretASpec: aSpec
 ]
 
 { #category : #accessing }
@@ -206,8 +190,7 @@ SpecInterpreter >> performNextSelectorAndIncrementIndex [
 		collect: [ :each | 
 			self class
 				interpretASpec: each
-				presenter: self presenter
-				selector: spec selector ].
+				presenter: self presenter ].
 	index := index + numArgs + 1.
 	^ self actionToPerformWithSelector: selector arguments: args
 ]
@@ -223,20 +206,17 @@ SpecInterpreter >> presenter: aPresenter [
 ]
 
 { #category : #'interpreting-private' }
-SpecInterpreter >> retrieveSpecFrom: aSpec selector: aSelector [
+SpecInterpreter >> retrieveSpecFrom: aSpec [
 	(self presenter needRebuild not and: [ self presenter spec notNil ])
 		ifTrue: [ spec := self presenter spec.
 			self presenter needRebuild: true.
 			((spec respondsTo: #isRedrawable) and: [ spec instance isSpecAdapter ])
-				ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ]
+				ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first ]
 				ifTrue: [ spec isRedrawable
 						ifTrue: [ spec removeSubWidgets ]
 						ifFalse: [ ^ spec instance ] ] ]
-		ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first selector: aSelector ].
-	aSelector
-		ifNil: [ aSpec isSpecLayout
-				ifTrue: [ spec selector: aSpec selector ] ]
-		ifNotNil: [ spec selector: aSelector ].
+		ifFalse: [ spec := self computeSpecFrom: arrayToInterpret first ].
+
 	^ nil
 ]
 
@@ -246,8 +226,7 @@ SpecInterpreter >> returnInterpretationOf: newInstance [
 	self presenter spec: spec.
 	result := self class
 		interpretASpec: newInstance
-		presenter: spec instance
-		selector: spec selector.
+		presenter: spec instance.
 	^ (result isKindOf: ComposablePresenter)
 		ifTrue: [ result private_buildWithSpec ]
 		ifFalse: [ result ]

--- a/src/Spec-Core/SpecWrapper.class.st
+++ b/src/Spec-Core/SpecWrapper.class.st
@@ -5,18 +5,16 @@ Class {
 	#name : #SpecWrapper,
 	#superclass : #Object,
 	#instVars : [
-		'instance',
-		'selector'
+		'instance'
 	],
 	#category : #'Spec-Core-Utilities'
 }
 
 { #category : #'instance creation' }
-SpecWrapper class >> instance: instance selector: selector [
+SpecWrapper class >> instance: instance [
 
 	^ self new
 		instance: instance;
-		selector: selector;
 		yourself
 ]
 
@@ -42,16 +40,4 @@ SpecWrapper >> isRedrawable [
 SpecWrapper >> removeSubWidgets [
 	
 	^ self instance removeSubWidgets
-]
-
-{ #category : #accessing }
-SpecWrapper >> selector [
-	
-	^ selector
-]
-
-{ #category : #accessing }
-SpecWrapper >> selector: anObject [
-	
-	selector := anObject
 ]

--- a/src/Spec-Layout/SpecLayout.class.st
+++ b/src/Spec-Layout/SpecLayout.class.st
@@ -7,7 +7,6 @@ Class {
 	#instVars : [
 		'type',
 		'commands',
-		'selector',
 		'result',
 		'shouldCheckSplitters',
 		'currentOffset',
@@ -426,12 +425,12 @@ SpecLayout >> resetArrayComputation [
 
 { #category : #accessing }
 SpecLayout >> selector [
-	^ selector
+	self deprecated: 'This method it useless and adding a selector variable only make the code more complexe. It is now removed.'.
 ]
 
 { #category : #accessing }
 SpecLayout >> selector: anObject [
-	selector := anObject
+	self deprecated: 'This method it useless and adding a selector variable only make the code more complexe. It is now removed.'.
 ]
 
 { #category : #commands }


### PR DESCRIPTION
Remove SpecLayout selector variable. This commit also clean the Interpreter to remove the usage of the useless variable

Fixes #46