### PR TITLE
289-TextPrensenterTesttestSelectAll-should-be-split

### DIFF
--- a/src/Spec-Tests/TextPresenterTest.class.st
+++ b/src/Spec-Tests/TextPresenterTest.class.st
@@ -15,11 +15,19 @@ TextPresenterTest >> initializationText [
 ]
 
 { #category : #tests }
+TextPresenterTest >> testClearSelection [
+	self initializationText.
+	self openInstance.
+	presenter setSelection: (1 to: 10).
+	self assert: presenter getSelection equals: (1 to: 10).
+	presenter clearSelection.
+	self assert: presenter getSelection isEmpty
+]
+
+{ #category : #tests }
 TextPresenterTest >> testSelectAll [
 	self initializationText.
 	self openInstance.
 	presenter selectAll.
-	self assert: presenter getSelection equals: (1 to: 15).
-	presenter clearSelection.
-	self assert: presenter getSelection isEmpty
+	self assert: presenter getSelection equals: (1 to: 15)
 ]


### PR DESCRIPTION
Split a test in two to explicit what we are testing.

Fixes #289