### PR TITLE
70-We-should-be-able-to-use-presenter-instead-of-model-in-layouts

### DIFF
--- a/src/Spec-Core/AbstractWidgetPresenter.class.st
+++ b/src/Spec-Core/AbstractWidgetPresenter.class.st
@@ -52,7 +52,7 @@ AbstractWidgetPresenter class >> adapterName [
 AbstractWidgetPresenter class >> defaultSpec [
 	<spec: #default>
 
-	^ { self adapterName. #adapt:. #model }
+	^ { self adapterName. #adapt:. #presenter }
 ]
 
 { #category : #'drag and drop' }

--- a/src/Spec-Core/MenuPresenter.class.st
+++ b/src/Spec-Core/MenuPresenter.class.st
@@ -46,7 +46,7 @@ MenuPresenter class >> popup [
 	<spec>
 	
 	^ #(MenuAdapter
-		adaptAsPopup: #(model))
+		adaptAsPopup: #(presenter))
 ]
 
 { #category : #'api-building' }

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -87,7 +87,7 @@ SpecInterpreter >> bindings [
 
 { #category : #'interpreting-private' }
 SpecInterpreter >> computeSpecFrom: aSymbol [
-	^ (aSymbol isSymbol and: [ aSymbol ~= #model ])
+	^ (aSymbol isSymbol and: [ (self isPresenterSymbol: aSymbol) not ])
 		ifTrue: [ | result |
 			result := self convertSymbolOfClassToInstance: aSymbol.
 			result isSpecContainer
@@ -121,7 +121,7 @@ SpecInterpreter >> extractArrayToInterpretFrom: aFragment [
 	
 	(aFragment isString or: [ aFragment isText ])
 		ifTrue: [ 
-			^ aFragment == #model
+			^ (self isPresenterSymbol: aFragment)
 				ifTrue: [ self presenter ]
 				ifFalse: [ self convertSymbolOfClassToInstance: aFragment ] ].
 	^ nil
@@ -172,6 +172,13 @@ SpecInterpreter >> interpretASpec: aSpec model: aPresenter selector: aSelector [
 SpecInterpreter >> interpretASpec: aSpec presenter: aPresenter [
 	self presenter: aPresenter.
 	^ self interpretASpec: aSpec
+]
+
+{ #category : #testing }
+SpecInterpreter >> isPresenterSymbol: aSymbol [
+	self flag: #todo. "We keep #model for one version of Pharo then we should only keep #presenter."
+	
+	^ #(#model #presenter) anySatisfy: [ :symbol | symbol = aSymbol ]
 ]
 
 { #category : #accessing }

--- a/src/Spec-Examples/CheckBoxExample.class.st
+++ b/src/Spec-Examples/CheckBoxExample.class.st
@@ -25,7 +25,7 @@ CheckBoxExample class >> defaultSpec [
 			#add:.	{ self topSpec. #layout:. 	#(#SpecLayoutFrame
 													bottomFraction: 0
 													bottomOffset: 20) }.
-			#add:.	{{#model . #container } . #layout: . #(#SpecLayoutFrame topOffset: 22) }
+			#add:.	{{#presenter . #container } . #layout: . #(#SpecLayoutFrame topOffset: 22) }
 	   }
 ]
 
@@ -35,9 +35,9 @@ CheckBoxExample class >> defaultSpec2 [
 	^ { #Panel.
 			#changeTableLayout.
 			#listDirection:.		#rightToLeft.
-			#addMorph:. {#model.	#button1.}.
-			#addMorph:. {#model.	#button2.}.
-			#addMorph:. {#model.	#button3.}.
+			#addMorph:. {#presenter.	#button1.}.
+			#addMorph:. {#presenter.	#button2.}.
+			#addMorph:. {#presenter.	#button3.}.
 			#hResizing:.	#shrinkWrap.
 			#vResizing:.	#shrinkWrap.	}
 ]
@@ -75,16 +75,16 @@ CheckBoxExample class >> title [
 CheckBoxExample class >> topSpec [
 
 	^ { #ContainerPresenter.
-			#add:. {{#model .	#button1 } . #layout:.  #(#SpecLayoutFrame
+			#add:. {{#presenter .	#button1 } . #layout:.  #(#SpecLayoutFrame
 															rightFraction: 0.33
 															bottomFraction: 0
 															bottomOffset: 25)}.
-			#add:.  {{#model .	#button2 } . #layout:. #(#SpecLayoutFrame
+			#add:.  {{#presenter .	#button2 } . #layout:. #(#SpecLayoutFrame
 															leftFraction: 0.33
 															rightFraction: 0.66
 															bottomFraction: 0
 															bottomOffset: 25)}.
-			#add:.  {{#model .	#button3 } . #layout:. #(#SpecLayoutFrame
+			#add:.  {{#presenter .	#button3 } . #layout:. #(#SpecLayoutFrame
 															leftFraction: 0.66
 															bottomFraction: 0
 															bottomOffset: 25)}}

--- a/src/Spec-Examples/MethodBrowser.class.st
+++ b/src/Spec-Examples/MethodBrowser.class.st
@@ -31,8 +31,8 @@ MethodBrowser class >> defaultSpec2 [
 ^{ #Panel.
 		#changeTableLayout.
 		#listDirection:. 	#bottomToTop.
-		#addMorph:. 		{#model. #listModel.}.
-		#addMorph:. 		{#model. #textModel.}.
+		#addMorph:. 		{#presenter. #listModel.}.
+		#addMorph:. 		{#presenter. #textModel.}.
 		#vResizing:.		 #spaceFill.
 		#hResizing:.		 #spaceFill.}
 ]

--- a/src/Spec-Layout/SpecLayoutAdd.class.st
+++ b/src/Spec-Layout/SpecLayoutAdd.class.st
@@ -146,22 +146,18 @@ SpecLayoutAdd >> subwidget: anObject [
 
 { #category : #'instance creation' }
 SpecLayoutAdd >> subwidget: aSpec layoutFrame: aLayoutFrame [
-	
 	subwidget := aSpec isSymbol
-				ifTrue: [{#model. aSpec}]
-				ifFalse: [
-					aSpec isCollection
-						ifTrue: [
-							aSpec isEmpty 
-								ifTrue: [ "should raise an error" ]
-								ifFalse: [ aSpec first == #model 
-											ifTrue: [ aSpec ]
-											ifFalse: [ {#model}, aSpec ]]]
-						ifFalse: [ 
-							"Not a symbol or a collection. We assume it's an object to add directly (like a morph by example)"
-							aSpec ]].
-	
-	layoutFrame := aLayoutFrame.
+		ifTrue: [ {#presenter.
+			aSpec} ]
+		ifFalse: [ aSpec isCollection
+				ifTrue: [ aSpec isEmpty
+						ifTrue: [ "should raise an error" ]
+						ifFalse: [ self flag: #todo.	"In one version of Pharo the #model should disaper. It's just here for retro compatibility"
+							(#(#model #presenter) anySatisfy: [ :symbol | aSpec first = symbol ])
+								ifTrue: [ aSpec ]
+								ifFalse: [ {#presenter} , aSpec ] ] ]
+				ifFalse: [ "Not a symbol or a collection. We assume it's an object to add directly (like a morph by example)" aSpec ] ].
+	layoutFrame := aLayoutFrame
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec-Layout/SpecLayoutAddWithSpec.class.st
+++ b/src/Spec-Layout/SpecLayoutAddWithSpec.class.st
@@ -40,6 +40,6 @@ SpecLayoutAddWithSpec >> subwidget: sub spec: aSpecSelector layoutFrame: aFrameL
 { #category : #'instance creation' }
 SpecLayoutAddWithSpec >> subwidgetArguments [
 	^ self subwidget isArray
-		ifTrue: [ #(model) , self subwidget , {#retrieveSpec:. self specSelector} ]
-		ifFalse: [ {#model. self subwidget. #retrieveSpec:. self specSelector} ]
+		ifTrue: [ #(presenter) , self subwidget , {#retrieveSpec:. self specSelector} ]
+		ifFalse: [ {#presenter. self subwidget. #retrieveSpec:. self specSelector} ]
 ]

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -64,7 +64,7 @@ SpecInterpreterTest >> testDynamicBuild [
 SpecInterpreterTest >> testInterpretASpecModelMorphAssociation [
 	| spec model morph |
 	model := AbstractWidgetPresenter new.
-	spec := {#PluggableListMorph . #model: . #model}.
+	spec := {#PluggableListMorph . #model: . #presenter}.
 	morph := specInterpreterClass interpretASpec: spec presenter: model.
 	self assert: model widget == morph
 ]

--- a/src/Spec-Tools/MonticelloRepositoryBrowser.class.st
+++ b/src/Spec-Tools/MonticelloRepositoryBrowser.class.st
@@ -25,8 +25,8 @@ MonticelloRepositoryBrowser class >> allManagers [
 MonticelloRepositoryBrowser class >> defaultSpec [
 	<spec: #default>
 	^ SpecLayout composed
-		add: #(model workingCopies) right: 0.5;
-		add: #(model repositories) left: 0.5;
+		add: #(presenter workingCopies) right: 0.5;
+		add: #(presenter repositories) left: 0.5;
 		yourself.
 
 ]

--- a/src/Spec-Tools/WorkingCopyToolBar.class.st
+++ b/src/Spec-Tools/WorkingCopyToolBar.class.st
@@ -17,26 +17,26 @@ Class {
 WorkingCopyToolBar class >> defaultSpec [ 
 
 	^ {#ContainerPresenter.
-			#add: . {{#model . #packageButton.} . #layout: .  #(FrameLayout
+			#add: . {{#presenter . #packageButton.} . #layout: .  #(FrameLayout
 										rightFraction: 0.25
 										bottomFraction: 0
 										bottomOffset: 25)} . 
 
-			#add: . {{#model . #configButton.} .
+			#add: . {{#presenter . #configButton.} .
 						#layout: . #(FrameLayout
 										leftFraction: 0.25
 										rightFraction: 0.5
 										bottomFraction: 0
 										bottomOffset: 25) } .
 											
-			#add: . {{#model . #sliceButton.} .
+			#add: . {{#presenter . #sliceButton.} .
 						#layout: . #(FrameLayout
 										leftFraction: 0.5
 										rightFraction: 0.75
 										bottomFraction: 0
 										bottomOffset: 25) } .											
 
-			#add: . {{#model . #browseButton.} .
+			#add: . {{#presenter . #browseButton.} .
 						#layout: . #(FrameLayout
 										leftFraction: 0.75
 										bottomFraction: 0


### PR DESCRIPTION
We should be able to use #prensenter instead of #model in layouts.

Fixes #70