### PR TITLE
93-Add-source-code-in-a-tab-in-the-demo

### DIFF
--- a/src/Spec-Examples/SpecDemoPage.class.st
+++ b/src/Spec-Examples/SpecDemoPage.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'tabManager'
 	],
-	#category : #'Spec-Examples-Demo-Support'
+	#category : #'Spec-Examples-Demo'
 }
 
 { #category : #specs }
@@ -30,6 +30,23 @@ SpecDemoPage class >> pageName [
 SpecDemoPage class >> priority [
 
 	^ 999
+]
+
+{ #category : #initialization }
+SpecDemoPage >> codeFor: aClass [
+	^ TonelWriter sourceCodeOf: aClass
+]
+
+{ #category : #initialization }
+SpecDemoPage >> codeTab [
+	^ self newTab
+		label: 'Code';
+		icon: (self iconNamed: #changeUpdate);
+		presenter:
+			(self newCode
+				text: (self codeFor: self pageClass);
+				yourself);
+		yourself
 ]
 
 { #category : #initialization }
@@ -71,7 +88,8 @@ SpecDemoPage >> initializeWidgets [
 	"tabManager whenTabSelected: [ self updateTitle ]."
 	tabManager
 		addTab: self exampleTab;
-		addTab: self commentTab.
+		addTab: self commentTab;
+		addTab: self codeTab.
 ]
 
 { #category : #initialization }

--- a/src/Spec-Examples/SpecDemoSpacerPage.class.st
+++ b/src/Spec-Examples/SpecDemoSpacerPage.class.st
@@ -1,0 +1,28 @@
+"
+Description
+--------------------
+
+I am a demo on layout spacers
+"
+Class {
+	#name : #SpecDemoSpacerPage,
+	#superclass : #SpecDemoPage,
+	#category : #'Spec-Examples-Demo-Layouts'
+}
+
+{ #category : #specs }
+SpecDemoSpacerPage class >> pageName [
+	^ 'Spacers in layout'
+]
+
+{ #category : #specs }
+SpecDemoSpacerPage class >> priority [
+
+	^ 50
+]
+
+{ #category : #initialization }
+SpecDemoSpacerPage >> pageClass [
+
+	^ SpecSpacerDemo
+]

--- a/src/Spec-Examples/SpecSpacerDemo.class.st
+++ b/src/Spec-Examples/SpecSpacerDemo.class.st
@@ -12,7 +12,7 @@ I am a simple demo to show how to use spacers in Spec layouts.
 "
 Class {
 	#name : #SpecSpacerDemo,
-	#superclass : #SpecDemoPage,
+	#superclass : #ComposablePresenter,
 	#instVars : [
 		'input2',
 		'input3',
@@ -55,11 +55,6 @@ SpecSpacerDemo class >> defaultSpec [
 { #category : #specs }
 SpecSpacerDemo class >> example [
 	^ self new openWithSpec
-]
-
-{ #category : #initialization }
-SpecSpacerDemo class >> pageName [
-	^ 'Spacers in layout'
 ]
 
 { #category : #specs }


### PR DESCRIPTION
Add a tab with the code of examples in demo.

Fixes #93