### PR TITLE
292-Move-all-tests-in-test-package

### DIFF
--- a/src/Spec-Tests/SpecObservableSlotTest.class.st
+++ b/src/Spec-Tests/SpecObservableSlotTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'point'
 	],
-	#category : #'Spec-Core-Observable'
+	#category : #'Spec-Tests-Observable'
 }
 
 { #category : #tests }


### PR DESCRIPTION
Observables tests should not be in Core.

Fixes #292