### PR TITLE
286-SpecStubViews-should-be-SpecStubView

### DIFF
--- a/src/Spec-StubAdapter/SpecStubButtonView.class.st
+++ b/src/Spec-StubAdapter/SpecStubButtonView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubButtonView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubCheckBoxView.class.st
+++ b/src/Spec-StubAdapter/SpecStubCheckBoxView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubCheckBoxView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubContainerView.class.st
+++ b/src/Spec-StubAdapter/SpecStubContainerView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubContainerView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubDialogWindowView.class.st
+++ b/src/Spec-StubAdapter/SpecStubDialogWindowView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubDialogWindowView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubDiffView.class.st
+++ b/src/Spec-StubAdapter/SpecStubDiffView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubDiffView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubDropListView.class.st
+++ b/src/Spec-StubAdapter/SpecStubDropListView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubDropListView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubFastTableView.class.st
+++ b/src/Spec-StubAdapter/SpecStubFastTableView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubFastTableView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubIconListView.class.st
+++ b/src/Spec-StubAdapter/SpecStubIconListView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubIconListView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubImageView.class.st
+++ b/src/Spec-StubAdapter/SpecStubImageView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubImageView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubListView.class.st
+++ b/src/Spec-StubAdapter/SpecStubListView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubListView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubMenuGroupView.class.st
+++ b/src/Spec-StubAdapter/SpecStubMenuGroupView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubMenuGroupView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubMenuItemView.class.st
+++ b/src/Spec-StubAdapter/SpecStubMenuItemView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubMenuItemView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubMenuView.class.st
+++ b/src/Spec-StubAdapter/SpecStubMenuView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubMenuView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubMultiColumnListView.class.st
+++ b/src/Spec-StubAdapter/SpecStubMultiColumnListView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubMultiColumnListView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubNumberInputFieldView.class.st
+++ b/src/Spec-StubAdapter/SpecStubNumberInputFieldView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubNumberInputFieldView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubRadioButtonView.class.st
+++ b/src/Spec-StubAdapter/SpecStubRadioButtonView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubRadioButtonView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubSliderView.class.st
+++ b/src/Spec-StubAdapter/SpecStubSliderView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubSliderView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubSpacerView.class.st
+++ b/src/Spec-StubAdapter/SpecStubSpacerView.class.st
@@ -3,6 +3,6 @@ Stub
 "
 Class {
 	#name : #SpecStubSpacerView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTabManagerView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTabManagerView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTabManagerView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTabView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTabView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTabView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTableContainerView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTableContainerView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTableContainerView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTextInputFieldView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTextInputFieldView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTextInputFieldView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTextView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTextView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTextView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTickingWindowView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTickingWindowView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTickingWindowView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTransferView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTransferView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTransferView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTreeColumnView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTreeColumnView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTreeColumnView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTreeNodeView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTreeNodeView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTreeNodeView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubTreeView.class.st
+++ b/src/Spec-StubAdapter/SpecStubTreeView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubTreeView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }

--- a/src/Spec-StubAdapter/SpecStubView.class.st
+++ b/src/Spec-StubAdapter/SpecStubView.class.st
@@ -2,7 +2,13 @@
 I am an abstract stub view. My subclasses do not display any real UI component
 "
 Class {
-	#name : #SpecStubViews,
+	#name : #SpecStubView,
 	#superclass : #Object,
 	#category : #'Spec-StubAdapter-Views'
 }
+
+{ #category : #compatibility }
+SpecStubView >> bindKeyCombination: aShortcut toAction: aBlock [
+
+	
+]

--- a/src/Spec-StubAdapter/SpecStubWindowView.class.st
+++ b/src/Spec-StubAdapter/SpecStubWindowView.class.st
@@ -4,6 +4,6 @@ Only stub object, no real view is displayed.
 "
 Class {
 	#name : #SpecStubWindowView,
-	#superclass : #SpecStubViews,
+	#superclass : #SpecStubView,
 	#category : #'Spec-StubAdapter-Views'
 }


### PR DESCRIPTION
rename SpecStubViews and add empty bindKeyCombination:toAction: to itfixes #286fixes #285