### PR TITLE
417-List-presenter-does-not-take-all-height-in-horizontal-paned-layout

### DIFF
--- a/src/Spec-MorphicAdapters/MorphicDefaultStyleSheet.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDefaultStyleSheet.class.st
@@ -25,7 +25,7 @@ MorphicDefaultStyleSheet >> initialize [
 		addClass: #CheckBox with: { MorphicStyleSheetExtent newExtent: 15@25 hResizing: true };
 		addClass: #RadioButton with: { MorphicStyleSheetExtent newExtent: 15@25 };
 		addClass: #DropList with: { MorphicStyleSheetExtent newExtent: 150@25 hResizing: true };
-		addClass: #List with: { MorphicStyleSheetExtent newExtent: 150@100 hResizing: true };
+		addClass: #List with: { MorphicStyleSheetExtent newExtent: 150@100 hResizing: true vResizing: true};
 		addClass: #Label with: { MorphicStyleSheetExtent newExtent: 50@25 hResizing: true };
 		addClass: #Link with: { MorphicStyleSheetExtent newExtent: 50@25 hResizing: true };
 		addClass: #Text with: { MorphicStyleSheetExtent newExtent: 150@100 hResizing: true vResizing: true};


### PR DESCRIPTION
List should fill verticaly by default. 

Fixes #417