### PR TITLE
347-addModelInwithSpecLayout-methods-should-be-renamed

### DIFF
--- a/src/Spec-Core/WindowPresenter.class.st
+++ b/src/Spec-Core/WindowPresenter.class.st
@@ -62,19 +62,19 @@ WindowPresenter >> addMenuItemsToWindowMenu: aMenu [
 	self presenter addMenuItemsToWindowMenu: aMenu
 ]
 
+{ #category : #menu }
+WindowPresenter >> addModelItemsToWindowMenu: aMenu [
+	self presenter addModelItemsToWindowMenu: aMenu
+]
+
 { #category : #'private building' }
-WindowPresenter >> addModelIn: widget withSpecLayout: aSpec [
+WindowPresenter >> addPresenterIn: widget withSpecLayout: aSpec [
 	
 	self presenter ifNil: [ ^ self ].
 	self initializeWindow.
 	self 
-		changed: #addModelIn:withSpecLayout:
+		changed: #addPresenterIn:withSpecLayout:
 		with: { widget. aSpec }
-]
-
-{ #category : #menu }
-WindowPresenter >> addModelItemsToWindowMenu: aMenu [
-	self presenter addModelItemsToWindowMenu: aMenu
 ]
 
 { #category : #api }
@@ -97,7 +97,7 @@ WindowPresenter >> basicBuildWithSpecLayout: aSpecLayout [
 	(self spec isNil or: [ self needRebuild ])
 		ifTrue: [ 
 			widget := (self adapterFrom: self retrieveDefaultSpec) widget.
-			self addModelIn: widget withSpecLayout: aSpecLayout ]
+			self addPresenterIn: widget withSpecLayout: aSpecLayout ]
 		ifFalse: [
 			widget := self widget ].
 	

--- a/src/Spec-Deprecated80/MorphicWindowAdapter.extension.st
+++ b/src/Spec-Deprecated80/MorphicWindowAdapter.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #MorphicWindowAdapter }
+
+{ #category : #'*Spec-Deprecated80' }
+MorphicWindowAdapter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
+	self
+		deprecated: 'Use #addPresenterIn:withSpecLayout: instead.'
+		transformWith: '`@receiver addModelIn: `@statements1 withSpecLayout: `@statements2' -> '`@receiver addPresenterIn: `@statements1 withSpecLayout: `@statements2'.
+	self addPresenterIn: widgetToBuild withSpecLayout: aSpec
+]

--- a/src/Spec-Deprecated80/SpecStubAbstractAdapter.extension.st
+++ b/src/Spec-Deprecated80/SpecStubAbstractAdapter.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #SpecStubAbstractAdapter }
+
+{ #category : #'*Spec-Deprecated80' }
+SpecStubAbstractAdapter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
+	self
+		deprecated: 'Use #addPresenterIn:withSpecLayout: instead.'
+		transformWith: '`@receiver addModelIn: `@statements1 withSpecLayout: `@statements2' -> '`@receiver addPresenterIn: `@statements1 withSpecLayout: `@statements2'.
+	self addPresenterIn: widgetToBuild withSpecLayout: aSpec
+]

--- a/src/Spec-Deprecated80/WindowPresenter.extension.st
+++ b/src/Spec-Deprecated80/WindowPresenter.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #WindowPresenter }
 
 { #category : #'*Spec-Deprecated80' }
+WindowPresenter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
+	self
+		deprecated: 'Use #addPresenterIn:withSpecLayout: instead.'
+		transformWith: '`@receiver addModelIn: `@statements1 withSpecLayout: `@statements2' -> '`@receiver addPresenterIn: `@statements1 withSpecLayout: `@statements2'.
+	self addPresenterIn: widgetToBuild withSpecLayout: aSpec
+]
+
+{ #category : #'*Spec-Deprecated80' }
 WindowPresenter >> model [
 	self deprecated: 'Model was renamed Presenter in Pharo 7' transformWith: '`@receiver model' -> '`@receiver presenter'.
 	

--- a/src/Spec-MorphicAdapters/MorphicDialogWindowAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDialogWindowAdapter.class.st
@@ -8,11 +8,11 @@ Class {
 }
 
 { #category : #private }
-MorphicDialogWindowAdapter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
+MorphicDialogWindowAdapter >> addPresenterIn: widgetToBuild withSpecLayout: aSpec [
 	"I replace the mainPanel (which contains contents and button bar) because like that I get the 
 	 status bar at the end (where it belongs)"
 
-	super addModelIn: widgetToBuild withSpecLayout: aSpec.
+	super addPresenterIn: widgetToBuild withSpecLayout: aSpec.
 		
 	widgetToBuild setToolbarFrom: [ self buildButtonBar ]
 ]

--- a/src/Spec-MorphicAdapters/MorphicWindowAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicWindowAdapter.class.st
@@ -60,20 +60,16 @@ MorphicWindowAdapter >> addMenuTo: aMorph [
 		vResizing: #rigid
 ]
 
-{ #category : #protocol }
-MorphicWindowAdapter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
-
-	self model initialExtent ifNotNil: [ :extent |
-		 widgetToBuild extent: extent ].
-	self
-		addContent: (self model presenter buildWithSpecLayout: aSpec)
-		toWindow: widgetToBuild
-]
-
 { #category : #'widget API' }
 MorphicWindowAdapter >> addModelItemsToWindowMenu: aMenu [
 
 	self model addMenuItemsToWindowMenu: aMenu
+]
+
+{ #category : #protocol }
+MorphicWindowAdapter >> addPresenterIn: widgetToBuild withSpecLayout: aSpec [
+	self model initialExtent ifNotNil: [ :extent | widgetToBuild extent: extent ].
+	self addContent: (self model presenter buildWithSpecLayout: aSpec) toWindow: widgetToBuild
 ]
 
 { #category : #private }
@@ -232,7 +228,7 @@ MorphicWindowAdapter >> rebuildWithSpecLayout: aSpec [
 	sub := self model window submorphs copy.
 	self model window removeAllMorphs.
 	sub allButLast do: [:e | self model window addMorphBack: e ].
-	self model addModelIn: self widget withSpecLayout: aSpec.
+	self model addPresenterIn: self widget withSpecLayout: aSpec.
 	self widget model: self
 ]
 

--- a/src/Spec-MorphicAdapters/WorldPresenter.class.st
+++ b/src/Spec-MorphicAdapters/WorldPresenter.class.st
@@ -34,7 +34,7 @@ WorldPresenter class >> setUpWorld [
 ]
 
 { #category : #private }
-WorldPresenter >> addModelIn: container withSpecLayout: aSpec [
+WorldPresenter >> addPresenterIn: container withSpecLayout: aSpec [
 
 	self presenter ifNil: [ ^ self ].
 	widget := self presenter buildWithSpecLayout: aSpec.

--- a/src/Spec-StubAdapter/SpecStubAbstractAdapter.class.st
+++ b/src/Spec-StubAdapter/SpecStubAbstractAdapter.class.st
@@ -28,7 +28,7 @@ SpecStubAbstractAdapter >> add: aWidget [
 ]
 
 { #category : #factory }
-SpecStubAbstractAdapter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
+SpecStubAbstractAdapter >> addPresenterIn: widgetToBuild withSpecLayout: aSpec [
 	
 	
 ]

--- a/src/Spec-StubAdapter/SpecStubWindowAdapter.class.st
+++ b/src/Spec-StubAdapter/SpecStubWindowAdapter.class.st
@@ -14,7 +14,7 @@ SpecStubWindowAdapter >> addContent: aView toWindow: aSpecWindow [
 ]
 
 { #category : #factory }
-SpecStubWindowAdapter >> addModelIn: widgetToBuild withSpecLayout: aSpec [
+SpecStubWindowAdapter >> addPresenterIn: widgetToBuild withSpecLayout: aSpec [
 	self
 		addContent: (self model presenter buildWithSpecLayout: aSpec)
 		toWindow: widgetToBuild


### PR DESCRIPTION
Fix name consistency to remove #model and use #presenter.

Fixes #347