### PR TITLE
85-make-spec-load-in-non-interactive

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -5,7 +5,8 @@ SmalltalkCISpec {
       #directory : 'src',
       #onConflict : #useIncoming,
       #onUpgrade : #useIncoming,
-	  #ignoreImage : true,
+      #ignoreImage : true,
+      #onWarningLog : false,
       #platforms : [ #pharo ]
     }
   ]

--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -46,11 +46,11 @@ BaselineOfSpec >> useCustomUIManager [
 	"Metacello pop some UIManager request during the loading of Spec. This cause a problem so we register a new UIManager if we are in non interactive mode that will always say to load the code in anycase."
 	
 	'UIManager: ' crLog.
-	UIManager default log.
+	Transcript show: UIManager default printString.
 	self shouldInstallHackedUIManager ifFalse: [ ^ self ].
 	
 	currentManager := UIManager default.
 	UIManager default: InImageProjectLoadingUIManager new.
-	'UIManager: ' crLog. 
-	UIManager default log.
+	'UIManager: ' crLog.
+	Transcript show: UIManager default printString
 ]

--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -38,13 +38,13 @@ BaselineOfSpec >> restoreOldUIManager [
 
 { #category : #'pre/post load' }
 BaselineOfSpec >> shouldInstallHackedUIManager [
-	^ {CommandLineUIManager.	NonInteractiveUIManager} anySatisfy: [ :e | UIManager default isKindOf: e ]
+	^ {CommandLineUIManager. NonInteractiveUIManager} anySatisfy: [ :e | UIManager default isKindOf: e ]
 ]
 
 { #category : #'pre/post load' }
 BaselineOfSpec >> useCustomUIManager [
 	"Metacello pop some UIManager request during the loading of Spec. This cause a problem so we register a new UIManager if we are in non interactive mode that will always say to load the code in anycase."
-
+	UIManager default crLog.
 	self shouldInstallHackedUIManager ifFalse: [ ^ self ].
 	
 	currentManager := UIManager default.

--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -44,13 +44,9 @@ BaselineOfSpec >> shouldInstallHackedUIManager [
 { #category : #'pre/post load' }
 BaselineOfSpec >> useCustomUIManager [
 	"Metacello pop some UIManager request during the loading of Spec. This cause a problem so we register a new UIManager if we are in non interactive mode that will always say to load the code in anycase."
-	
-	'UIManager: ' crLog.
-	Transcript show: UIManager default printString.
+
 	self shouldInstallHackedUIManager ifFalse: [ ^ self ].
 	
 	currentManager := UIManager default.
-	UIManager default: InImageProjectLoadingUIManager new.
-	'UIManager: ' crLog.
-	Transcript show: UIManager default printString
+	UIManager default: InImageProjectLoadingUIManager new
 ]

--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -44,9 +44,13 @@ BaselineOfSpec >> shouldInstallHackedUIManager [
 { #category : #'pre/post load' }
 BaselineOfSpec >> useCustomUIManager [
 	"Metacello pop some UIManager request during the loading of Spec. This cause a problem so we register a new UIManager if we are in non interactive mode that will always say to load the code in anycase."
-	UIManager default crLog.
+	
+	'UIManager: ' crLog.
+	UIManager default log.
 	self shouldInstallHackedUIManager ifFalse: [ ^ self ].
 	
 	currentManager := UIManager default.
-	UIManager default: InImageProjectLoadingUIManager new
+	UIManager default: InImageProjectLoadingUIManager new.
+	'UIManager: ' crLog. 
+	UIManager default log.
 ]

--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #BaselineOfSpec,
 	#superclass : #BaselineOf,
+	#instVars : [
+		'currentManager'
+	],
 	#category : #BaselineOfSpec
 }
 
@@ -9,6 +12,10 @@ BaselineOfSpec >> baseline: spec [
 	<baseline>
 
 	spec for: #common do: [ 
+		spec 
+			preLoadDoIt: #useCustomUIManager;
+			postLoadDoIt: #restoreOldUIManager.
+
 		spec 
 			package: 'Spec-Core' with: [ spec requires: #('Spec-Layout') ];
 			package: 'Spec-Inspector'with: [ spec requires: #('Spec-PolyWidgets') ];
@@ -19,4 +26,27 @@ BaselineOfSpec >> baseline: spec [
 			package: 'Spec-StubAdapter' with: [ spec requires: #('Spec-Core') ];
 			package: 'Spec-Examples' with: [ spec requires: #('Spec-Tools' 'Spec-Inspector') ];
 			package: 'Spec-Tests' with: [ spec requires: #('Spec-PolyWidgets' 'Spec-Examples') ] ]
+]
+
+{ #category : #'pre/post load' }
+BaselineOfSpec >> restoreOldUIManager [
+	
+	self shouldInstallHackedUIManager ifFalse: [ ^ self ].
+	
+	currentManager beDefault
+]
+
+{ #category : #'pre/post load' }
+BaselineOfSpec >> shouldInstallHackedUIManager [
+	^ {CommandLineUIManager.	NonInteractiveUIManager} anySatisfy: [ :e | UIManager default isKindOf: e ]
+]
+
+{ #category : #'pre/post load' }
+BaselineOfSpec >> useCustomUIManager [
+	"Metacello pop some UIManager request during the loading of Spec. This cause a problem so we register a new UIManager if we are in non interactive mode that will always say to load the code in anycase."
+
+	self shouldInstallHackedUIManager ifFalse: [ ^ self ].
+	
+	currentManager := UIManager default.
+	UIManager default: InImageProjectLoadingUIManager new
 ]

--- a/src/BaselineOfSpec/InImageProjectLoadingUIManager.class.st
+++ b/src/BaselineOfSpec/InImageProjectLoadingUIManager.class.st
@@ -8,7 +8,7 @@ I am used by the baseline of Spec because during the loading of Spec Metacello w
 "
 Class {
 	#name : #InImageProjectLoadingUIManager,
-	#superclass : #NonInteractiveUIManager,
+	#superclass : #CommandLineUIManager,
 	#category : #BaselineOfSpec
 }
 

--- a/src/BaselineOfSpec/InImageProjectLoadingUIManager.class.st
+++ b/src/BaselineOfSpec/InImageProjectLoadingUIManager.class.st
@@ -1,0 +1,18 @@
+"
+Description
+--------------------
+
+I am a UI manager that will always answer true to confirm requests.
+
+I am used by the baseline of Spec because during the loading of Spec Metacello will raise 
+"
+Class {
+	#name : #InImageProjectLoadingUIManager,
+	#superclass : #NonInteractiveUIManager,
+	#category : #BaselineOfSpec
+}
+
+{ #category : #'ui requests' }
+InImageProjectLoadingUIManager >> confirm: queryString trueChoice: trueChoice falseChoice: falseChoice cancelChoice: cancelChoice default: aSymbol [
+	^ true
+]

--- a/src/BaselineOfSpec/InImageProjectLoadingUIManager.class.st
+++ b/src/BaselineOfSpec/InImageProjectLoadingUIManager.class.st
@@ -16,3 +16,21 @@ Class {
 InImageProjectLoadingUIManager >> confirm: queryString trueChoice: trueChoice falseChoice: falseChoice cancelChoice: cancelChoice default: aSymbol [
 	^ true
 ]
+
+{ #category : #'ui requests' }
+InImageProjectLoadingUIManager >> warningDefaultAction: aWarning [
+	| logBlock |
+	"Pass all warnings, but log them"
+	
+	logBlock := [:logger |
+		logger 
+			cr;
+			nextPutAll: '*** Warning: ';
+			nextPutAll: aWarning description;
+			cr ].
+	
+	Smalltalk logDuring: logBlock.
+	self logYellowDuring: logBlock.
+	
+	aWarning pass
+]

--- a/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
+++ b/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
@@ -14,6 +14,7 @@ MCMergeOrLoadWarning >> defaultAction [
 { #category : #'*BaselineOfSpec' }
 MCMergeOrLoadWarning >> pass [
 	'Pass' crLog.
+	handlerContext nextHandlerContext crLog.
 	super pass
 ]
 

--- a/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
+++ b/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
@@ -12,6 +12,18 @@ MCMergeOrLoadWarning >> defaultAction [
 ]
 
 { #category : #'*BaselineOfSpec' }
+MCMergeOrLoadWarning >> pass [
+	'Pass' crLog.
+	super pass
+]
+
+{ #category : #'*BaselineOfSpec' }
+MCMergeOrLoadWarning >> resume [
+	'resume' crLog.
+	super resume
+]
+
+{ #category : #'*BaselineOfSpec' }
 MCMergeOrLoadWarning class >> signalFor: aVersionCollection [
 	'Signal merge or load ' crLog.
 	^ self new

--- a/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
+++ b/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
@@ -10,3 +10,11 @@ MCMergeOrLoadWarning >> defaultAction [
 		cancelChoice: 'Cancel' translated
 		default: nil
 ]
+
+{ #category : #'*BaselineOfSpec' }
+MCMergeOrLoadWarning class >> signalFor: aVersionCollection [
+	'Signal merge or load ' crLog.
+	^ self new
+		versions: aVersionCollection;
+		signal
+]

--- a/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
+++ b/src/BaselineOfSpec/MCMergeOrLoadWarning.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #MCMergeOrLoadWarning }
+
+{ #category : #'*BaselineOfSpec' }
+MCMergeOrLoadWarning >> defaultAction [
+	'Default action of merge or load' crLog.
+	^ UIManager default
+		confirm: self messageText
+		trueChoice: 'Load' translated
+		falseChoice: 'Merge' translated
+		cancelChoice: 'Cancel' translated
+		default: nil
+]


### PR DESCRIPTION
Make Spec load in non-interactive because Metacello might pop UIManager request that will just cancel the load of some packages in non interactive mode.

Fixes #85