### PR TITLE
48-remove-duplication-in-interpreter

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -217,8 +217,13 @@ ComposablePresenter >> aboutText: aString [
 ]
 
 { #category : #api }
-ComposablePresenter >> adapterFrom: aSpecLayout model: aModel [
-	^ SpecInterpreter interpretASpec: aSpecLayout presenter: aModel
+ComposablePresenter >> adapterFrom: aSpecLayout [
+	^ SpecInterpreter interpretASpec: aSpecLayout presenter: self
+]
+
+{ #category : #api }
+ComposablePresenter >> adapterFromSelector: aSymbol [
+	^ self adapterFrom: (self retrieveSpec: aSymbol)
 ]
 
 { #category : #private }
@@ -298,6 +303,16 @@ ComposablePresenter >> bindMenuKeyCombination: aShortcut toAction: aBlock [
 ]
 
 { #category : #api }
+ComposablePresenter >> buildAdapterWithSpecLayout: aSpecLayout [
+	"Build the adapter using the spec name provided as argument"
+
+	| adapter |
+	adapter := self adapterFrom: aSpecLayout.
+	self setExtentAndBindingTo: adapter widget.
+	^ adapter
+]
+
+{ #category : #api }
 ComposablePresenter >> buildWithSpec [
 	"Build the widget using the default spec"
 	
@@ -314,11 +329,8 @@ ComposablePresenter >> buildWithSpec: aSpec [
 { #category : #api }
 ComposablePresenter >> buildWithSpecLayout: aSpecLayout [
 	"Build the widget using the spec name provided as argument"
-	| widget adapter|
-	adapter := self adapterFrom: aSpecLayout model: self.
-	widget := adapter asWidget.
-	self setExtentAndBindingTo: widget.
-	^ widget
+
+	^ (self buildAdapterWithSpecLayout: aSpecLayout) widget
 ]
 
 { #category : #api }
@@ -898,28 +910,6 @@ ComposablePresenter >> owner [
 ComposablePresenter >> owner: anObject [
 
 	owner := anObject.
-]
-
-{ #category : #private }
-ComposablePresenter >> privateAdapterFromModel: aModel withSpec: aSpec [
-	"apparently when looking at the implementation, it does not return a widget but an adapter so it should be called adapter :)"
-	^ SpecInterpreter private_buildWidgetFor: self withSpec: aSpec.
-]
-
-{ #category : #private }
-ComposablePresenter >> private_buildWithSpec [
-	"Build the widget using the default spec"
-	
-	^ self private_buildWithSpec: self defaultSpecSelector
-]
-
-{ #category : #private }
-ComposablePresenter >> private_buildWithSpec: aSpec [
-	"Build the widget using the spec name provided as argument"
-	| adapter |
-	adapter := self privateAdapterFromModel: self withSpec: aSpec.
-	self setExtentAndBindingTo: adapter widget.	
-	^ adapter
 ]
 
 { #category : #'private-focus' }

--- a/src/Spec-Core/ContainerPresenter.class.st
+++ b/src/Spec-Core/ContainerPresenter.class.st
@@ -26,11 +26,8 @@ ContainerPresenter class >> defaultSpec [
 
 { #category : #api }
 ContainerPresenter >> buildAdapterWithSpec [
-	"Build the widget using the spec name provided as argument"
-
-	| adapter widget aSpecLayout |
-	aSpecLayout := self retrieveSpec: self defaultSpecSelector.
-	adapter := SpecInterpreter interpretASpec: aSpecLayout presenter: self.
+	| adapter widget |
+	adapter := self adapterFromSelector: self defaultSpecSelector.
 	widget := adapter widget.
 	self setExtentAndBindingTo: widget.
 	^ adapter

--- a/src/Spec-Core/DialogWindowPresenter.class.st
+++ b/src/Spec-Core/DialogWindowPresenter.class.st
@@ -33,9 +33,7 @@ DialogWindowPresenter >> buildWithSpecLayout: aSpec [
 	(self spec notNil and: [ self needRebuild not ])
 		ifTrue: [ widget := self spec instance ]
 		ifFalse: [ contents := self presenter buildWithSpecLayout: aSpec.
-			widget := self
-				privateAdapterFromModel: self
-				withSpec: self defaultSpecSelector.
+			widget := self adapterFromSelector: self defaultSpecSelector.
 			contents := nil ].
 	self extent
 		ifNotNil: [ :ex | 

--- a/src/Spec-Core/MenuGroupPresenter.class.st
+++ b/src/Spec-Core/MenuGroupPresenter.class.st
@@ -74,7 +74,7 @@ MenuGroupPresenter >> autoRefresh: aBoolean [
 MenuGroupPresenter >> buildWithSpecLayout: aSpecLayout [
 	"Build the widget using the spec name provided as argument"
 	| adapter widget|
-	adapter := self adapterFrom: aSpecLayout model: self.
+	adapter := self adapterFrom: aSpecLayout.
 	widget := adapter asWidget.
 	self announce: (WidgetBuilt model: self widget: widget).
 	^ widget

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -57,11 +57,6 @@ SpecInterpreter class >> interpretASpec: aSpec presenter: aPresenter [
 	^ self new interpretASpec: aSpec presenter: aPresenter
 ]
 
-{ #category : #private }
-SpecInterpreter class >> private_buildWidgetFor: aComposablePresenter withSpec: aSymbol [
-	^ self interpretASpec: (aComposablePresenter retrieveSpec: aSymbol) presenter: aComposablePresenter
-]
-
 { #category : #'interpreting-private' }
 SpecInterpreter >> actionToPerformWithSelector: selector arguments: args [
 
@@ -224,10 +219,8 @@ SpecInterpreter >> retrieveSpecFrom: aSpec [
 SpecInterpreter >> returnInterpretationOf: newInstance [
 	| result |
 	self presenter spec: spec.
-	result := self class
-		interpretASpec: newInstance
-		presenter: spec instance.
+	result := self class interpretASpec: newInstance presenter: spec instance.
 	^ (result isKindOf: ComposablePresenter)
-		ifTrue: [ result private_buildWithSpec ]
+		ifTrue: [ result buildAdapterWithSpecLayout: (result retrieveSpec: result defaultSpecSelector) ]
 		ifFalse: [ result ]
 ]

--- a/src/Spec-Core/WindowPresenter.class.st
+++ b/src/Spec-Core/WindowPresenter.class.st
@@ -84,17 +84,14 @@ WindowPresenter >> askOkToClose [
 { #category : #private }
 WindowPresenter >> buildWithSpecLayout: aSpec [
 	"Build the widget using the spec name provided as argument"
+
 	| adapter widget |
-	
 	(self spec notNil and: [ self needRebuild not ])
 		ifTrue: [ widget := self spec instance ]
-		ifFalse: [
-			adapter := self privateAdapterFromModel: self withSpec: self defaultSpecSelector.
+		ifFalse: [ adapter := self adapterFromSelector: self defaultSpecSelector.
 			widget := adapter widget.
 			self addModelIn: widget withSpecLayout: aSpec ].
-
 	self ensureExtentFor: widget.
-	
 	^ widget
 ]
 

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -31,15 +31,6 @@ SpecInterpreterTest >> tearDown [
 ]
 
 { #category : #tests }
-SpecInterpreterTest >> testBuildWidgetForWithSpec [
-	| model morph |
-	model := TestingComposablePresenter new.
-	morph := model buildWithSpec: #testingSpec.
-	self assert: morph model == model.
-	self assert: model widget class equals: RubPluggableTextMorph
-]
-
-{ #category : #tests }
 SpecInterpreterTest >> testConvertRandomSymbolOfClassToInstance [
 	| symbol instance |
 	symbol := #PluggableListMorph.

--- a/src/Spec-Tests/TestingComposablePresenter.class.st
+++ b/src/Spec-Tests/TestingComposablePresenter.class.st
@@ -20,11 +20,6 @@ TestingComposablePresenter class >> defaultSpec [
 ]
 
 { #category : #specs }
-TestingComposablePresenter class >> testingSpec [
-	^ {#RubPluggableTextMorph. #model:. #model. }
-]
-
-{ #category : #specs }
 TestingComposablePresenter class >> title [
 
 	^ 'You should not see me !'


### PR DESCRIPTION
Some cleaning of the interpreter.

This also remove one sender of Object>>#asWidget and a hack to create Morph from the Spec directly.

Fixes #48