### PR TITLE
125-MorphicTabManagerAdaptor-does-not-need-to-call-asWidget

### DIFF
--- a/src/Spec-MorphicAdapters/MorphicTabManagerAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTabManagerAdapter.class.st
@@ -35,7 +35,7 @@ MorphicTabManagerAdapter >> buildWidget [
 
 { #category : #'widget API' }
 MorphicTabManagerAdapter >> getTabs [
-	^ [ (self model tabs collect: [ :each | self buildTab: each ]) collect: #asWidget ]
+	^ [ self model tabs collect: [ :each | self buildTab: each ] ]
 ]
 
 { #category : #'spec protocol' }


### PR DESCRIPTION
MorphicTabManagerAdaptor does not need to call #asWidget

FIxes #125