### PR TITLE
116-Clean-icon-management

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -128,6 +128,11 @@ ComposablePresenter class >> defaultSpec [
 	^ self subclassResponsibility
 ]
 
+{ #category : #accessing }
+ComposablePresenter class >> iconNamed: aSymbol [
+	^ Smalltalk ui icons iconNamed: aSymbol
+]
+
 { #category : #defaults }
 ComposablePresenter class >> inputTextHeight [
 
@@ -548,9 +553,13 @@ ComposablePresenter >> hide [
 
 { #category : #icon }
 ComposablePresenter >> icon: aSymbol [
-	"Return the icon associated with the argument."
-	self flag: #remove.
+	self deprecated: 'Use #iconNamed: instead' transformWith: '`@receiver icon: `@statements' -> '`@receiver iconNamed: `@statements'.
 	^ self iconNamed: aSymbol
+]
+
+{ #category : #accessing }
+ComposablePresenter >> iconNamed: aSymbol [
+	^ self class iconNamed: aSymbol
 ]
 
 { #category : #api }

--- a/src/Spec-Core/ManifestSpecCore.class.st
+++ b/src/Spec-Core/ManifestSpecCore.class.st
@@ -38,6 +38,11 @@ ManifestSpecCore class >> ruleLongMethodsRuleV1FalsePositive [
 ]
 
 { #category : #'code-critics' }
+ManifestSpecCore class >> ruleRBEquivalentSuperclassMethodsRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#'ComposablePresenter class' #iconNamed: #true)) #'2018-11-07T10:48:10.451257+01:00') )
+]
+
+{ #category : #'code-critics' }
 ManifestSpecCore class >> ruleRBOverridesDeprecatedMethodRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#MenuItemPresenter #name #false)) #'2016-07-01T15:56:13.378417+02:00') )
 ]


### PR DESCRIPTION
Deprecate ComposablePresenter>>#icon: to use #iconNamed:

Fixes #116