### PR TITLE
400-Demo-crash-the-image

### DIFF
--- a/src/Spec-Examples/SpecDemo.class.st
+++ b/src/Spec-Examples/SpecDemo.class.st
@@ -81,8 +81,7 @@ SpecDemo >> addItemTo: aGroup [
 
 { #category : #accessing }
 SpecDemo >> availablePages [
-
-	^ SpecDemoPage allSubclasses sort: [ :a :b | a priority <= b priority ]
+	^ SpecDemoPage availablePages
 ]
 
 { #category : #accessing }
@@ -155,7 +154,7 @@ SpecDemo >> list: anObject [
 SpecDemo >> mainMenu [
 
 	| aMenu |
-	aMenu := MenuPresenter new
+	aMenu := MenuBarPresenter new
 		addGroup: [ :group | 
 			group
 				addItem: [ :item | 

--- a/src/Spec-Examples/SpecDemoPage.class.st
+++ b/src/Spec-Examples/SpecDemoPage.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Spec-Examples-Demo'
 }
 
+{ #category : #accessing }
+SpecDemoPage class >> availablePages [
+	^ self allSubclasses sort: #priority ascending
+]
+
 { #category : #specs }
 SpecDemoPage class >> defaultSpec [
 	<spec>

--- a/src/Spec-Examples/SpecDemoStandaloneFormPresenter.class.st
+++ b/src/Spec-Examples/SpecDemoStandaloneFormPresenter.class.st
@@ -150,6 +150,11 @@ SpecDemoStandaloneFormPresenter >> dateLabel: anObject [
 	dateLabel := anObject
 ]
 
+{ #category : #accessing }
+SpecDemoStandaloneFormPresenter >> femaleButton [
+	^ femaleButton
+]
+
 { #category : #'model updates' }
 SpecDemoStandaloneFormPresenter >> fillFormWithWorkingModel [
 	| aModel |
@@ -280,6 +285,11 @@ SpecDemoStandaloneFormPresenter >> itemsLabel [
 { #category : #accessing }
 SpecDemoStandaloneFormPresenter >> itemsLabel: anObject [
 	itemsLabel := anObject
+]
+
+{ #category : #accessing }
+SpecDemoStandaloneFormPresenter >> maleButton [
+	^ maleButton
 ]
 
 { #category : #initialization }

--- a/src/Spec-Tests/SpecDemoTest.class.st
+++ b/src/Spec-Tests/SpecDemoTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #SpecDemoTest,
+	#superclass : #SpecSmokeTestCase,
+	#category : #'Spec-Tests-Examples'
+}
+
+{ #category : #running }
+SpecDemoTest >> classToTest [
+	^ SpecDemo
+]
+
+{ #category : #tests }
+SpecDemoTest >> testSmokeTestForDemoPages [
+	<expectedFailure>
+	SpecDemoPage availablePages
+		do: [ :demoPage | 
+			[ self shouldnt: [ window := demoPage new openWithSpec ] raise: Error description: 'Broken demo page: ' , demoPage asString ]
+				ensure: [ window ifNotNil: #close ] ]
+]


### PR DESCRIPTION
This commit fix the global demo and add a test.

I also add a test as expected failure that all the demo pages do not raise an error but it does not pass yet. I'll see to fix it in another PR.

Fixes #400