### PR TITLE
150--Replace-uses-of-Objecthalt-in-class-TreePresenter-with-uses-of-ObjectopenDebugger-to-show-that-these-halts-are-not-leftover-debugging-code

### DIFF
--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -87,7 +87,7 @@ TreePresenter class >> exampleOfAutoRefreshOnExpand [
 
 { #category : #examples }
 TreePresenter class >> exampleWithCustomColumnsAndNodes [
-	"self exampleWithCustomColumnsAndNodes"
+	<haltOrBreakpointForTesting>
 	| m col1 col2 |
 
 	m := TreePresenter new.
@@ -130,7 +130,7 @@ TreePresenter class >> exampleWithCustomColumnsAndNodes [
 
 { #category : #examples }
 TreePresenter class >> exampleWithCustomColumnsAndNodesAndChildren [
-	"self exampleWithCustomColumnsAndNodesAndChildren"
+	<haltOrBreakpointForTesting>
 
 	| m col1 col2 |
 	m := TreePresenter new.


### PR DESCRIPTION
Flag necessary halts to not display them in the Breakpoint browser.

Fixes #150