### PR TITLE
119-Remove-use-of-Smalltalk-ui-theme-in-presenters

### DIFF
--- a/src/Spec-Core/AbstractWidgetPresenter.class.st
+++ b/src/Spec-Core/AbstractWidgetPresenter.class.st
@@ -120,7 +120,7 @@ AbstractWidgetPresenter >> color: aColor [
 
 { #category : #initialization }
 AbstractWidgetPresenter >> defaultColor [
-	^ Smalltalk ui theme backgroundColor
+	^ self theme backgroundColor
 ]
 
 { #category : #'drag and drop' }

--- a/src/Spec-Core/LabelPresenter.class.st
+++ b/src/Spec-Core/LabelPresenter.class.st
@@ -36,7 +36,7 @@ LabelPresenter class >> title [
 
 { #category : #initialization }
 LabelPresenter >> defaultColor [
-	^ Smalltalk ui theme textColor
+	^ self theme textColor
 ]
 
 { #category : #api }

--- a/src/Spec-Core/ListPresenter.class.st
+++ b/src/Spec-Core/ListPresenter.class.st
@@ -249,7 +249,7 @@ ListPresenter >> initializeValueHolders [
 	multiSelectionHolder := IdentityDictionary new asValueHolder.
 	multiSelection := false asValueHolder.
 	allowToSelect := true asValueHolder.
-	backgroundColorBlock := [ :item :index | Smalltalk ui theme backgroundColor ] asValueHolder.
+	backgroundColorBlock := [ :item :index | self theme backgroundColor ] asValueHolder.
 	autoDeselect := true asValueHolder.
 	listAnnouncer := Announcer new.
 

--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -463,9 +463,9 @@ TreePresenter >> initialize [
 	isCheckList := false asValueHolder.
 	keyStroke := [ :key | ] asValueHolder.
 	multiSelection := false asValueHolder.
-	evenRowColor := Smalltalk ui theme backgroundColor asValueHolder.
-	oddRowColor := Smalltalk ui theme backgroundColor asValueHolder.
-	preferedPaneColor := Smalltalk ui theme backgroundColor asValueHolder.
+	evenRowColor := self theme backgroundColor asValueHolder.
+	oddRowColor := self theme backgroundColor asValueHolder.
+	preferedPaneColor := self theme backgroundColor asValueHolder.
 	resizerWidth := 2 asValueHolder.
 	rowInset := 2 asValueHolder.
 	iconBlock := [ :each : node | node icon ] asValueHolder.


### PR DESCRIPTION
Replace usage of `Smalltalk ui theme`.

Fixes #119