### PR TITLE
412-Right-click-on-a-list-produce-an-error

### DIFF
--- a/src/Spec-MorphicAdapters/SpecListFastTableDataSource.class.st
+++ b/src/Spec-MorphicAdapters/SpecListFastTableDataSource.class.st
@@ -51,7 +51,7 @@ SpecListFastTableDataSource >> menuColumn: column row: rowIndex [
 	| menuPresenter |
 
 	menuPresenter := self model contextMenu.
-	menuPresenter ifNil: [ ^ self ].
+	menuPresenter ifNil: [ ^ nil ].
 	^ SpecBindings
 		value: self model application adapterBindings
 		during: [ 


### PR DESCRIPTION
When there is no menu, data source should return nil and not self.

Fixes #412