### PR TITLE
81-do-not-use-window-value-everywhere

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -349,14 +349,13 @@ ComposablePresenter >> centerWidget: aWindow [
 
 { #category : #api }
 ComposablePresenter >> centered [
-
-	window value ifNotNil: [ :w | w centered ]
+	self presenterWindow ifNotNil: [ :w | w centered ]
 ]
 
 { #category : #api }
 ComposablePresenter >> centeredRelativeTo: aModel [
 
-	window value ifNotNil: [ :w | w centeredRelativeTo: aModel ]
+	self presenterWindow ifNotNil: [ :w | w centeredRelativeTo: aModel ]
 ]
 
 { #category : #'instance creation' }
@@ -408,10 +407,7 @@ ComposablePresenter >> defaultWindowPresenterClass [
 
 { #category : #private }
 ComposablePresenter >> delete [
-
-	window value
-		ifNil: [ self changed: #delete with: #() ]
-		ifNotNil: [ :w | w delete ]
+	self presenterWindow ifNil: [ self changed: #delete with: #() ] ifNotNil: [ :w | w delete ]
 ]
 
 { #category : #api }
@@ -879,14 +875,14 @@ ComposablePresenter >> openDialogWithSpec: aSpec [
 ComposablePresenter >> openDialogWithSpecLayout: aSpec [
 	"Build the widget using the spec name provided as argument and display it into a window"
 
-	(window value notNil and: [ self needRebuild not ])
-		ifTrue: [ window value rebuildWithSpec: aSpec ]
-		ifFalse: [ window value: (DialogWindowPresenter new presenter: self).
-			window value openWithSpecLayout: aSpec.
-			self initializeDialogWindow: window value.
-			window value updateTitle.
+	(self presenterWindow notNil and: [ self needRebuild not ])
+		ifTrue: [ self presenterWindow rebuildWithSpec: aSpec ]
+		ifFalse: [ self presenterWindow: (DialogWindowPresenter new presenter: self).
+			self presenterWindow openWithSpecLayout: aSpec.
+			self initializeDialogWindow: self presenterWindow.
+			self presenterWindow updateTitle.
 			self takeKeyboardFocus ].
-	^ window value
+	^ self presenterWindow
 ]
 
 { #category : #api }
@@ -907,12 +903,12 @@ ComposablePresenter >> openWithSpec: aSpec [
 ComposablePresenter >> openWithSpecLayout: aSpec [
 	"Build the widget using the spec name provided as argument and display it into a window"
 
-	(window value notNil and: [ self needRebuild not ])
-		ifTrue: [ window value rebuildWithSpecLayout: aSpec ]
-		ifFalse: [ window value: (self defaultWindowPresenterClass new presenter: self).
-			window value openWithSpecLayout: aSpec.
+	(self presenterWindow notNil and: [ self needRebuild not ])
+		ifTrue: [ self presenterWindow rebuildWithSpecLayout: aSpec ]
+		ifFalse: [ self presenterWindow: (self defaultWindowPresenterClass new presenter: self).
+			self presenterWindow openWithSpecLayout: aSpec.
 			self takeKeyboardFocus ].
-	^ window value
+	^ self presenterWindow
 ]
 
 { #category : #accessing }
@@ -925,6 +921,16 @@ ComposablePresenter >> owner [
 ComposablePresenter >> owner: anObject [
 
 	owner := anObject.
+]
+
+{ #category : #accessing }
+ComposablePresenter >> presenterWindow [
+	^ window value
+]
+
+{ #category : #accessing }
+ComposablePresenter >> presenterWindow: aWindow [
+	window value: aWindow
 ]
 
 { #category : #'private-focus' }
@@ -1112,12 +1118,7 @@ ComposablePresenter >> widget [
 
 { #category : #accessing }
 ComposablePresenter >> window [
-
-	^ window value
-		ifNil: [
-			owner
-				ifNil: [ nil ]
-				ifNotNil: [:o | o window ]]
+	^ self presenterWindow ifNil: [ owner ifNotNil: [ :o | o window ] ]
 ]
 
 { #category : #api }

--- a/src/Spec-MorphicAdapters/ComposablePresenter.extension.st
+++ b/src/Spec-MorphicAdapters/ComposablePresenter.extension.st
@@ -83,15 +83,12 @@ ComposablePresenter >> openWorldWithSpec: aSpec [
 ComposablePresenter >> openWorldWithSpecLayout: aSpec [
 	"Build the widget using the spec name provided as argument and display it into the world"
 
-	(window value notNil and: [ self needRebuild not ])
-		ifTrue: [
-			window value rebuildWithSpecLayout: aSpec ]
-		ifFalse: [ 
-			window value: (WorldPresenter new model: self).
-			window value openWithSpecLayout: aSpec.
+	(self presenterWindow notNil and: [ self needRebuild not ])
+		ifTrue: [ self presenterWindow rebuildWithSpecLayout: aSpec ]
+		ifFalse: [ self presenterWindow: (WorldPresenter new model: self).
+			self presenterWindow openWithSpecLayout: aSpec.
 			self takeKeyboardFocus ].
-		
-	^ window value
+	^ self presenterWindow
 ]
 
 { #category : #'*Spec-MorphicAdapters' }


### PR DESCRIPTION
Do not use `window value` everywhere. 

Fixes #81