### PR TITLE
129-TabPresenter-is-too-corelated-to-Morph

### DIFF
--- a/src/Spec-Core/TabPresenter.class.st
+++ b/src/Spec-Core/TabPresenter.class.st
@@ -178,7 +178,7 @@ TabPresenter >> morphHolder [
 { #category : #api }
 TabPresenter >> presenter: aComposablePresenter [
 	aComposablePresenter owner: self.
-	self retrievingBlock: [ aComposablePresenter buildWithSpec asWidget ]
+	self retrievingBlock: [ aComposablePresenter buildWithSpec ]
 ]
 
 { #category : #api }

--- a/src/Spec-Examples/SpecDemoPage.class.st
+++ b/src/Spec-Examples/SpecDemoPage.class.st
@@ -45,25 +45,23 @@ SpecDemoPage >> commentFor: aClass [
 
 { #category : #initialization }
 SpecDemoPage >> commentTab [
-	| tab commentInput |
-	tab := self newTab.
-	tab
+	^ self newTab
 		label: 'Comment';
-		icon: (tab iconNamed: #helpIcon);
-		presenter: (commentInput := self newText).
-	commentInput text: (self commentFor: self pageClass).
-	^ tab
+		icon: (self iconNamed: #helpIcon);
+		presenter:
+			(self newText
+				text: (self commentFor: self pageClass);
+				yourself);
+		yourself
 ]
 
 { #category : #initialization }
 SpecDemoPage >> exampleTab [
-	| tab |
-	tab := self newTab.
-	tab
+	^ self newTab
 		label: 'Example';
-		icon: (tab iconNamed: #smallPaint);
-		presenter: (self instantiate: self pageClass).
-	^ tab
+		icon: (self iconNamed: #smallPaint);
+		presenter: (self instantiate: self pageClass);
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec-Examples/TabsExample.class.st
+++ b/src/Spec-Examples/TabsExample.class.st
@@ -34,27 +34,28 @@ TabsExample class >> open [
 
 { #category : #private }
 TabsExample >> browserTab [
-	| tab |
-	tab := self newTab.
-	tab
+	^ self newTab
 		label: 'Browser';
-		icon: (tab iconNamed: #nautilusIcon);
+		icon: (self iconNamed: #nautilusIcon);
 		presenter:
 			(ClassMethodBrowser new
 				classes: Smalltalk allClasses;
-				yourself).
-	^ tab
+				yourself);
+		yourself
 ]
 
 { #category : #private }
 TabsExample >> dynamicTab [
-	| tab |
-	tab := self newTab.
-	tab
+	^ self newTab
 		label: 'Dynamic';
-		icon: (tab iconNamed: #nautilusIcon);
-		presenter: DynamicWidgetChange new.
-	^ tab
+		icon: (self iconNamed: #nautilusIcon);
+		presenter: DynamicWidgetChange new;
+		yourself
+]
+
+{ #category : #api }
+TabsExample >> initialExtent [
+	^ 900@600
 ]
 
 { #category : #initialization }
@@ -73,26 +74,22 @@ TabsExample >> manager [
 
 { #category : #private }
 TabsExample >> objectClassTab [
-	| tab |
-	tab := self newTab.
-	tab
+	^ self newTab
 		label: 'Object class';
-		icon: (tab iconNamed: #nautilusIcon);
-		presenter: (MessageBrowser new messages: Object methods).
-	^ tab
+		icon: (self iconNamed: #nautilusIcon);
+		presenter: (MessageBrowser new messages: Object methods);
+		yourself
 ]
 
 { #category : #private }
 TabsExample >> objectInspectorTab [
-	|tab|
-	tab := self newTab.
-	tab
+	^ self newTab
 		label: 'Object inspector';
-		icon: (tab iconNamed: #nautilusIcon);
-		retrievingBlock: [ (EyeInspector new
+		icon: (self iconNamed: #nautilusIcon);
+		retrievingBlock: [ EyeInspector new
 				inspect: Object;
-				buildWithSpec: #inspectorSpec) asWidget ].
-			^tab
+				buildWithSpec: #inspectorSpec ];
+		yourself
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Tab presenter and Tab example do not need to call #asWidget.

Fixes #129