### PR TITLE
344-Remove-users-of-FastTablePresenter-to-use-ListPresenter

### DIFF
--- a/src/Spec-Inspector/EyeInspector.class.st
+++ b/src/Spec-Inspector/EyeInspector.class.st
@@ -285,11 +285,11 @@ EyeInspector >> limit2 [
 { #category : #accessing }
 EyeInspector >> list [
 	^ list
-		ifNil: [ list := self instantiate: FastTablePresenter.
-			list
-				handlesDoubleClick: true;
+		ifNil: [ list := self newList
+				activateOnDoubleClick;
 				whenSelectionChangedDo: [ :selection | [ :item | self refreshDescription: item ] cull: selection selectedItem ];
-				doubleClickAction: [ self diveIntoSelectedObject ] ]
+				whenActivatedDo: [ self diveIntoSelectedObject ];
+				yourself ]
 ]
 
 { #category : #'event-handling' }

--- a/src/Spec-PolyWidgets/EditableList.class.st
+++ b/src/Spec-PolyWidgets/EditableList.class.st
@@ -134,7 +134,7 @@ EditableList >> initializePresenter [
 
 { #category : #initialization }
 EditableList >> initializeWidgets [
-	list := self instantiate: FastTablePresenter.
+	list := self newList.
 	addButton := self newButton.
 	removeButton := self newButton.
 	upButton := self newButton.

--- a/src/Spec-PolyWidgets/SelectEntity.class.st
+++ b/src/Spec-PolyWidgets/SelectEntity.class.st
@@ -37,7 +37,7 @@ SelectEntity class >> defaultSpec [
 { #category : #example }
 SelectEntity class >> example [
 	self new
-		selectDialog: [ FastTablePresenter new
+		selectDialog: [ ListPresenter new
 				items: #(Henrik Peter);
 				yourself ];
 		displaySymbol: #asString;

--- a/src/Spec-Tools/ChangeSorterApplication.class.st
+++ b/src/Spec-Tools/ChangeSorterApplication.class.st
@@ -483,9 +483,9 @@ ChangeSorterApplication >> initializePresenter [
 { #category : #initialization }
 ChangeSorterApplication >> initializeWidgets [
 
-	methodsListPresenter := self instantiate: FastTablePresenter.
-	classesListPresenter := self instantiate: FastTablePresenter.
-	changesListPresenter := self instantiate: FastTablePresenter.
+	methodsListPresenter := self newList.
+	classesListPresenter := self newList.
+	changesListPresenter := self newList.
 	prettyButton := self newCheckBox.
 	diffButton := self newCheckBox.
 	textPresenter := self newCode.
@@ -495,6 +495,10 @@ ChangeSorterApplication >> initializeWidgets [
 	methodsListPresenter menu: [:menu :shifted | self messageMenu: menu shifted: shifted ].
 	changesListPresenter menu: [:aMenu :shifted | self changeSetMenu: aMenu shifted: shifted  ].
 	classesListPresenter menu: [:aMenu :shifted | self classMenu: aMenu shifted: shifted ].
+	
+	methodsListPresenter itemSubstringFilter.
+	classesListPresenter itemSubstringFilter.
+	changesListPresenter itemSubstringFilter.
 
 	changesListPresenter items: self model allChanges.
 	changesListPresenter displayBlock: [:item | item name ].


### PR DESCRIPTION
Replace usage of FastTablePresenter to use ListPresenter.

There is still one user but it uses a table and not a list...

Fixes #344