### PR TITLE
280-ListPresenter-does-not-triggers-an-event-when-items-change

### DIFF
--- a/src/Spec-Core/AbstractListPresenter.class.st
+++ b/src/Spec-Core/AbstractListPresenter.class.st
@@ -228,7 +228,11 @@ AbstractListPresenter >> items: aCollection [
 	aCollection is a collection of your domain specific items.
 	This creates a collection model"
 	
-	model := SpecCollectionListModel on: aCollection
+	model ifNil: [ 
+		model := SpecCollectionListModel on: aCollection.
+		^ self ].
+	
+	model collection: aCollection
 ]
 
 { #category : #private }
@@ -530,7 +534,17 @@ AbstractListPresenter >> whenListChanged: aBlock [
 	"Specify a block to value after the contents of the list has changed"
 	"Basically when you set a new list of items"
 	"<api: #event>"
+	self
+		deprecated: 'Use #whenModelChangedDo: instead'
+		transformWith: '`@receiver whenListChanged: `@argument'
+						-> '`@receiver whenModelChangedDo: `@argument'.
 	
+	self whenModelChangedDo: aBlock
+]
+
+{ #category : #'api-events' }
+AbstractListPresenter >> whenModelChangedDo: aBlock [
+
 	model whenChangedDo: aBlock
 ]
 

--- a/src/Spec-Core/SpecAbstractSelectionMode.class.st
+++ b/src/Spec-Core/SpecAbstractSelectionMode.class.st
@@ -77,9 +77,21 @@ SpecAbstractSelectionMode >> selectIndex: anIndex [
 ]
 
 { #category : #selecting }
+SpecAbstractSelectionMode >> selectIndexes: aCollection [
+
+	self subclassResponsibility
+]
+
+{ #category : #selecting }
 SpecAbstractSelectionMode >> selectItem: anItem [
 	
 	self basicSelectIndex: (self indexOfItem: anItem)
+]
+
+{ #category : #selecting }
+SpecAbstractSelectionMode >> selectedIndexes [
+
+	self subclassResponsibility
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Spec-Core/SpecCollectionListModel.class.st
+++ b/src/Spec-Core/SpecCollectionListModel.class.st
@@ -37,8 +37,10 @@ SpecCollectionListModel >> collection [
 
 { #category : #accessing }
 SpecCollectionListModel >> collection: anObject [
+
 	collection := anObject.
-	self refreshList
+	self refreshList.
+	self triggerListChanged
 ]
 
 { #category : #accessing }
@@ -85,8 +87,15 @@ SpecCollectionListModel >> size [
 	^ collection size
 ]
 
+{ #category : #private }
+SpecCollectionListModel >> triggerListChanged [
+
+	changedBlock ifNil: [ ^ self ].
+	changedBlock value
+]
+
 { #category : #events }
-SpecCollectionListModel >> whenChangedDo: aBlockClosure [ 
+SpecCollectionListModel >> whenChangedDo: aBlockClosure [
 	
 	changedBlock := aBlockClosure
 ]

--- a/src/Spec-Core/SpecSingleSelectionMode.class.st
+++ b/src/Spec-Core/SpecSingleSelectionMode.class.st
@@ -45,6 +45,14 @@ SpecSingleSelectionMode >> selectAll [
 ]
 
 { #category : #selecting }
+SpecSingleSelectionMode >> selectIndexes: aCollection [
+	"This provides polymorphism with sibling classes, but in our case it will work 
+	 selecting just one (first) element of the collection."
+	
+	self selectIndex: aCollection first 
+]
+
+{ #category : #selecting }
 SpecSingleSelectionMode >> selectedIndex [
 	
 	^ selectedIndexValueHolder value
@@ -52,7 +60,9 @@ SpecSingleSelectionMode >> selectedIndex [
 
 { #category : #selecting }
 SpecSingleSelectionMode >> selectedIndexes [
-	
+	"This provides polymorphism with sibling classes, and answers an array with a single 
+	 element."
+		
 	^ self isEmpty
 		ifTrue: [ #() ]
 		ifFalse: [ { self selectedIndex } ]

--- a/src/Spec-Tests/AbstractListPresenterTest.class.st
+++ b/src/Spec-Tests/AbstractListPresenterTest.class.st
@@ -88,6 +88,20 @@ AbstractListPresenterTest >> testActivationWithoutActivationBlockDoesNothing [
 	self assert: activatedItem equals: nil
 ]
 
+{ #category : #tests }
+AbstractListPresenterTest >> testReplaceItemList [
+	| changed |
+
+	changed := false.
+	presenter whenModelChangedDo: [ changed := true ]. 
+	presenter items: #(a b c).
+	
+	self 
+		assert: presenter model collection
+		equals: #(a b c).
+	self assert: changed
+]
+
 { #category : #'tests-smoke' }
 AbstractListPresenterTest >> testSmokeOpenEmptyPresenter [
 


### PR DESCRIPTION
ensure when replacing a list, an event is thrown

Fixes #280