### PR TITLE
97-do-not-force-to-have-getters-in-presenters

### DIFF
--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -65,8 +65,18 @@ SpecInterpreter class >> interpretASpec: aSpec presenter: aPresenter [
 
 { #category : #'interpreting-private' }
 SpecInterpreter >> actionToPerformWithSelector: selector arguments: args [
+	^ [ spec perform: selector withArguments: args ]
+		on: MessageNotUnderstood
+		do: [ :ex | 
+			"Maybe the message is not understood because we are trying to access a sub-part of a presenter but there is no accessor. In that case we can try to directly access the presenter.
 
-	^ spec perform: selector withArguments: args
+			We are thinking of killing the interpreter. Maybe later if we know that we are getting the content of a variable of a presenter we can avoid using a catch and directly access the variable."
+			(selector last ~= $: and: [ args isEmpty ])
+				ifTrue: [ spec class instVarNames
+						detect: [ :var | var = selector ]
+						ifFound: [ :var | spec instVarNamed: selector ]
+						ifNone: [ self error: spec asString , ' does not implement the method ' , selector , '. Maybe your spec reference a presenter that does not exists.' ] ]
+				ifFalse: [ ex resume ] ]
 ]
 
 { #category : #bindings }

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -68,3 +68,10 @@ SpecInterpreterTest >> testInterpretASpecModelMorphAssociation [
 	morph := specInterpreterClass interpretASpec: spec presenter: model.
 	self assert: model widget == morph
 ]
+
+{ #category : #tests }
+SpecInterpreterTest >> testInterpreterCanAccessPresenterVariablesWithoutAccessor [
+	| window |
+	[ self shouldnt: [ window := SpecMockPesenterWithoutGetter new openWithSpec ] raise: MessageNotUnderstood ]
+		ensure: [ window ifNotNil: #close ]
+]

--- a/src/Spec-Tests/SpecMockPesenterWithoutGetter.class.st
+++ b/src/Spec-Tests/SpecMockPesenterWithoutGetter.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #SpecMockPesenterWithoutGetter,
+	#superclass : #ComposablePresenter,
+	#instVars : [
+		'buttonPresenter'
+	],
+	#category : #'Spec-Tests-Utils'
+}
+
+{ #category : #specs }
+SpecMockPesenterWithoutGetter class >> defaultSpec [
+	^ SpecLayout composed newColumn: [ :col | col newRow: [ :row | row add: #buttonPresenter ] ]
+]
+
+{ #category : #initialization }
+SpecMockPesenterWithoutGetter >> initializeWidgets [
+	buttonPresenter := self newButton
+]


### PR DESCRIPTION
Do not force the user to have getters for its presenters all the time. We can access the variables.

Fixes #97 and as bonus Fixes #96