### PR TITLE
461-Dynamic-rebuild-fail-with-executable-layout-if-its-required-before-the-first-opening

### DIFF
--- a/src/Spec-BackendTests/AbstractLayoutTestCase.class.st
+++ b/src/Spec-BackendTests/AbstractLayoutTestCase.class.st
@@ -1,0 +1,104 @@
+Class {
+	#name : #AbstractLayoutTestCase,
+	#superclass : #ParametrizedTestCase,
+	#instVars : [
+		'presenter',
+		'window',
+		'backendForTest'
+	],
+	#category : #'Spec-BackendTests'
+}
+
+{ #category : #testing }
+AbstractLayoutTestCase class >> isAbstract [ 
+	^ self = AbstractLayoutTestCase
+]
+
+{ #category : #testing }
+AbstractLayoutTestCase class >> testParameters [
+	^ ParametrizedTestMatrix new
+		forSelector: #backendForTest addOptions: AbstractBackendForTest allSubclasses;
+		yourself
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> adapter [
+
+	"Force opening the spec instance here.
+	The action should have been correctly configured before
+	depending on the spec initialization strategy"
+	backendForTest openInstanceOf: self.
+	^ presenter adapter
+]
+
+{ #category : #accessing }
+AbstractLayoutTestCase >> backendForTest: aClass [ 
+	
+	backendForTest := aClass new
+]
+
+{ #category : #accessing }
+AbstractLayoutTestCase >> classToTest [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> openInstance [
+
+	backendForTest openInstanceOf: self 
+
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> prepareToRunAgain [
+
+	backendForTest runTest: [ super prepareToRunAgain ]
+
+]
+
+{ #category : #accessing }
+AbstractLayoutTestCase >> presenter [
+	^ presenter
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> runCase [
+
+	self resources do: [:each | each availableFor: self].
+	[	super setUp.
+		backendForTest runTest: [
+			presenter := self classToTest new.
+			self performTest].
+	] ensure: [
+		self tearDown.
+		self cleanUpInstanceVariables]
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> setUp [
+	self error: 'Do not override me.... use #initializeTestedInstance'
+
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> tearDown [
+	window ifNotNil: [ window delete ].
+	super tearDown
+]
+
+{ #category : #running }
+AbstractLayoutTestCase >> widget [
+
+	^ self adapter widget
+]
+
+{ #category : #accessing }
+AbstractLayoutTestCase >> window [
+	^ window
+]
+
+{ #category : #accessing }
+AbstractLayoutTestCase >> window: aWindowPresenter [ 
+	window := aWindowPresenter
+]

--- a/src/Spec-BackendTests/MockDynamicPresenter.class.st
+++ b/src/Spec-BackendTests/MockDynamicPresenter.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : #MockDynamicPresenter,
+	#superclass : #ComposablePresenter,
+	#instVars : [
+		'list',
+		'label'
+	],
+	#category : #'Spec-BackendTests-Layout'
+}
+
+{ #category : #specs }
+MockDynamicPresenter class >> defaultSpec [
+	^ SpecBoxLayout newVertical
+		add: #list;
+		add: #label;
+		yourself
+]
+
+{ #category : #'instance creation' }
+MockDynamicPresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #'instance creation' }
+MockDynamicPresenter class >> openWithRebuildBeforeOpening [
+	<script>
+	^ self new
+		selectFirstElement;
+		openWithSpec
+]
+
+{ #category : #initialization }
+MockDynamicPresenter >> initializePresenter [
+	list
+		whenSelectionChangedDo: [ :sel | 
+			label := self newLabel.
+			label label: sel selectedItem asString.
+			self needRebuild: false.
+			self buildWithSpec ]
+]
+
+{ #category : #initialization }
+MockDynamicPresenter >> initializeWidgets [
+	list := self newList.
+	label := self newLabel.
+	
+	list items: #(1 2 3)
+]
+
+{ #category : #accessing }
+MockDynamicPresenter >> label [
+	^ label
+]
+
+{ #category : #action }
+MockDynamicPresenter >> selectFirstElement [
+	list selectedIndex: 1
+]

--- a/src/Spec-BackendTests/SpecExecutableLayoutTest.class.st
+++ b/src/Spec-BackendTests/SpecExecutableLayoutTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #SpecExecutableLayoutTest,
+	#superclass : #AbstractLayoutTestCase,
+	#category : #'Spec-BackendTests-Layout'
+}
+
+{ #category : #accessing }
+SpecExecutableLayoutTest >> classToTest [
+	^ MockDynamicPresenter
+]
+
+{ #category : #tests }
+SpecExecutableLayoutTest >> testCanDynamicallyRebuildPresenter [
+	self openInstance.
+	self assert: presenter label label equals: ''.
+	self shouldnt: [ presenter selectFirstElement ] raise: Error.
+	self assert: presenter label label equals: '1'
+]
+
+{ #category : #tests }
+SpecExecutableLayoutTest >> testRebuildPresenterBeforeOpeningWorks [
+	self assert: presenter label label equals: ''.
+	self
+		shouldnt: [ presenter selectFirstElement.
+			self openInstance ]
+		raise: Error.
+	self assert: presenter label label equals: '1'
+]

--- a/src/Spec-Layout/SpecExecutableLayout.class.st
+++ b/src/Spec-Layout/SpecExecutableLayout.class.st
@@ -37,12 +37,14 @@ SpecExecutableLayout >> asSpecLayout [
 
 { #category : #building }
 SpecExecutableLayout >> buildAdapterFor: aPresenter bindings: bindings [
-	adapter := aPresenter needRebuild
+	adapter := (aPresenter needRebuild or: [ aPresenter adapter isNil ])
 		ifTrue: [ (bindings adapterClass: self adapterName) adapt: aPresenter ]
-		ifFalse: [ aPresenter needRebuild: true.
-			aPresenter adapter
+		ifFalse: [ aPresenter adapter
 				removeSubWidgets;
 				yourself ].
+			
+	"Ensure we remove the flag `no need of rebuild` if it was set."
+	aPresenter needRebuild: true.
 
 	adapter layout: self.
 

--- a/src/Spec-Tools/ChangeSorterPresenter.class.st
+++ b/src/Spec-Tools/ChangeSorterPresenter.class.st
@@ -668,8 +668,7 @@ ChangeSorterPresenter >> selectorsMenu: aBlock [
 { #category : #'menu - change set' }
 ChangeSorterPresenter >> setCurrentChangeSet [
 	self selectedChangeSet ifNil: [ ^ self inform: 'No change set selected' ].
-	self model setCurrentChangeSet: self selectedChangeSet.
-	self window title: self title
+	self model setCurrentChangeSet: self selectedChangeSet
 ]
 
 { #category : #initialization }
@@ -735,7 +734,7 @@ ChangeSorterPresenter >> updateClassesList [
 		ifNotNil: [ :change | 
 			classesListPresenter
 				items: (change changedClasses sort: [ :a :b | a name < b name ]) ].
-	classesListPresenter selectItem: sel
+	sel ifNotNil: [ classesListPresenter selectItem: sel ]
 ]
 
 { #category : #api }

--- a/src/Spec-Tools/DualChangeSorterPresenter.class.st
+++ b/src/Spec-Tools/DualChangeSorterPresenter.class.st
@@ -331,3 +331,8 @@ DualChangeSorterPresenter >> subtractFrom: src to: dest [
 DualChangeSorterPresenter >> title [
 	^ String streamContents: [ :stream | stream << self class title << ' on: ' << self model currentChangeSet name ]
 ]
+
+{ #category : #api }
+DualChangeSorterPresenter >> updateTitle [
+	self window title: self title
+]


### PR DESCRIPTION
Fix dynamic rebuild in case it was never built + add tests.

Bonus: Fix a bug on the title of the dual code changes.

Fixes #461