### PR TITLE
105-layouts-should-keep-objects-instead-of-arrays

### DIFF
--- a/src/Spec-Layout/AbstractSpecLayoutAction.class.st
+++ b/src/Spec-Layout/AbstractSpecLayoutAction.class.st
@@ -17,8 +17,7 @@ AbstractSpecLayoutAction >> arguments [
 
 { #category : #protocol }
 AbstractSpecLayoutAction >> asSpecElements [
-
-	self subclassResponsibility 
+	^ {self selector} , self arguments
 ]
 
 { #category : #accesing }

--- a/src/Spec-Layout/SpecLayoutAdd.class.st
+++ b/src/Spec-Layout/SpecLayoutAdd.class.st
@@ -22,7 +22,7 @@ SpecLayoutAdd class >> subwidget: subwidget layoutFrame: aLayoutFrame [
 
 { #category : #'instance creation' }
 SpecLayoutAdd >> arguments [
-	^ {{subwidget. #layout:. layoutFrame generateSpec}}
+	^ {{self subwidgetArguments. #layout:. layoutFrame generateSpec}}
 ]
 
 { #category : #protocol }
@@ -59,8 +59,7 @@ SpecLayoutAdd >> initialize [
 
 	super initialize.
 	self selector: #add:.
-	layoutFrame := SpecLayoutFrame identity.
-	subwidget := nil.
+	layoutFrame := SpecLayoutFrame identity
 ]
 
 { #category : #accessing }
@@ -160,6 +159,11 @@ SpecLayoutAdd >> subwidget: aSpec layoutFrame: aLayoutFrame [
 							aSpec ]].
 	
 	layoutFrame := aLayoutFrame.
+]
+
+{ #category : #'instance creation' }
+SpecLayoutAdd >> subwidgetArguments [
+	^ subwidget asArray
 ]
 
 { #category : #protocol }

--- a/src/Spec-Layout/SpecLayoutAddColumn.class.st
+++ b/src/Spec-Layout/SpecLayoutAddColumn.class.st
@@ -18,10 +18,9 @@ SpecLayoutAddColumn class >> block: aBlock layoutFrame: aLayoutFrame [
 
 { #category : #'instance creation' }
 SpecLayoutAddColumn >> block: aBlock layoutFrame: aLayoutFrame [
-
-	| row |
-	row := SpecColumnLayout composed.
-	aBlock value: row.
-	subwidget := row asArray.
+	| column |
+	column := SpecColumnLayout composed.
+	aBlock value: column.
+	subwidget := column.
 	self layoutFrame: aLayoutFrame
 ]

--- a/src/Spec-Layout/SpecLayoutAddRow.class.st
+++ b/src/Spec-Layout/SpecLayoutAddRow.class.st
@@ -19,10 +19,9 @@ SpecLayoutAddRow class >> block: aBlock layoutFrame: aLayoutFrame [
 
 { #category : #'instance creation' }
 SpecLayoutAddRow >> block: aBlock layoutFrame: aLayoutFrame [
-
 	| row |
 	row := SpecRowLayout composed.
 	aBlock value: row.
-	subwidget := row asArray.
+	subwidget := row.
 	self layoutFrame: aLayoutFrame
 ]

--- a/src/Spec-Layout/SpecLayoutAddWithSpec.class.st
+++ b/src/Spec-Layout/SpecLayoutAddWithSpec.class.st
@@ -4,6 +4,9 @@ A SpecLayoutAddWithSpec is an action representing an add in the spec layout with
 Class {
 	#name : #SpecLayoutAddWithSpec,
 	#superclass : #SpecLayoutAdd,
+	#instVars : [
+		'specSelector'
+	],
 	#category : #'Spec-Layout-Actions'
 }
 
@@ -17,12 +20,26 @@ SpecLayoutAddWithSpec class >> subwidget: subwidget spec: aSpecSelector layoutFr
 		yourself
 ]
 
+{ #category : #accessing }
+SpecLayoutAddWithSpec >> specSelector [
+	^ specSelector
+]
+
+{ #category : #accessing }
+SpecLayoutAddWithSpec >> specSelector: aSymbol [
+	specSelector := aSymbol
+]
+
 { #category : #'instance creation' }
 SpecLayoutAddWithSpec >> subwidget: sub spec: aSpecSelector layoutFrame: aFrameLayout [
-
-	self subwidget: (sub isArray 
-						ifTrue: [ #(model), sub , {#retrieveSpec:. aSpecSelector} ]
-						ifFalse: [ {#model. sub . #retrieveSpec: . aSpecSelector } ]).
-						
+	self subwidget: sub.
+	self specSelector: aSpecSelector.
 	self layoutFrame: aFrameLayout
+]
+
+{ #category : #'instance creation' }
+SpecLayoutAddWithSpec >> subwidgetArguments [
+	^ self subwidget isArray
+		ifTrue: [ #(model) , self subwidget , {#retrieveSpec:. self specSelector} ]
+		ifFalse: [ {#model. self subwidget. #retrieveSpec:. self specSelector} ]
 ]

--- a/src/Spec-Layout/SpecLayoutSend.class.st
+++ b/src/Spec-Layout/SpecLayoutSend.class.st
@@ -21,12 +21,6 @@ SpecLayoutSend >> arguments [
 ]
 
 { #category : #protocol }
-SpecLayoutSend >> asSpecElements [
-
-	^ {self selector.}, self arguments
-]
-
-{ #category : #protocol }
 SpecLayoutSend >> bottomFraction [
 
 	^ 0

--- a/src/Spec-Layout/SpecTableLayoutAddSpacer.class.st
+++ b/src/Spec-Layout/SpecTableLayoutAddSpacer.class.st
@@ -53,7 +53,7 @@ SpecTableLayoutAddSpacer >> arguments [
 			ifTrue: [ {#hResizing: . resizingMode . #vResizing: . #shrinkWrap} ]
 			ifFalse: [ {#hResizing: . #shrinkWrap . #vResizing: . resizingMode} ].
 	
-	^ { {subwidget} , resizing , dimensions }
+	^ { {subwidget asArray} , resizing , dimensions }
 ]
 
 { #category : #initialization }

--- a/src/Spec-Layout/SpecTableLayoutSend.class.st
+++ b/src/Spec-Layout/SpecTableLayoutSend.class.st
@@ -15,9 +15,3 @@ SpecTableLayoutSend class >> selector: selector [
 		selector: selector;
 		yourself
 ]
-
-{ #category : #protocol }
-SpecTableLayoutSend >> asSpecElements [
-
-	^ {self selector.}, self arguments
-]


### PR DESCRIPTION
Layouts should keep objects instead of arrays in their variables. 

Fixes #105