### PR TITLE
98-begin-migration-guide

### DIFF
--- a/resources/migration/specPharo7ToSpecPharo8.md
+++ b/resources/migration/specPharo7ToSpecPharo8.md
@@ -1,0 +1,47 @@
+# Spec migration guide: From Pharo 7 Spec to Pharo 8 Spec
+
+This guide will cover the main changes that happened in Spec between Pharo 7 and Pharo 8 and provide informations on how to migrate from the former to the latter.
+
+## Deprecated API
+
+* `WindowPresenter>>model(:)` is now renamed `#presenter(:)`
+* `ComposablePresenter>>defaultWindowModelClass` is now `#defaultWindowPresenterClass`
+* `ComposablePresenter>>instantiateModels:` is now `#instantiatePresenters:` 
+
+## Removals
+
+* `WindowPresenter` title variable was removed because it provided no public API to it. If you used it, please contact us with your usecase.
+* `SpecLayout>>#selector(:)` was removed because it was unused and added complexity to the code.
+
+## Selection of the binding
+
+We refactored the way to register and use a binding. The current way to do it is to execute this code with the right binding:
+
+```Smalltalk
+	SpecBindings value: MorphicAdapterBindings during: [ mySpecPresenter openWithSpec ]
+```
+
+## Injecting a Morph in a spec
+
+In the previous version of Spec it was possible to inject directly a morph into a spec while declaring it. This feature was removed because it breaks the layers of the Spec framework.
+
+The right way to use a Morph that has no presenter in Spec is to create a presenter describing the widget (as we do un `ButtonMorph`) and to create an adaopter to it for each graphical framework used as backend of Spec (like with the `MorphicButtonAdapter`).
+
+## Linking a presenter to its adapter
+
+In the previous version of Spec, to link a presenter to an adapter you needed to create a method like this one:
+
+```Smalltalk
+ButtonPresenter class >> defaultSpec
+	<spec>
+	
+	^ #(ButtonAdapter
+		adapt: #(model))
+```
+
+This is not necessary anymore. You only needs to implement the method `#adapterName`
+
+```Smalltalk
+ButtonPresenter class >> adapterName 
+	^ #ButtonAdapter
+```


### PR DESCRIPTION
Add a migration guide for what is already done in the updated Spec.

Related to #98