### PR TITLE
380-Objects-that-the-SpecInterpreter-creates-should-have-an-owner

### DIFF
--- a/src/Spec-Core/AbstractAdapter.class.st
+++ b/src/Spec-Core/AbstractAdapter.class.st
@@ -13,7 +13,8 @@ Class {
 	#instVars : [
 		'model',
 		'widget',
-		'selector'
+		'selector',
+		'owner'
 	],
 	#category : #'Spec-Core-Base'
 }
@@ -45,6 +46,12 @@ AbstractAdapter class >> allAdapters [
 	"The abstract adapters should be able to return all the adapters for a framework"
 	
 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractAdapter class >> owner: anOwner [
+
+	^ self new owner: anOwner; yourself
 ]
 
 { #category : #initialization }
@@ -114,6 +121,18 @@ AbstractAdapter >> layout: aLayout [
 { #category : #accessing }
 AbstractAdapter >> model [
 	^ model
+]
+
+{ #category : #accessing }
+AbstractAdapter >> owner [
+
+	"Every object instantiated by the SpecInerpreter should have an owner that will assign it to a particular presenter"
+	^ owner
+]
+
+{ #category : #accessing }
+AbstractAdapter >> owner: anObject [
+	owner := anObject
 ]
 
 { #category : #accessing }

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -1011,7 +1011,6 @@ ComposablePresenter >> show [
 { #category : #TOREMOVE }
 ComposablePresenter >> specSpacer [
 
-	self halt.
 	^ SpacerPresenter new
 ]
 

--- a/src/Spec-Core/RadioButtonGroupPresenter.class.st
+++ b/src/Spec-Core/RadioButtonGroupPresenter.class.st
@@ -135,7 +135,8 @@ RadioButtonGroupPresenter >> initialize [
 { #category : #initialization }
 RadioButtonGroupPresenter >> initializePresenter [
 	self
-		whenCanDeselectByClickChanged: [ :aBoolean | buttons do: [ :each | each canDeselectByClick: aBoolean ] ]
+		whenCanDeselectByClickChangedDo:
+			[ :aBoolean | buttons do: [ :each | each canDeselectByClick: aBoolean ] ]
 ]
 
 { #category : #api }

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -70,11 +70,13 @@ SpecInterpreter >> computeSpecFrom: aSymbol [
 SpecInterpreter >> convertSymbolOfClassToInstance: aSymbol [
 	| translatedSymbol |
 	
+	aSymbol logCr.
 	translatedSymbol := self bindings translateSymbol: aSymbol.
+	translatedSymbol logCr.
 	
 	^ (Smalltalk 
 		at: translatedSymbol
-		ifAbsent: [ ^ translatedSymbol ]) new
+		ifAbsent: [ ^ translatedSymbol ]) owner: self presenter
 ]
 
 { #category : #'interpreting-private' }

--- a/src/Spec-Layout/SpecLayoutFrame.class.st
+++ b/src/Spec-Layout/SpecLayoutFrame.class.st
@@ -14,7 +14,8 @@ Class {
 		'rightFraction',
 		'rightOffset',
 		'topFraction',
-		'topOffset'
+		'topOffset',
+		'owner'
 	],
 	#category : #'Spec-Layout-Support'
 }
@@ -23,6 +24,12 @@ Class {
 SpecLayoutFrame class >> identity [
 	"by default a layout frame is initialized to represent the identity transformation"
 	^ self new
+]
+
+{ #category : #'instance creation' }
+SpecLayoutFrame class >> owner: anObject [
+
+	^ self new owner: anObject; yourself.
 ]
 
 { #category : #converting }
@@ -125,6 +132,18 @@ SpecLayoutFrame >> leftOffset [
 SpecLayoutFrame >> leftOffset: anObject [
 	
 	leftOffset := anObject
+]
+
+{ #category : #accessing }
+SpecLayoutFrame >> owner [
+
+	"Every object instantiated by the SpecInerpreter should have an owner that will assign it to a particular presenter"
+	^ owner
+]
+
+{ #category : #accessing }
+SpecLayoutFrame >> owner: anObject [
+	owner := anObject
 ]
 
 { #category : #accessing }

--- a/src/Spec-MorphicAdapters/MorphicListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicListAdapter.class.st
@@ -143,16 +143,13 @@ MorphicListAdapter >> refreshWidgetHeaderTitle [
 
 { #category : #'widget API' }
 MorphicListAdapter >> refreshWidgetList [
-	
 	(self widget showIndex < self widget dataSource numberOfRows
-		and: [ self widget isRowIndexVisible: self widget showIndex ])
-			ifFalse: [ self widget resetPosition ].
-	
+		and: [ self widget isIndexVisible: self widget showIndex ])
+		ifFalse: [ self widget resetPosition ].
 	self refreshWidgetSelection.
-
-	(self widget hasSelection and: [ (self widget isRowIndexVisible: self widget selectedRowIndex) ])
-		ifFalse: [ 
-			self widget resetPosition.
+	(self widget hasSelection
+		and: [ self widget isIndexVisible: self widget selectedIndex ])
+		ifFalse: [ self widget resetPosition.
 			self widget ensureVisibleFirstSelection ].
 	self widget refresh
 ]

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -33,7 +33,7 @@ SpecInterpreterTest >> tearDown [
 { #category : #tests }
 SpecInterpreterTest >> testConvertRandomSymbolOfClassToInstance [
 	| symbol instance |
-	symbol := #PluggableListMorph.
+	symbol := #MenuRegistration.
 	instance := specInterpreter convertSymbolOfClassToInstance: symbol.
 	self assert: instance class name equals: symbol
 ]
@@ -59,7 +59,7 @@ SpecInterpreterTest >> testDynamicBuild [
 SpecInterpreterTest >> testInterpretASpecModelMorphAssociation [
 	| spec model morph |
 	model := AbstractWidgetPresenter new.
-	spec := {#PluggableListMorph . #model: . #presenter}.
+	spec := {#MenuRegistration . #help: . #icon:}.
 	morph := specInterpreterClass interpretASpec: spec presenter: model.
 	self assert: model adapter == morph
 ]


### PR DESCRIPTION
- add owner to the objects that SpecInterpreter can instantiate (adapters, layout frame)
- clean forgotten halt
- some automatic rewrites