### PR TITLE
185-ProgressPresenter-should-use-progression-and-not-progressionBlock

### DIFF
--- a/src/Spec-Core/ProgressBarProgressing.class.st
+++ b/src/Spec-Core/ProgressBarProgressing.class.st
@@ -15,18 +15,18 @@ Internal Representation and Key Implementation Points.
 --------------------
 
     Instance Variables
-	currentValueHolder:		<aValueHolder>	Store the current value of the progress bar. We need it to be able to notify the user when it changes so that the user can register to the change.
-	progressionBlock:			<aBlock>			A block returning a number between 0 and 1 defining the progress of the bar.
-	refreshDelay:				<aDelay>			A delay defining the refresh rate of the bar.
+	currentValueHolder:		<aValueHolder>		Store the current value of the progress bar. We need it to be able to notify the user when it changes so that the user can register to the change.
+	progression:					<aValuable>			A block returning a number between 0 and 1 defining the progress of the bar.
+	refreshDelay:				<aDelay>				A delay defining the refresh rate of the bar.
 
 "
 Class {
 	#name : #ProgressBarProgressing,
 	#superclass : #ProgressBarState,
 	#instVars : [
-		'progressionBlock',
 		'refreshDelay',
-		'currentValueHolder'
+		'currentValueHolder',
+		'progression'
 	],
 	#category : #'Spec-Core-Widgets-Utils'
 }
@@ -34,7 +34,7 @@ Class {
 { #category : #'instance creation' }
 ProgressBarProgressing class >> progression: aBlock every: aDelay [
 	^ self new
-		progressionBlock: aBlock;
+		progression: aBlock;
 		refreshDelay: aDelay;
 		yourself
 ]
@@ -56,13 +56,13 @@ ProgressBarProgressing >> initialize [
 ]
 
 { #category : #accessing }
-ProgressBarProgressing >> progressionBlock [
-	^ progressionBlock
+ProgressBarProgressing >> progression [
+	^ progression
 ]
 
 { #category : #accessing }
-ProgressBarProgressing >> progressionBlock: anObject [
-	progressionBlock := anObject
+ProgressBarProgressing >> progression: aValuable [
+	progression := aValuable
 ]
 
 { #category : #accessing }
@@ -71,8 +71,8 @@ ProgressBarProgressing >> refreshDelay [
 ]
 
 { #category : #accessing }
-ProgressBarProgressing >> refreshDelay: anObject [
-	refreshDelay := anObject
+ProgressBarProgressing >> refreshDelay: aDelay [
+	refreshDelay := aDelay
 ]
 
 { #category : #enumerating }

--- a/src/Spec-Core/TextInputFieldPresenter.class.st
+++ b/src/Spec-Core/TextInputFieldPresenter.class.st
@@ -143,11 +143,6 @@ TextInputFieldPresenter >> eventKeyStrokesForPreviousFocus [
 	^ { Character tab shift asKeyCombination }
 ]
 
-{ #category : #'as yet unclassified' }
-TextInputFieldPresenter >> ghostText: aString [ 
-	self placeholder: aString
-]
-
 { #category : #initialization }
 TextInputFieldPresenter >> initialize [
 

--- a/src/Spec-MorphicAdapters/ProgressBarProgressing.extension.st
+++ b/src/Spec-MorphicAdapters/ProgressBarProgressing.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #ProgressBarProgressing }
 ProgressBarProgressing >> customizeMorphicBar: aProgressBarMorph [
 	self flag: #todo.	"This is not the best solution but we do not know yet what is. Pablo would like to have a minimal version of TaskIt in the image that could be used. But at least this is only in one place and we can update it easily."
 	[ [ self currentValue < 1 ]
-		whileTrue: [ self currentValue: self progressionBlock value.
+		whileTrue: [ self currentValue: self progression value.
 			aProgressBarMorph value: self currentValue.
 			self refreshDelay wait ] ] fork
 ]


### PR DESCRIPTION
Remove reintroduced deprecated method.