### PR TITLE
165-Backport-PluggableTextMorph-changes-from-pharo-and-rewrite-the-input-number

### DIFF
--- a/src/Spec-MorphicAdapters/MorphicNumberInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicNumberInputFieldAdapter.class.st
@@ -22,7 +22,7 @@ MorphicNumberInputFieldAdapter >> buildWidget [
 	| textMorph iconsContainer |
 	
 	textMorph := super buildWidget.
-	textMorph eventHandler: (MorphicEventHandler new on: #keyStroke send: #keystroke:from: to: self).
+	textMorph announcer when: RubKeystroke send: #keystroke:from: to: self.
 
 	"We add an arrow up and arrow down to the morph to match common input number implementations"	
 	iconsContainer := Morph new
@@ -51,7 +51,7 @@ MorphicNumberInputFieldAdapter >> buildWidget [
 
 { #category : #actions }
 MorphicNumberInputFieldAdapter >> decreaseValueOf: aTextMorph [
-	aTextMorph setTextAndAccept: (self decreasedValueFrom: aTextMorph getText)
+	aTextMorph setText: (self decreasedValueFrom: aTextMorph getText)
 ]
 
 { #category : #actions }
@@ -84,7 +84,7 @@ MorphicNumberInputFieldAdapter >> inBounds: aNumber [
 
 { #category : #actions }
 MorphicNumberInputFieldAdapter >> increaseValueOf: aTextMorph [
-	aTextMorph setTextAndAccept: (self increasedValueFrom: aTextMorph getText)
+	aTextMorph setText: (self increasedValueFrom: aTextMorph getText)
 ]
 
 { #category : #actions }
@@ -108,14 +108,14 @@ MorphicNumberInputFieldAdapter >> inferiorToMaximum: aNumber [
 ]
 
 { #category : #events }
-MorphicNumberInputFieldAdapter >> keystroke: aKeyboardEvent from: aTextMorph [
+MorphicNumberInputFieldAdapter >> keystroke: aRubricEvent from: aTextMorph [
 
-	aKeyboardEvent keyCharacter = Character arrowUp
-		ifTrue: [ self increaseValueOf: aTextMorph.
+	aRubricEvent event keyCharacter = Character arrowUp
+		ifTrue: [ self increaseValueOf: aRubricEvent morph.
 			^ true ].
 
-	aKeyboardEvent keyCharacter = Character arrowDown
-		ifTrue: [ self decreaseValueOf: aTextMorph.
+	aRubricEvent event keyCharacter = Character arrowDown
+		ifTrue: [ self decreaseValueOf: aRubricEvent morph.
 			^ true ].
 		
 	^ false

--- a/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
@@ -29,8 +29,7 @@ MorphicTextInputFieldAdapter >> adapt: aModel [
 { #category : #factory }
 MorphicTextInputFieldAdapter >> buildWidget [
 	| plu |
-	plu := PluggableTextFieldMorph new
-		convertTo: String;
+	plu := RubPluggableTextFieldMorph new
 		on: self
 			text: #getText
 			accept: #accept:
@@ -48,8 +47,7 @@ MorphicTextInputFieldAdapter >> buildWidget [
 		dropEnabled: self dropEnabled;
 		hResizing: #spaceFill;
 		vResizing: #spaceFill;
-		acceptOnCR: self acceptOnCR;
-		hideScrollBarsIndefinitely.
+		acceptOnCR: self acceptOnCR.
 	^ plu
 ]
 

--- a/src/Spec-MorphicAdapters/PluggableTextFieldMorph.extension.st
+++ b/src/Spec-MorphicAdapters/PluggableTextFieldMorph.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #PluggableTextFieldMorph }
-
-{ #category : #'*Spec-MorphicAdapters' }
-PluggableTextFieldMorph >> setTextAndAccept: aText [
-	self
-		setText: aText;
-		hasUnacceptedEdits: true;
-		accept
-]


### PR DESCRIPTION
Use rubric instead of PluggableTextMorph for input text and number.

Fixes #165