### PR TITLE
110-remove-some-useless-variables

### DIFF
--- a/src/Spec-Layout/SpecColumnLayout.class.st
+++ b/src/Spec-Layout/SpecColumnLayout.class.st
@@ -59,7 +59,6 @@ SpecColumnLayout >> manualFractionComputation [
 
 { #category : #converting }
 SpecColumnLayout >> privateAsArray [
-
 	self resetArrayComputation.
 	self countNumberOfProportionals.
 
@@ -69,8 +68,7 @@ SpecColumnLayout >> privateAsArray [
 
 	self shiftLastWidgets.
 
-	result addAll: super privateAsArray.
-	^ result asArray
+	^ super privateAsArray
 ]
 
 { #category : #private }

--- a/src/Spec-Layout/SpecLayout.class.st
+++ b/src/Spec-Layout/SpecLayout.class.st
@@ -7,8 +7,6 @@ Class {
 	#instVars : [
 		'type',
 		'commands',
-		'result',
-		'shouldCheckSplitters',
 		'currentOffset',
 		'currentProportional',
 		'numberOfProportionals',
@@ -243,35 +241,25 @@ SpecLayout >> computeLayoutFromTop: top bottom: bottom left: left right: right [
 ]
 
 { #category : #private }
-SpecLayout >> computeNotSplitterWidget: widget [
-	
-	self
-		setOffsetsFor: widget
-		top: widget topOffset
-		left: widget leftOffset
-		bottom: widget bottomOffset
-		right: widget rightOffset
-		borderWidth: self class windowBorderWidth.
-
-	widget asSpecElements do: [ :el | result add: el ]
+SpecLayout >> computeNonSplitterWidgetsIn: result [
+	(self commands reject: #isSplitter)
+		do: [ :widget | 
+			self
+				setOffsetsFor: widget
+				top: widget topOffset
+				left: widget leftOffset
+				bottom: widget bottomOffset
+				right: widget rightOffset
+				borderWidth: self class windowBorderWidth.
+			result addAll: widget asSpecElements ]
 ]
 
 { #category : #private }
-SpecLayout >> computeNotSplitterWidgets [
-
-	(self commands reject: [ :e | e isSplitter ]) 
-		do: [ :e | self computeNotSplitterWidget: e ]
-]
-
-{ #category : #private }
-SpecLayout >> computeSplitters [
-
-	(self commands select: [ :e | e isSplitter ])
-		do: [ :e | 
-			shouldCheckSplitters := true.
-			e asSpecElements do: [ :el | result add: el ] ].
-	shouldCheckSplitters
-		ifTrue: [ result add: #checkSplitters ]
+SpecLayout >> computeSplittersIn: result [
+	(self commands select: #isSplitter)
+		ifNotEmpty: [ :spliters | 
+			spliters do: [ :spliter | result addAll: spliter asSpecElements ].
+			result add: #checkSplitters ]
 ]
 
 { #category : #initialization }
@@ -406,19 +394,20 @@ SpecLayout >> newRow: aBlock top: top bottom: bottom [
 
 { #category : #converting }
 SpecLayout >> privateAsArray [
-
+	| result |
+	result := OrderedCollection new.
+	
 	self resetArrayComputation.
 	
-	self computeNotSplitterWidgets.
-	self computeSplitters.
+	self computeNonSplitterWidgetsIn: result.
+	self computeSplittersIn: result.
 	
 	^ result asArray
 ]
 
 { #category : #converting }
 SpecLayout >> resetArrayComputation [
-	result := OrderedCollection new.
-	shouldCheckSplitters := false
+	"Do nothing here"
 ]
 
 { #category : #accessing }

--- a/src/Spec-Layout/SpecRowLayout.class.st
+++ b/src/Spec-Layout/SpecRowLayout.class.st
@@ -70,8 +70,7 @@ SpecRowLayout >> privateAsArray [
 	
 	self shiftLastWidgets.
 	
-	result addAll: super privateAsArray.
-	^ result asArray
+	^ super privateAsArray
 ]
 
 { #category : #private }


### PR DESCRIPTION
Remove the need of the #result and #shouldCheckSplitters inst variables.

Those variables are useless because they are just used internally in few methods.

Fixes #110