### PR TITLE
455-Remove-usage-of-interpreter-to-adapt-AbstractWidgetPresenters

### DIFF
--- a/src/Spec-Core/AbstractWidgetPresenter.class.st
+++ b/src/Spec-Core/AbstractWidgetPresenter.class.st
@@ -50,6 +50,7 @@ AbstractWidgetPresenter class >> adapterName [
 
 { #category : #specs }
 AbstractWidgetPresenter class >> defaultSpec [
+	<spec: #default>
 	^ SpecAbstractWidgetLayout for: self adapterName
 ]
 

--- a/src/Spec-Core/AbstractWidgetPresenter.class.st
+++ b/src/Spec-Core/AbstractWidgetPresenter.class.st
@@ -50,9 +50,7 @@ AbstractWidgetPresenter class >> adapterName [
 
 { #category : #specs }
 AbstractWidgetPresenter class >> defaultSpec [
-	<spec: #default>
-
-	^ { self adapterName. #adapt:. #presenter }
+	^ SpecAbstractWidgetLayout for: self adapterName
 ]
 
 { #category : #'drag and drop' }

--- a/src/Spec-Layout/SpecAbstractWidgetLayout.class.st
+++ b/src/Spec-Layout/SpecAbstractWidgetLayout.class.st
@@ -30,6 +30,14 @@ SpecAbstractWidgetLayout class >> for: aSymbol [
 ]
 
 { #category : #building }
+SpecAbstractWidgetLayout >> adapt: aPresenter bindings: adapterBindings [
+	| adapter |
+	adapter := self adapterFor: aPresenter bindings: adapterBindings.
+	adapter adapt: aPresenter.
+	^ adapter
+]
+
+{ #category : #building }
 SpecAbstractWidgetLayout >> adapterFor: aPresenter bindings: adapterBindings [
 	^ self class environment
 		at: (adapterBindings translateSymbol: self adapterName)
@@ -56,7 +64,12 @@ SpecAbstractWidgetLayout >> asSpecLayout [
 SpecAbstractWidgetLayout >> buildAdapterFor: aPresenter bindings: adapterBindings [
 	"In case we are building an adapter, we need to get the actual adapter class for a specific binding and make it adapt the presenter."
 
-	| adapter |
-	adapter := self adapterFor: aPresenter bindings: adapterBindings.
-	^ adapter adapt: aPresenter
+	^ aPresenter needRebuild
+		ifTrue: [ self adapt: aPresenter bindings: adapterBindings ]
+		ifFalse: [ aPresenter needRebuild: true.
+			aPresenter adapter
+				ifNil: [ self adapt: aPresenter bindings: adapterBindings ]
+				ifNotNil: [ :adapter | 
+					adapter isRedrawable ifTrue: [ adapter removeSubWidgets ].
+					adapter ] ]
 ]

--- a/src/Spec-Layout/SpecAbstractWidgetLayout.class.st
+++ b/src/Spec-Layout/SpecAbstractWidgetLayout.class.st
@@ -1,0 +1,62 @@
+"
+I am a layout used for AbstractWidgetPresenters. I will manage all presenter that need to be adapted via a spec adapter for a specific binding.
+
+Examples
+--------------------
+
+	SpecAbstractWidgetLayout for: #ListAdapter
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	adapterName:		<aSymbol>		Key to use in order to find the real adapter of a presenter for a specific binding.
+
+"
+Class {
+	#name : #SpecAbstractWidgetLayout,
+	#superclass : #Object,
+	#instVars : [
+		'adapterName'
+	],
+	#category : #'Spec-Layout-Base'
+}
+
+{ #category : #'instance creation' }
+SpecAbstractWidgetLayout class >> for: aSymbol [
+	^ self new
+		adapterName: aSymbol;
+		yourself
+]
+
+{ #category : #building }
+SpecAbstractWidgetLayout >> adapterFor: aPresenter bindings: adapterBindings [
+	^ self class environment
+		at: (adapterBindings translateSymbol: self adapterName)
+		ifPresent: [ :class | class owner: aPresenter ]
+		ifAbsent: [ self error: 'No binding for ' , self adapterName , ' found.' ]
+]
+
+{ #category : #accessing }
+SpecAbstractWidgetLayout >> adapterName [
+	^ adapterName
+]
+
+{ #category : #accessing }
+SpecAbstractWidgetLayout >> adapterName: anObject [
+	adapterName := anObject
+]
+
+{ #category : #accessing }
+SpecAbstractWidgetLayout >> asSpecLayout [
+	^ self
+]
+
+{ #category : #building }
+SpecAbstractWidgetLayout >> buildAdapterFor: aPresenter bindings: adapterBindings [
+	"In case we are building an adapter, we need to get the actual adapter class for a specific binding and make it adapt the presenter."
+
+	| adapter |
+	adapter := self adapterFor: aPresenter bindings: adapterBindings.
+	^ adapter adapt: aPresenter
+]

--- a/src/Spec-Tests/SpecAbstractWidgetLayoutTest.class.st
+++ b/src/Spec-Tests/SpecAbstractWidgetLayoutTest.class.st
@@ -1,0 +1,29 @@
+"
+A SpecAbstractWidgetLayoutTest is a test class for testing the behavior of SpecAbstractWidgetLayout
+"
+Class {
+	#name : #SpecAbstractWidgetLayoutTest,
+	#superclass : #TestCase,
+	#category : #'Spec-Tests-Layout'
+}
+
+{ #category : #test }
+SpecAbstractWidgetLayoutTest >> testAdapterForBindings [
+	| layout |
+	layout := SpecAbstractWidgetLayout for: #ListAdapter.
+	self assert: (layout adapterFor: ListPresenter new bindings: SpecStubAdapterBindings new) class equals: SpecStubListAdapter
+]
+
+{ #category : #test }
+SpecAbstractWidgetLayoutTest >> testAdapterForBindingsRaiseErrorIfNoBinding [
+	| layout |
+	layout := SpecAbstractWidgetLayout for: #NonExistingAdapter.
+	self should: [ layout adapterFor: ListPresenter new bindings: SpecStubAdapterBindings new ] raise: Error
+]
+
+{ #category : #test }
+SpecAbstractWidgetLayoutTest >> testBuildAdapterForBindings [
+	| layout |
+	layout := SpecAbstractWidgetLayout for: #ListAdapter.
+	self assert: (layout buildAdapterFor: ListPresenter new bindings: SpecStubAdapterBindings new) widget class equals: SpecStubListView
+]

--- a/src/Spec-Tests/SpecAbstractWidgetLayoutTest.class.st
+++ b/src/Spec-Tests/SpecAbstractWidgetLayoutTest.class.st
@@ -27,3 +27,22 @@ SpecAbstractWidgetLayoutTest >> testBuildAdapterForBindings [
 	layout := SpecAbstractWidgetLayout for: #ListAdapter.
 	self assert: (layout buildAdapterFor: ListPresenter new bindings: SpecStubAdapterBindings new) widget class equals: SpecStubListView
 ]
+
+{ #category : #test }
+SpecAbstractWidgetLayoutTest >> testDynamicBuild [
+	"Cyril: This is currently a duplicated of a test in SpecInterpreter, but this test is useful for more that the SpecInterpreter and since we plan to remove the interpreter I want to ensure we do not lose this test. This comment can be removed once the SpecInterpreter will be removed."
+
+	| model widget1 widget2 widget3 |
+	model := TestingComposablePresenter new.
+	model openWithSpec close.
+	widget1 := model list adapter.
+	model openWithSpec close.
+	widget2 := model list adapter.
+	self deny: widget1 == widget2.
+	model list needRebuild: false.
+	model needRebuild: false.
+	model openWithSpec close.
+	widget3 := model list adapter.
+	self assert: widget2 == widget3.
+	self assert: model needRebuild
+]


### PR DESCRIPTION
Do not use the Interpreter to adapt widget presenters.

Fixes #455