### PR TITLE
31-use-special-icon-for-presenters

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -185,6 +185,12 @@ ComposablePresenter class >> specSelectors [
 			collect: [ :pragmas | pragmas method selector ]]
 ]
 
+{ #category : #'as yet unclassified' }
+ComposablePresenter class >> systemIconName [
+
+	^ #smallWindow
+]
+
 { #category : #specs }
 ComposablePresenter class >> title [
 	


### PR DESCRIPTION
Use a special icon in browser for the presenters. 

Fixes #31