### PR TITLE
431-Improve-transmission-application

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -304,14 +304,6 @@ ComposablePresenter >> applyMenuModel: aMenuModel [
 			item subMenu ifNotNil: [ :subMenu | subMenu applyTo: self	] ] ]
 ]
 
-{ #category : #private }
-ComposablePresenter >> applyTransmissions [
-	"I'll apply all transmissions the user did not applied himself."
-
-	transmissions ifNil: [ ^ self ].
-	transmissions reject: #wasApplied thenDo: #apply
-]
-
 { #category : #converting }
 ComposablePresenter >> asPresenter [
 	"This allows to use presenter instances inside layouts directly"
@@ -581,7 +573,6 @@ ComposablePresenter >> initializePrivateHooks [
 
 	self initializeWidgets.
 	self initializePresenter.
-	self applyTransmissions.
 	self updatePresenter.
 
 ]

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -306,9 +306,10 @@ ComposablePresenter >> applyMenuModel: aMenuModel [
 
 { #category : #private }
 ComposablePresenter >> applyTransmissions [
-	
+	"I'll apply all transmissions the user did not applied himself."
+
 	transmissions ifNil: [ ^ self ].
-	transmissions do: #apply
+	transmissions reject: #wasApplied thenDo: #apply
 ]
 
 { #category : #converting }

--- a/src/Spec-Core/DropListPresenter.class.st
+++ b/src/Spec-Core/DropListPresenter.class.st
@@ -163,6 +163,12 @@ DropListPresenter >> initialize [
 
 ]
 
+{ #category : #initialization }
+DropListPresenter >> initializePorts [
+	self addOutputPort: DropListSelectionPresenterPort new.
+	self addInputPort: ItemsPresenterPort new
+]
+
 { #category : #api }
 DropListPresenter >> items: aList [
 	"Populate the drop list with a list of ui specific items"

--- a/src/Spec-Core/DropListSelectionPresenterPort.class.st
+++ b/src/Spec-Core/DropListSelectionPresenterPort.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #DropListSelectionPresenterPort,
+	#superclass : #OutputPresenterPort,
+	#category : #'Spec-Core-Transmission'
+}
+
+{ #category : #accessing }
+DropListSelectionPresenterPort class >> portName [
+	
+	^ #selection
+]
+
+{ #category : #attaching }
+DropListSelectionPresenterPort >> attachTransmission: aTransmission [
+	self presenter
+		whenSelectionChangedDo: [ :selection |
+			aTransmission toPort
+				incomingTransmission: (aTransmission transformed: selection selectedItem model)
+				from: self.
+			aTransmission applyPostTransmission ]
+]

--- a/src/Spec-Core/DropListSelectionPresenterPort.class.st
+++ b/src/Spec-Core/DropListSelectionPresenterPort.class.st
@@ -13,9 +13,11 @@ DropListSelectionPresenterPort class >> portName [
 { #category : #attaching }
 DropListSelectionPresenterPort >> attachTransmission: aTransmission [
 	self presenter
-		whenSelectionChangedDo: [ :selection |
+		whenSelectionChangedDo: [ :selection | 
+			| transmitted |
+			transmitted := selection selectedItem model.
 			aTransmission toPort
-				incomingTransmission: (aTransmission transformed: selection selectedItem model)
+				incomingTransmission: (aTransmission transformed: transmitted)
 				from: self.
-			aTransmission applyPostTransmission ]
+			aTransmission applyPostTransmissionWith: transmitted ]
 ]

--- a/src/Spec-Core/ListSelectionPresenterPort.class.st
+++ b/src/Spec-Core/ListSelectionPresenterPort.class.st
@@ -16,9 +16,10 @@ ListSelectionPresenterPort class >> portName [
 
 { #category : #attaching }
 ListSelectionPresenterPort >> attachTransmission: aTransmission [
-
-	self presenter whenSelectionChangedDo: [ :selection | 
-		aTransmission toPort
-			incomingTransmission: (aTransmission transformed: selection selectedItem)
-			from: self ]
+	self presenter
+		whenSelectionChangedDo: [ :selection | 
+			aTransmission toPort
+				incomingTransmission: (aTransmission transformed: selection selectedItem)
+				from: self.
+			self postTransmission: aTransmission ]
 ]

--- a/src/Spec-Core/ListSelectionPresenterPort.class.st
+++ b/src/Spec-Core/ListSelectionPresenterPort.class.st
@@ -18,8 +18,10 @@ ListSelectionPresenterPort class >> portName [
 ListSelectionPresenterPort >> attachTransmission: aTransmission [
 	self presenter
 		whenSelectionChangedDo: [ :selection | 
+			| transmitted |
+			transmitted := selection selectedItem.
 			aTransmission toPort
-				incomingTransmission: (aTransmission transformed: selection selectedItem)
+				incomingTransmission: (aTransmission transformed: transmitted)
 				from: self.
-			aTransmission applyPostTransmission ]
+			aTransmission applyPostTransmissionWith: transmitted ]
 ]

--- a/src/Spec-Core/ListSelectionPresenterPort.class.st
+++ b/src/Spec-Core/ListSelectionPresenterPort.class.st
@@ -21,5 +21,5 @@ ListSelectionPresenterPort >> attachTransmission: aTransmission [
 			aTransmission toPort
 				incomingTransmission: (aTransmission transformed: selection selectedItem)
 				from: self.
-			self postTransmission: aTransmission ]
+			aTransmission applyPostTransmission ]
 ]

--- a/src/Spec-Core/OutputPresenterPort.class.st
+++ b/src/Spec-Core/OutputPresenterPort.class.st
@@ -20,10 +20,3 @@ OutputPresenterPort >> isOutput [
 
 	^ true
 ]
-
-{ #category : #attaching }
-OutputPresenterPort >> postTransmission: aTransmission [
-	"Apply the post transmission of a transmission"
-
-	aTransmission postTransmission ifNotNil: [ :valuable | valuable cull: self presenter cull: aTransmission toPresenter ]
-]

--- a/src/Spec-Core/OutputPresenterPort.class.st
+++ b/src/Spec-Core/OutputPresenterPort.class.st
@@ -20,3 +20,10 @@ OutputPresenterPort >> isOutput [
 
 	^ true
 ]
+
+{ #category : #attaching }
+OutputPresenterPort >> postTransmission: aTransmission [
+	"Apply the post transmission of a transmission"
+
+	aTransmission postTransmission ifNotNil: [ :valuable | valuable cull: self presenter cull: aTransmission toPresenter ]
+]

--- a/src/Spec-Core/PresenterTransmission.class.st
+++ b/src/Spec-Core/PresenterTransmission.class.st
@@ -34,7 +34,7 @@ PresenterTransmission >> apply [
 PresenterTransmission >> applyPostTransmission [
 	self postTransmission ifNil: [ ^ self ].
 
-	self postTransmission cull: self fromPresenter cull: self toPresenter
+	self postTransmission cull: self toPresenter cull: self fromPresenter
 ]
 
 { #category : #script }

--- a/src/Spec-Core/PresenterTransmission.class.st
+++ b/src/Spec-Core/PresenterTransmission.class.st
@@ -30,6 +30,13 @@ PresenterTransmission >> apply [
 	fromPort attachTransmission: self
 ]
 
+{ #category : #actions }
+PresenterTransmission >> applyPostTransmission [
+	self postTransmission ifNil: [ ^ self ].
+
+	self postTransmission cull: self fromPresenter cull: self toPresenter
+]
+
 { #category : #script }
 PresenterTransmission >> from: aPresenter [
 	self fromPort: aPresenter outputPortDefault

--- a/src/Spec-Core/PresenterTransmission.class.st
+++ b/src/Spec-Core/PresenterTransmission.class.st
@@ -48,6 +48,26 @@ PresenterTransmission >> from: aPresenter port: aSymbol [
 ]
 
 { #category : #actions }
+PresenterTransmission >> from: aPresenter port: aSymbol to: anotherPresenter transform: aValuable [
+	self
+		from: aPresenter
+		port: aSymbol
+		to: anotherPresenter
+		transform: aValuable
+		postTransmission: nil
+]
+
+{ #category : #actions }
+PresenterTransmission >> from: aPresenter port: aSymbol to: anotherPresenter transform: aValuable postTransmission: anotherValuable [
+	self
+		from: aPresenter port: aSymbol;
+		to: anotherPresenter;
+		transform: aValuable;
+		postTransmission: anotherValuable;
+		apply
+]
+
+{ #category : #actions }
 PresenterTransmission >> from: aPresenter to: anotherPresenter transform: aValuable [
 	self
 		from: aPresenter

--- a/src/Spec-Core/PresenterTransmission.class.st
+++ b/src/Spec-Core/PresenterTransmission.class.st
@@ -31,10 +31,10 @@ PresenterTransmission >> apply [
 ]
 
 { #category : #actions }
-PresenterTransmission >> applyPostTransmission [
+PresenterTransmission >> applyPostTransmissionWith: aTransmittedObject [
 	self postTransmission ifNil: [ ^ self ].
 
-	self postTransmission cull: self toPresenter cull: self fromPresenter
+	self postTransmission cull: self toPresenter cull: self fromPresenter cull: aTransmittedObject
 ]
 
 { #category : #script }

--- a/src/Spec-Core/PresenterTransmission.class.st
+++ b/src/Spec-Core/PresenterTransmission.class.st
@@ -12,7 +12,6 @@ Class {
 		'fromPort',
 		'toPort',
 		'transformBlock',
-		'wasApplied',
 		'postTransmission'
 	],
 	#category : #'Spec-Core-Transmission'
@@ -28,10 +27,7 @@ PresenterTransmission class >> on: aPresenter [
 
 { #category : #actions }
 PresenterTransmission >> apply [
-	"We apply only once the transmission."
-
-	fromPort attachTransmission: self.
-	wasApplied := true
+	fromPort attachTransmission: self
 ]
 
 { #category : #script }
@@ -77,12 +73,6 @@ PresenterTransmission >> fromPort: aPort [
 { #category : #private }
 PresenterTransmission >> fromPresenter [
 	^ self fromPort presenter
-]
-
-{ #category : #initialization }
-PresenterTransmission >> initialize [
-	super initialize.
-	wasApplied := false.
 ]
 
 { #category : #initialization }
@@ -147,9 +137,4 @@ PresenterTransmission >> transformed: anObject [
 
 	transformBlock ifNil: [ ^ anObject ].
 	^ transformBlock value: anObject
-]
-
-{ #category : #accessing }
-PresenterTransmission >> wasApplied [
-	^ wasApplied
 ]

--- a/src/Spec-Core/PresenterTransmission.class.st
+++ b/src/Spec-Core/PresenterTransmission.class.st
@@ -9,11 +9,11 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'presenter',
-		'fromPresenter',
-		'toPresenter',
 		'fromPort',
 		'toPort',
-		'transformBlock'
+		'transformBlock',
+		'wasApplied',
+		'postTransmission'
 	],
 	#category : #'Spec-Core-Transmission'
 }
@@ -27,41 +27,40 @@ PresenterTransmission class >> on: aPresenter [
 ]
 
 { #category : #actions }
-PresenterTransmission >> apply [ 
+PresenterTransmission >> apply [
+	"We apply only once the transmission."
 
-	fromPort attachTransmission: self
-]
-
-{ #category : #private }
-PresenterTransmission >> basicFrom: aPresenter port: aPort [
-
-	fromPresenter := aPresenter.
-	fromPort := aPort
-]
-
-{ #category : #private }
-PresenterTransmission >> basicFromPort: aPort [
-
-	fromPort := aPort
-]
-
-{ #category : #private }
-PresenterTransmission >> basicTo: aPresenter port: aPort [
-
-	toPresenter := aPresenter.
-	toPort := aPort
+	fromPort attachTransmission: self.
+	wasApplied := true
 ]
 
 { #category : #script }
 PresenterTransmission >> from: aPresenter [
-
-	self basicFrom: aPresenter port: aPresenter outputPortDefault
+	self fromPort: aPresenter outputPortDefault
 ]
 
 { #category : #script }
 PresenterTransmission >> from: aPresenter port: aSymbol [
+	self fromPort: (aPresenter outputPortNamed: aSymbol)
+]
 
-	self basicFrom: aPresenter port: (aPresenter outputPortNamed: aSymbol)
+{ #category : #actions }
+PresenterTransmission >> from: aPresenter to: anotherPresenter transform: aValuable [
+	self
+		from: aPresenter
+		to: anotherPresenter
+		transform: aValuable
+		postTransmission: nil
+]
+
+{ #category : #actions }
+PresenterTransmission >> from: aPresenter to: anotherPresenter transform: aValuable postTransmission: anotherValuable [
+	self
+		from: aPresenter;
+		to: anotherPresenter;
+		transform: aValuable;
+		postTransmission: anotherValuable;
+		apply
 ]
 
 { #category : #accessing }
@@ -70,11 +69,37 @@ PresenterTransmission >> fromPort [
 	^ fromPort
 ]
 
+{ #category : #private }
+PresenterTransmission >> fromPort: aPort [
+	fromPort := aPort
+]
+
+{ #category : #private }
+PresenterTransmission >> fromPresenter [
+	^ self fromPort presenter
+]
+
+{ #category : #initialization }
+PresenterTransmission >> initialize [
+	super initialize.
+	wasApplied := false.
+]
+
 { #category : #initialization }
 PresenterTransmission >> initializePresenter: aPresenter [
 
 	self initialize.
 	presenter := aPresenter
+]
+
+{ #category : #accessing }
+PresenterTransmission >> postTransmission [
+	^ postTransmission
+]
+
+{ #category : #accessing }
+PresenterTransmission >> postTransmission: aValuable [
+	postTransmission := aValuable
 ]
 
 { #category : #private }
@@ -86,19 +111,29 @@ PresenterTransmission >> presenter [
 { #category : #script }
 PresenterTransmission >> to: aPresenter [
 
-	self basicTo: aPresenter port: aPresenter inputPortDefault
+	self toPort: aPresenter inputPortDefault
 ]
 
 { #category : #script }
 PresenterTransmission >> to: aPresenter port: aSymbol [
 
-	self basicTo: aPresenter port: (aPresenter inputPortNamed: aSymbol)
+	self toPort: (aPresenter inputPortNamed: aSymbol)
 ]
 
 { #category : #accessing }
 PresenterTransmission >> toPort [
 
 	^ toPort
+]
+
+{ #category : #private }
+PresenterTransmission >> toPort: aPort [
+	toPort := aPort
+]
+
+{ #category : #private }
+PresenterTransmission >> toPresenter [
+	^ self toPort presenter
 ]
 
 { #category : #script }
@@ -112,4 +147,9 @@ PresenterTransmission >> transformed: anObject [
 
 	transformBlock ifNil: [ ^ anObject ].
 	^ transformBlock value: anObject
+]
+
+{ #category : #accessing }
+PresenterTransmission >> wasApplied [
+	^ wasApplied
 ]

--- a/src/Spec-Examples/TransmissionExample.class.st
+++ b/src/Spec-Examples/TransmissionExample.class.st
@@ -52,7 +52,7 @@ TransmissionExample >> initializeWidgets [
 			aClass organization allProtocols 
 				collect: [ :each | aClass -> each ]
 				as: OrderedCollection ]
-		postTransmission: [ :origin :destination | destination selectIndex: 1 ].
+		postTransmission: [ :destination :origin | destination selectIndex: 1 ].
 			
 	self transmit 
 		from: protocols

--- a/src/Spec-Examples/TransmissionExample.class.st
+++ b/src/Spec-Examples/TransmissionExample.class.st
@@ -41,26 +41,30 @@ TransmissionExample >> initializeWidgets [
 	code := self newText beForCode.
 
 	self transmit 
-		from: packages; 
-		to: classes; 
+		from: packages
+		to: classes
 		transform: [ :aPackage | aPackage definedClasses asOrderedCollection ].
+		
 	self transmit 
-		from: classes; 
-		to: protocols; 
+		from: classes
+		to: protocols
 		transform: [ :aClass | 
 			aClass organization allProtocols 
 				collect: [ :each | aClass -> each ]
-				as: OrderedCollection ].
+				as: OrderedCollection ]
+		postTransmission: [ :origin :destination | destination selectIndex: 1 ].
+			
 	self transmit 
-		from: protocols; 
-		to: methods; 
+		from: protocols
+		to: methods
 		transform: [ :aPair | 
 			aPair value methods 
 				collect: [ :each | aPair key >> each ]
 				as: OrderedCollection ].
+			
 	self transmit 
-		from: methods; 
-		to: code; 
+		from: methods
+		to: code
 		transform: #sourceCode.
 	
 	packages items: RPackageOrganizer default packages


### PR DESCRIPTION
Add post transmissions and improve transmissions applications.

- It is now possible to give a post transmission valuable (See issue https://github.com/pharo-spec/Spec/issues/430)
- Now the user can apply transmissions himself, possibly via syntaxic suggar (#from:to:transform: or #from:to:transform:postTransmission:)
- Remove useless variables and rename methods to more conventional names now that they are simpler

Fixes #431
Fixes #430