### PR TITLE
103-speclayout-arguments-variable-seems-useless

### DIFF
--- a/src/Spec-Layout/AbstractSpecLayoutAction.class.st
+++ b/src/Spec-Layout/AbstractSpecLayoutAction.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #AbstractSpecLayoutAction,
 	#superclass : #Object,
 	#instVars : [
-		'arguments',
 		'selector'
 	],
 	#category : #'Spec-Layout-Actions'
@@ -13,24 +12,13 @@ Class {
 
 { #category : #accesing }
 AbstractSpecLayoutAction >> arguments [
-	^ arguments
-]
-
-{ #category : #accesing }
-AbstractSpecLayoutAction >> arguments: anObject [
-	arguments := anObject
+	^ self subclassResponsibility
 ]
 
 { #category : #protocol }
 AbstractSpecLayoutAction >> asSpecElements [
 
 	self subclassResponsibility 
-]
-
-{ #category : #protocol }
-AbstractSpecLayoutAction >> generateArguments [
-
-	
 ]
 
 { #category : #accesing }

--- a/src/Spec-Layout/SpecLayout.class.st
+++ b/src/Spec-Layout/SpecLayout.class.st
@@ -252,8 +252,7 @@ SpecLayout >> computeNotSplitterWidget: widget [
 		bottom: widget bottomOffset
 		right: widget rightOffset
 		borderWidth: self class windowBorderWidth.
-	
-	widget generateArguments.
+
 	widget asSpecElements do: [ :el | result add: el ]
 ]
 
@@ -270,7 +269,6 @@ SpecLayout >> computeSplitters [
 	(self commands select: [ :e | e isSplitter ])
 		do: [ :e | 
 			shouldCheckSplitters := true.
-			e generateArguments.
 			e asSpecElements do: [ :el | result add: el ] ].
 	shouldCheckSplitters
 		ifTrue: [ result add: #checkSplitters ]
@@ -441,11 +439,7 @@ SpecLayout >> send: aSelector [
 
 { #category : #commands }
 SpecLayout >> send: aSelector withArguments: arguments [
-
-
-	self commands add: (SpecLayoutSend
-							selector: aSelector
-							arguments: arguments).
+	self commands add: (SpecLayoutSend selector: aSelector)
 ]
 
 { #category : #initialization }

--- a/src/Spec-Layout/SpecLayoutAdd.class.st
+++ b/src/Spec-Layout/SpecLayoutAdd.class.st
@@ -20,6 +20,11 @@ SpecLayoutAdd class >> subwidget: subwidget layoutFrame: aLayoutFrame [
 		yourself
 ]
 
+{ #category : #'instance creation' }
+SpecLayoutAdd >> arguments [
+	^ {{subwidget. #layout:. layoutFrame generateSpec}}
+]
+
 { #category : #protocol }
 SpecLayoutAdd >> bottomFraction [
 
@@ -47,12 +52,6 @@ SpecLayoutAdd >> bottomOffset: aNumber [
 { #category : #accessing }
 SpecLayoutAdd >> fractions [
 	^ layoutFrame fractionRectangle
-]
-
-{ #category : #'instance creation' }
-SpecLayoutAdd >> generateArguments [
-	
-	self arguments: {{subwidget .#layout:. layoutFrame generateSpec}}.
 ]
 
 { #category : #initialization }
@@ -161,7 +160,6 @@ SpecLayoutAdd >> subwidget: aSpec layoutFrame: aLayoutFrame [
 							aSpec ]].
 	
 	layoutFrame := aLayoutFrame.
-	self generateArguments
 ]
 
 { #category : #protocol }

--- a/src/Spec-Layout/SpecLayoutAddColumn.class.st
+++ b/src/Spec-Layout/SpecLayoutAddColumn.class.st
@@ -23,6 +23,5 @@ SpecLayoutAddColumn >> block: aBlock layoutFrame: aLayoutFrame [
 	row := SpecColumnLayout composed.
 	aBlock value: row.
 	subwidget := row asArray.
-	self layoutFrame: aLayoutFrame.
-	self generateArguments
+	self layoutFrame: aLayoutFrame
 ]

--- a/src/Spec-Layout/SpecLayoutAddRow.class.st
+++ b/src/Spec-Layout/SpecLayoutAddRow.class.st
@@ -24,6 +24,5 @@ SpecLayoutAddRow >> block: aBlock layoutFrame: aLayoutFrame [
 	row := SpecRowLayout composed.
 	aBlock value: row.
 	subwidget := row asArray.
-	self layoutFrame: aLayoutFrame.
-	self generateArguments
+	self layoutFrame: aLayoutFrame
 ]

--- a/src/Spec-Layout/SpecLayoutAddWithSpec.class.st
+++ b/src/Spec-Layout/SpecLayoutAddWithSpec.class.st
@@ -24,6 +24,5 @@ SpecLayoutAddWithSpec >> subwidget: sub spec: aSpecSelector layoutFrame: aFrameL
 						ifTrue: [ #(model), sub , {#retrieveSpec:. aSpecSelector} ]
 						ifFalse: [ {#model. sub . #retrieveSpec: . aSpecSelector } ]).
 						
-	self layoutFrame: aFrameLayout.
-	self generateArguments
+	self layoutFrame: aFrameLayout
 ]

--- a/src/Spec-Layout/SpecLayoutSend.class.st
+++ b/src/Spec-Layout/SpecLayoutSend.class.st
@@ -8,12 +8,16 @@ Class {
 }
 
 { #category : #'instance creation' }
-SpecLayoutSend class >> selector: selector arguments: arguments [
+SpecLayoutSend class >> selector: selector [
 
 	^ self new
-		arguments: arguments;
 		selector: selector;
 		yourself
+]
+
+{ #category : #accesing }
+SpecLayoutSend >> arguments [
+	^ {  }
 ]
 
 { #category : #protocol }

--- a/src/Spec-Layout/SpecSplitterHorizontal.class.st
+++ b/src/Spec-Layout/SpecSplitterHorizontal.class.st
@@ -18,6 +18,11 @@ SpecSplitterHorizontal class >> commands: commands [
 		yourself
 ]
 
+{ #category : #protocol }
+SpecSplitterHorizontal >> arguments [
+	^ {(self commands identityIndexOf: self)}
+]
+
 { #category : #accessing }
 SpecSplitterHorizontal >> commands [
 	
@@ -28,15 +33,6 @@ SpecSplitterHorizontal >> commands [
 SpecSplitterHorizontal >> commands: anObject [
 	
 	commands := anObject
-]
-
-{ #category : #protocol }
-SpecSplitterHorizontal >> generateArguments [
-	| index |
-
-	index := self commands identityIndexOf: self.
-
-	self arguments: { index }
 ]
 
 { #category : #initialization }

--- a/src/Spec-Layout/SpecSplitterVertical.class.st
+++ b/src/Spec-Layout/SpecSplitterVertical.class.st
@@ -18,6 +18,11 @@ SpecSplitterVertical class >> commands: commands [
 		yourself
 ]
 
+{ #category : #protocol }
+SpecSplitterVertical >> arguments [
+	^ {(self commands identityIndexOf: self)}
+]
+
 { #category : #accessing }
 SpecSplitterVertical >> commands [
 	
@@ -28,15 +33,6 @@ SpecSplitterVertical >> commands [
 SpecSplitterVertical >> commands: anObject [
 	
 	commands := anObject
-]
-
-{ #category : #protocol }
-SpecSplitterVertical >> generateArguments [
-	| index |
-
-	index := self commands identityIndexOf: self.
-
-	self arguments: { index }
 ]
 
 { #category : #initialization }

--- a/src/Spec-Layout/SpecTableLayout.class.st
+++ b/src/Spec-Layout/SpecTableLayout.class.st
@@ -241,10 +241,7 @@ SpecTableLayout >> send: aSelector [
 
 { #category : #commands }
 SpecTableLayout >> send: aSelector withArguments: arguments [
-	commands 
-		add: (SpecTableLayoutSend
-					selector: aSelector
-					arguments: arguments)
+	commands add: (SpecTableLayoutSend selector: aSelector)
 ]
 
 { #category : #'commands - layout properties' }

--- a/src/Spec-Layout/SpecTableLayoutAdd.class.st
+++ b/src/Spec-Layout/SpecTableLayoutAdd.class.st
@@ -19,8 +19,8 @@ SpecTableLayoutAdd class >> subwidget: aSymbol [
 ]
 
 { #category : #'instance creation' }
-SpecTableLayoutAdd >> generateArguments [
-	self arguments: {{subwidget}}
+SpecTableLayoutAdd >> arguments [
+	^ {{subwidget}}
 ]
 
 { #category : #initialization }
@@ -49,6 +49,4 @@ SpecTableLayoutAdd >> subwidget: aSpec [
 				ifFalse: [ 
 					"Not a symbol or a collection. We assume it's an object to add directly (like a morph by example)"
 					aSpec ]].
-		
-	self generateArguments
 ]

--- a/src/Spec-Layout/SpecTableLayoutAddSpacer.class.st
+++ b/src/Spec-Layout/SpecTableLayoutAddSpacer.class.st
@@ -29,14 +29,8 @@ SpecTableLayoutAddSpacer class >> weighted: aNumber [
 	^ self new spaceFillWeight: aNumber
 ]
 
-{ #category : #protocol }
-SpecTableLayoutAddSpacer >> asSpecElements [
-	self generateArguments.
-	^ super asSpecElements
-]
-
 { #category : #'instance creation' }
-SpecTableLayoutAddSpacer >> generateArguments [
+SpecTableLayoutAddSpacer >> arguments [
 	| resizingMode resizing width height dimensions |
 	width := 0.
 	height := 0.
@@ -59,7 +53,7 @@ SpecTableLayoutAddSpacer >> generateArguments [
 			ifTrue: [ {#hResizing: . resizingMode . #vResizing: . #shrinkWrap} ]
 			ifFalse: [ {#hResizing: . #shrinkWrap . #vResizing: . resizingMode} ].
 	
-	self arguments: { {subwidget} , resizing , dimensions }
+	^ { {subwidget} , resizing , dimensions }
 ]
 
 { #category : #initialization }

--- a/src/Spec-Layout/SpecTableLayoutAddWithSpec.class.st
+++ b/src/Spec-Layout/SpecTableLayoutAddWithSpec.class.st
@@ -20,6 +20,4 @@ SpecTableLayoutAddWithSpec >> subwidget: sub spec: aSpecSelector [
 	self subwidget: (sub isArray 
 						ifTrue: [ #(model), sub , {#retrieveSpec:. aSpecSelector} ]
 						ifFalse: [ {#model. sub . #retrieveSpec: . aSpecSelector } ]).
-	
-	self generateArguments
 ]

--- a/src/Spec-Layout/SpecTableLayoutSend.class.st
+++ b/src/Spec-Layout/SpecTableLayoutSend.class.st
@@ -9,10 +9,9 @@ Class {
 }
 
 { #category : #'instance creation' }
-SpecTableLayoutSend class >> selector: selector arguments: arguments [
+SpecTableLayoutSend class >> selector: selector [
 
 	^ self new
-		arguments: arguments;
 		selector: selector;
 		yourself
 ]


### PR DESCRIPTION
Remove the #arguments variable and direcly compute it when needed.

I runned all the tests and openned the interfaces in the image and it seems to have no impact. I also benched the tests and there is almost no difference. 

Fixes #103