### PR TITLE
cleanup/layout-and-interpreter

### DIFF
--- a/src/Spec-Core/Array.extension.st
+++ b/src/Spec-Core/Array.extension.st
@@ -1,10 +1,11 @@
 Extension { #name : #Array }
 
 { #category : #'*Spec-Core' }
-Array >> buildAdapterFor: aPresenter bindings: adapterBindings [
-	"Provides polymorphism with executable layouts."
+Array >> asSpecLayout [
 
-	^ aPresenter adapterFrom: self
+	^ SpecLegacyArrayLayout new
+		array: self;
+		yourself
 ]
 
 { #category : #'*Spec-Core' }

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -975,10 +975,10 @@ ComposablePresenter >> resolveSymbol: aSymbol [
 ]
 
 { #category : #api }
-ComposablePresenter >> retrieveDefaultSpec [
+ComposablePresenter >> retrieveSpec: aSelector [
 
 	self layout ifNotNil: [ ^ self layout ].
-	^ self retrieveSpec: self defaultSpecSelector
+	^ super retrieveSpec: aSelector
 ]
 
 { #category : #TOMOVE }

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -89,6 +89,7 @@ Class {
 	#traits : 'TSpecObservable',
 	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
+		'#layout',
 		'#application',
 		'#focusOrder',
 		'#extentHolder',
@@ -350,6 +351,14 @@ ComposablePresenter >> bindMenuKeyCombination: aShortcut toAction: aBlock [
 	self additionalKeyBindings at: aShortcut put: aBlock.
 	
 	self changed: #bindMenuKeyCombination:toAction: with: {aShortcut . aBlock}
+]
+
+{ #category : #building }
+ComposablePresenter >> buildWithSpec [
+	"Build the widget using the default spec"
+	
+	self layout ifNotNil: [ ^ self buildWithSpecLayout: self layout ].
+	^ super buildWithSpec
 ]
 
 { #category : #'api-window' }
@@ -714,6 +723,11 @@ ComposablePresenter >> keyStrokesForPreviousFocus: aCollection [
 	keyStrokesForPreviousFocusHolder value: aCollection 
 ]
 
+{ #category : #accessing }
+ComposablePresenter >> layout [
+	^ layout
+]
+
 { #category : #'window menu' }
 ComposablePresenter >> neglectMenuModel: aMenuModel [
 
@@ -970,6 +984,8 @@ ComposablePresenter >> resolveSymbol: aSymbol [
 
 { #category : #api }
 ComposablePresenter >> retrieveDefaultSpec [
+
+	self layout ifNotNil: [ ^ self layout ].
 	^ self retrieveSpec: self defaultSpecSelector
 ]
 

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -353,14 +353,6 @@ ComposablePresenter >> bindMenuKeyCombination: aShortcut toAction: aBlock [
 	self changed: #bindMenuKeyCombination:toAction: with: {aShortcut . aBlock}
 ]
 
-{ #category : #building }
-ComposablePresenter >> buildWithSpec [
-	"Build the widget using the default spec"
-	
-	self layout ifNotNil: [ ^ self buildWithSpecLayout: self layout ].
-	^ super buildWithSpec
-]
-
 { #category : #'api-window' }
 ComposablePresenter >> cancelled [
 	self flag: #TODO. "just for dialogs... I wonder if we need it here?"

--- a/src/Spec-Core/DynamicComposablePresenter.class.st
+++ b/src/Spec-Core/DynamicComposablePresenter.class.st
@@ -25,8 +25,7 @@ Class {
 	#name : #DynamicComposablePresenter,
 	#superclass : #ComposablePresenter,
 	#instVars : [
-		'widgets',
-		'layout'
+		'widgets'
 	],
 	#category : #'Spec-Core-Base'
 }

--- a/src/Spec-Core/MenuGroupPresenter.class.st
+++ b/src/Spec-Core/MenuGroupPresenter.class.st
@@ -66,8 +66,8 @@ MenuGroupPresenter >> autoRefresh: aBoolean [
 { #category : #private }
 MenuGroupPresenter >> buildWithSpecLayout: aSpecLayout [
 	"Build the widget using the spec name provided as argument"
-	| adapter widget|
-	adapter := self adapterFrom: aSpecLayout.
+	| widget|
+	adapter := self basicBuildAdapterWithSpecLayout: aSpecLayout.
 	widget := adapter asWidget.
 	self announce: (WidgetBuilt model: self widget: widget).
 	^ widget

--- a/src/Spec-Core/PluggableButtonMorph.extension.st
+++ b/src/Spec-Core/PluggableButtonMorph.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #PluggableButtonMorph }
+
+{ #category : #'*Spec-Core' }
+PluggableButtonMorph >> getMenu: shiftPressed [ 
+	"Answer the menu for this button, supplying an empty menu to be filled in. If the menu selector takes an extra argument, pass in the current state of the shift key."
+
+	| menu |
+	getMenuSelector isNil ifTrue: [^nil].
+	menu := self theme newMenuIn: self for: model.
+	getMenuSelector numArgs = 1 
+		ifTrue: [^model perform: getMenuSelector with: menu].
+	getMenuSelector numArgs = 2 
+		ifTrue: 
+			[^model 
+				perform: getMenuSelector
+				with: menu
+				with: shiftPressed].
+	^self error: 'The getMenuSelector must be a 1- or 2-keyword symbol'
+]

--- a/src/Spec-Core/Presenter.class.st
+++ b/src/Spec-Core/Presenter.class.st
@@ -81,16 +81,6 @@ Presenter >> adapter: anAdapter [
 	adapter := anAdapter
 ]
 
-{ #category : #'private building' }
-Presenter >> adapterFrom: aSpecLayout [
-
-	self flag: #TODO. "this is here for compatibility (since layouts now are executable). 
-	We will need to remove the interpreter and then this method too."
-	^ SpecInterpreter 
-		interpretASpec: aSpecLayout 
-		presenter: self
-]
-
 { #category : #accessing }
 Presenter >> application [
 	"Answer application owner of this composition.
@@ -104,7 +94,7 @@ Presenter >> application [
 Presenter >> basicBuildAdapterWithSpecLayout: aSpecLayout [
 	"I assume the SpecBindings is well defined"
 	| newAdapter |
-	newAdapter := aSpecLayout buildAdapterFor: self bindings: SpecBindings value.
+	newAdapter := aSpecLayout asSpecLayout buildAdapterFor: self bindings: SpecBindings value.
 	adapter := newAdapter.
 	"self setExtentAndBindingTo: newAdapter widget."
 	self announcer announce: (WidgetBuilt 

--- a/src/Spec-Core/Presenter.class.st
+++ b/src/Spec-Core/Presenter.class.st
@@ -117,7 +117,7 @@ Presenter >> buildAdapterWithSpecLayout: aSpecLayout [
 Presenter >> buildWithSpec [
 	"Build the widget using the default spec"
 	
-	^ self buildWithSpec: self defaultSpecSelector
+	^ self buildWithSpecLayout: self retrieveDefaultSpec
 ]
 
 { #category : #building }

--- a/src/Spec-Core/SpecMillerColumnPresenter.class.st
+++ b/src/Spec-Core/SpecMillerColumnPresenter.class.st
@@ -18,7 +18,6 @@ Class {
 	#name : #SpecMillerColumnPresenter,
 	#superclass : #ComposablePresenter,
 	#instVars : [
-		'presenters',
 		'newPresenterBlock'
 	],
 	#category : #'Spec-Core-Miller'
@@ -29,30 +28,17 @@ SpecMillerColumnPresenter >> addPresenter: newSubPresenter [
 
 	newSubPresenter whenActivatedDo: [ :selection | 
 			self changeSelection: selection selectedItem from: newSubPresenter ].
-	presenters add: newSubPresenter.
-
 	newSubPresenter owner: self.
-	
-	self adapter ifNotNil: [ 
-		self adapter add: newSubPresenter ].
+	layout add: newSubPresenter.
 ]
 
 { #category : #initialization }
 SpecMillerColumnPresenter >> changeSelection: selection from: aPresenter [
 
 	| selectedPresenterIndex |
-	selectedPresenterIndex := presenters indexOf: aPresenter.
+	selectedPresenterIndex := self presenters indexOf: aPresenter.
 	self resetTo: selectedPresenterIndex.
 	self pushModel: selection.
-]
-
-{ #category : #specs }
-SpecMillerColumnPresenter >> defaultSpec [
-
-	| layout |
-	layout := SpecBoxLayout newHorizontal.
-	presenters do: [ :each | layout add: each ].
-	^ layout
 ]
 
 { #category : #initialization }
@@ -65,7 +51,7 @@ SpecMillerColumnPresenter >> initialize [
 { #category : #initialization }
 SpecMillerColumnPresenter >> initializeWidgets [
 	
-	presenters := OrderedCollection new
+	layout := SpecBoxLayout newHorizontal
 ]
 
 { #category : #initialization }
@@ -83,7 +69,7 @@ SpecMillerColumnPresenter >> presenterBlock: aBlockClosure [
 { #category : #accessing }
 SpecMillerColumnPresenter >> presenters [
 
-	^ presenters
+	^ layout presenters
 ]
 
 { #category : #model }
@@ -96,20 +82,8 @@ SpecMillerColumnPresenter >> pushModel: aModel [
 SpecMillerColumnPresenter >> resetTo: anIndex [
 	"Remove all presenters up to anIndex.
 	0 means to remove all elements."
-	presenters copy withIndexDo: [ :presenter :index |
-		index <= anIndex ifFalse: [ 
-			presenters remove: presenter.
-			self adapter ifNotNil: [ :theAdapter | theAdapter remove: presenter ] ] ]
-]
-
-{ #category : #initialization }
-SpecMillerColumnPresenter >> retrieveSpec: aSelector [
-	| layout |
-
-	layout := self perform: aSelector.
-	layout isSpecLayout ifTrue: [ 
-		layout selector: aSelector ].
-	^ layout
+	self presenters copy withIndexDo: [ :presenter :index |
+		index <= anIndex ifFalse: [ layout remove: presenter ] ]
 ]
 
 { #category : #model }

--- a/src/Spec-Core/WindowPresenter.class.st
+++ b/src/Spec-Core/WindowPresenter.class.st
@@ -103,10 +103,10 @@ WindowPresenter >> basicBuildWithSpecLayout: aSpecLayout [
 
 	(self spec isNil or: [ self needRebuild ])
 		ifTrue: [ 
-			widget := (self adapterFrom: self retrieveDefaultSpec) widget.
+			widget := (self retrieveDefaultSpec asSpecLayout
+				buildAdapterFor: self bindings: SpecBindings value) widget.
 			self addPresenterIn: widget withSpecLayout: aSpecLayout.
-			self announce: (WidgetBuilt model: self widget: widget).
-			self announce: (WindowBuilt model: self). ]
+			self announce: (WidgetBuilt model: self widget: widget).]
 		ifFalse: [
 			widget := self widget ].
 	

--- a/src/Spec-Deprecated80/DialogWindowPresenter.extension.st
+++ b/src/Spec-Deprecated80/DialogWindowPresenter.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #DialogWindowPresenter }
 
 { #category : #'*Spec-Deprecated80' }
 DialogWindowPresenter >> toolbar [
-	self deprecated: 'The way dialogs uses toolbars changed in Pharo 8 and this way is deprecated. 
+	[self deprecated: 'The way dialogs uses toolbars changed in Pharo 8 and this way is deprecated. 
 	
 	Before the dialog bar had one or two buttons: Ok and Cancel, but they where not configurable. Now the user can add itself multiple buttons and configure their action more easily.
 	
@@ -18,6 +18,6 @@ DialogWindowPresenter >> toolbar [
 		addButton: ''Ignore'' 
 		do: [ :presenter | presenter close ]. 
 
-	'.
+	'.].
 	^ DeprecatedSpecToolbarHelper for: self
 ]

--- a/src/Spec-Layout/SpecBoxLayout.class.st
+++ b/src/Spec-Layout/SpecBoxLayout.class.st
@@ -55,6 +55,14 @@ SpecBoxLayout >> add: aName expand: shouldExpand fill: shouldFill padding: aNumb
 ]
 
 { #category : #adding }
+SpecBoxLayout >> add: aPresenter withConstraints: aBlock [
+	
+	super add: aPresenter withConstraints: aBlock.
+	adapter ifNotNil: [ :theAdapter |
+		theAdapter add: aPresenter constraints: (children at: aPresenter) ]
+]
+
+{ #category : #adding }
 SpecBoxLayout >> addLast: aName [
 
 	self 
@@ -161,6 +169,13 @@ SpecBoxLayout >> isHorizontal [
 SpecBoxLayout >> isVertical [ 
 
 	^ self direction = SpecLayoutDirection vertical
+]
+
+{ #category : #removing }
+SpecBoxLayout >> remove: aPresenter [
+
+	children removeKey: aPresenter.
+	adapter ifNotNil: [ :theAdapter | theAdapter remove: aPresenter ]
 ]
 
 { #category : #accessing }

--- a/src/Spec-Layout/SpecExecutableLayout.class.st
+++ b/src/Spec-Layout/SpecExecutableLayout.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'children',
-		'selector'
+		'selector',
+		'adapter'
 	],
 	#category : #'Spec-Layout-Base'
 }
@@ -31,10 +32,14 @@ SpecExecutableLayout >> asArray [
 	self error: 'Should not arrive here. This layout is executable then it will not be interpreted.'
 ]
 
+{ #category : #converting }
+SpecExecutableLayout >> asSpecLayout [
+	
+	^ self
+]
+
 { #category : #building }
 SpecExecutableLayout >> buildAdapterFor: aModel bindings: bindings [
-	| adapter |
-	
 	adapter := (bindings adapterClass: self adapterName) adapt: aModel.
 	adapter layout: self.
 	children

--- a/src/Spec-Layout/SpecExecutableLayout.class.st
+++ b/src/Spec-Layout/SpecExecutableLayout.class.st
@@ -81,6 +81,12 @@ SpecExecutableLayout >> isSpecLayout [
 	^ true
 ]
 
+{ #category : #accessing }
+SpecExecutableLayout >> presenters [
+	
+	^ children keys
+]
+
 { #category : #private }
 SpecExecutableLayout >> resolvePresenter: presenterNameOrLayout model: aModel bindings: bindings [
 

--- a/src/Spec-Layout/SpecLayout.class.st
+++ b/src/Spec-Layout/SpecLayout.class.st
@@ -3,7 +3,7 @@ A SpecPresenter is a object used to describe a user interface
 "
 Class {
 	#name : #SpecLayout,
-	#superclass : #Object,
+	#superclass : #SpecLegacyLayout,
 	#instVars : [
 		'type',
 		'commands',
@@ -200,10 +200,9 @@ SpecLayout >> asArray [
 ]
 
 { #category : #building }
-SpecLayout >> buildAdapterFor: aPresenter bindings: adapterBindings [
-	"Provides polymorphism with executable layouts."
+SpecLayout >> asSpecLayout [
 
-	^ aPresenter adapterFrom: self
+	^ self
 ]
 
 { #category : #accessing }
@@ -284,12 +283,6 @@ SpecLayout >> isExecutable [
 	 interpreting it)"
 
 	^ false
-]
-
-{ #category : #testing }
-SpecLayout >> isSpecLayout [
-
-	^ true
 ]
 
 { #category : #commands }

--- a/src/Spec-Layout/SpecLegacyArrayLayout.class.st
+++ b/src/Spec-Layout/SpecLegacyArrayLayout.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #SpecLegacyArrayLayout,
+	#superclass : #SpecLegacyLayout,
+	#instVars : [
+		'specArray'
+	],
+	#category : #'Spec-Layout-Layouts'
+}
+
+{ #category : #accessing }
+SpecLegacyArrayLayout >> array: aCollection [ 
+	
+	specArray := aCollection
+]
+
+{ #category : #converting }
+SpecLegacyArrayLayout >> asArray [
+
+	^ specArray
+]
+
+{ #category : #converting }
+SpecLegacyArrayLayout >> selector [
+
+	^ nil
+]

--- a/src/Spec-Layout/SpecLegacyLayout.class.st
+++ b/src/Spec-Layout/SpecLegacyLayout.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #SpecLegacyLayout,
+	#superclass : #Object,
+	#category : #'Spec-Layout-Layouts'
+}
+
+{ #category : #building }
+SpecLegacyLayout >> buildAdapterFor: aPresenter bindings: adapterBindings [
+	"Provides polymorphism with executable layouts."
+
+	^ SpecInterpreter 
+		interpretASpec: self 
+		presenter: aPresenter
+]
+
+{ #category : #testing }
+SpecLegacyLayout >> isSpecLayout [
+
+	^ true
+]

--- a/src/Spec-MorphicAdapters/AbstractMorphicAdapter.class.st
+++ b/src/Spec-MorphicAdapters/AbstractMorphicAdapter.class.st
@@ -207,7 +207,7 @@ AbstractMorphicAdapter >> enable [
 
 { #category : #protocol }
 AbstractMorphicAdapter >> enabled [
-	^ self model isEnabled
+	^ self presenter isEnabled
 ]
 
 { #category : #protocol }

--- a/src/Spec-MorphicAdapters/PluggableButtonMorph.extension.st
+++ b/src/Spec-MorphicAdapters/PluggableButtonMorph.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #PluggableButtonMorph }
 
-{ #category : #'*Spec-Core' }
+{ #category : #'*Spec-MorphicAdapters' }
 PluggableButtonMorph >> getMenu: shiftPressed [ 
 	"Answer the menu for this button, supplying an empty menu to be filled in. If the menu selector takes an extra argument, pass in the current state of the shift key."
 


### PR DESCRIPTION
Fix #416

Several cleanups to layouting and interpreter.
 - extracting legacy (Array based) layout into another object to cleanup presenter implementation
 - composable presenters may have layout instances and talk to them
 - layouts can be updated at runtime