### PR TITLE
466-Cannot-addremove-page-to-Notebook

### DIFF
--- a/src/Spec-BackendTests/NotebookAdapterTest.class.st
+++ b/src/Spec-BackendTests/NotebookAdapterTest.class.st
@@ -8,3 +8,47 @@ Class {
 NotebookAdapterTest >> classToTest [
 	^ NotebookPresenter
 ]
+
+{ #category : #running }
+NotebookAdapterTest >> initializeTestedInstance [
+	presenter
+		addPage: (NotebookPage title: 'Mock' icon: (self iconNamed: #changeUpdate) provider: [ ButtonPresenter new ]);
+		addPage: (NotebookPage title: 'Mock2' icon: (self iconNamed: #changeUpdate) provider: [ LabelPresenter new ])
+]
+
+{ #category : #tests }
+NotebookAdapterTest >> testAddPage [
+	self assert: self adapter numberOfTabs equals: 2.
+	presenter addPage: (NotebookPage title: 'Mock3' provider: [ LabelPresenter new ]).
+	self assert: self adapter numberOfTabs equals: 3
+]
+
+{ #category : #tests }
+NotebookAdapterTest >> testClickOnPage [
+	self adapter clickTab: 2.
+	self assert: self adapter selectedPageName equals: 'Mock2'
+]
+
+{ #category : #tests }
+NotebookAdapterTest >> testRemovePage [
+	| page |
+	presenter addPage: (page := NotebookPage title: 'Mock3' provider: [ LabelPresenter new ]).
+	self assert: self adapter numberOfTabs equals: 3.
+	presenter removePage: page.
+	self assert: self adapter numberOfTabs equals: 2
+]
+
+{ #category : #tests }
+NotebookAdapterTest >> testRemovePageAt [
+	presenter addPage: (NotebookPage title: 'Mock3' provider: [ LabelPresenter new ]).
+	self assert: self adapter numberOfTabs equals: 3.
+	presenter removePageAt: 2.
+	self assert: self adapter numberOfTabs equals: 2.
+	self assert: self adapter selectedPageName equals: 'Mock'
+]
+
+{ #category : #tests }
+NotebookAdapterTest >> testSelectedPage [
+	presenter selectPageIndex: 2.
+	self assert: self adapter selectedPageName equals: 'Mock2'
+]

--- a/src/Spec-BackendTests/NotebookAdapterTest.class.st
+++ b/src/Spec-BackendTests/NotebookAdapterTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #NotebookAdapterTest,
+	#superclass : #AbstractWidgetAdapterTestCase,
+	#category : #'Spec-BackendTests'
+}
+
+{ #category : #accessing }
+NotebookAdapterTest >> classToTest [
+	^ NotebookPresenter
+]

--- a/src/Spec-Core/NotebookPage.class.st
+++ b/src/Spec-Core/NotebookPage.class.st
@@ -11,7 +11,8 @@ Class {
 		'owner',
 		'presenterProvider',
 		'titleHolder',
-		'iconHolder'
+		'iconHolder',
+		'layoutSpecHolder'
 	],
 	#category : #'Spec-Core-Widgets-Tab'
 }
@@ -23,6 +24,17 @@ NotebookPage class >> title: aString icon: anIcon provider: aBlock [
 		title: aString;
 		icon: anIcon;
 		presenterProvider: aBlock;
+		yourself
+]
+
+{ #category : #'instance creation' }
+NotebookPage class >> title: aString icon: anIcon provider: aBlock layoutSpec: aSymbol [
+
+	^ self new 
+		title: aString;
+		icon: anIcon;
+		presenterProvider: aBlock;
+		layoutSpec: aSymbol;
 		yourself
 ]
 
@@ -53,9 +65,20 @@ NotebookPage >> initialize [
 	super initialize.
 	titleHolder := nil asValueHolder.
 	iconHolder := nil asValueHolder.
+	layoutSpecHolder := nil asValueHolder.
 	
 	titleHolder whenChangedDo: [ self pageTitleChanged ].
 	iconHolder whenChangedDo: [ self pageTitleChanged ]
+]
+
+{ #category : #accessing }
+NotebookPage >> layoutSpec [
+	^ layoutSpecHolder value
+]
+
+{ #category : #accessing }
+NotebookPage >> layoutSpec: aSymbol [
+	layoutSpecHolder value: aSymbol
 ]
 
 { #category : #accessing }

--- a/src/Spec-Core/NotebookPresenter.class.st
+++ b/src/Spec-Core/NotebookPresenter.class.st
@@ -72,10 +72,34 @@ NotebookPresenter >> pagesChanged [
 	self changed: #updatePages
 ]
 
+{ #category : #removing }
+NotebookPresenter >> removePage: aNotebookPresenter [
+	pagesHolder remove: aNotebookPresenter
+]
+
+{ #category : #removing }
+NotebookPresenter >> removePageAt: anIndex [
+	pagesHolder removeAt: anIndex
+]
+
 { #category : #accessing }
 NotebookPresenter >> resetAllPageContents [
 
 	self pages do: #resetContent
+]
+
+{ #category : #accessing }
+NotebookPresenter >> selectPage: aPage [
+	"Alias to make code more readable"
+
+	self selectedPage: aPage
+]
+
+{ #category : #accessing }
+NotebookPresenter >> selectPageIndex: aNumber [
+	"Alias to make code more readable"
+
+	^ self selectedPageIndex: aNumber
 ]
 
 { #category : #accessing }
@@ -112,6 +136,11 @@ NotebookPresenter >> selectedPageIndex: aNumber [
 NotebookPresenter >> updatePageContent: aPage [
 
 	self changed: #updatePageContent: with: { aPage }
+]
+
+{ #category : #enumerating }
+NotebookPresenter >> whenPagesChangedDo: aBlock [
+	pagesHolder whenChangedDo: aBlock
 ]
 
 { #category : #'api-events' }

--- a/src/Spec-Core/NotebookPresenter.class.st
+++ b/src/Spec-Core/NotebookPresenter.class.st
@@ -24,12 +24,6 @@ NotebookPresenter >> addPage: aPage [
 	pagesHolder add: aPage
 ]
 
-{ #category : #private }
-NotebookPresenter >> basicSelectedPage: aPage [
-
-	selectedPageHolder value: aPage
-]
-
 { #category : #initialization }
 NotebookPresenter >> initialize [
 
@@ -110,10 +104,8 @@ NotebookPresenter >> selectedPage [
 
 { #category : #accessing }
 NotebookPresenter >> selectedPage: aPage [
-
-	aPage = self selectedPage ifTrue: [ ^self ].
-	self basicSelectedPage: aPage.
-	self changed: #selectedPage
+	aPage = self selectedPage ifTrue: [ ^ self ].
+	selectedPageHolder value: aPage
 ]
 
 { #category : #accessing }

--- a/src/Spec-Examples/SpecDemoNotebookPage.class.st
+++ b/src/Spec-Examples/SpecDemoNotebookPage.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #SpecDemoNotebookPage,
+	#superclass : #SpecDemoPage,
+	#category : #'Spec-Examples-Demo-Other'
+}
+
+{ #category : #specs }
+SpecDemoNotebookPage class >> pageName [
+	^ 'Notebook'
+]
+
+{ #category : #specs }
+SpecDemoNotebookPage class >> priority [
+	^ 13
+]
+
+{ #category : #initialization }
+SpecDemoNotebookPage >> pageClass [
+	^ SpecDemoNotebookPresenter
+]

--- a/src/Spec-Examples/SpecDemoNotebookPresenter.class.st
+++ b/src/Spec-Examples/SpecDemoNotebookPresenter.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #SpecDemoNotebookPresenter,
+	#superclass : #ComposablePresenter,
+	#instVars : [
+		'notebook',
+		'checkbox',
+		'dynamicPage'
+	],
+	#category : #'Spec-Examples-Demo-Other'
+}
+
+{ #category : #specs }
+SpecDemoNotebookPresenter class >> defaultSpec [
+	^ SpecBoxLayout newVertical
+		add: #notebook;
+		add:
+			(SpecBoxLayout newHorizontal
+				add: #checkbox withConstraints: [ :constraints | constraints width: 20 ];
+				add: 'Show dynamic presenter')
+			withConstraints: [ :constraints | constraints height: self labelHeight ];
+		yourself
+]
+
+{ #category : #pages }
+SpecDemoNotebookPresenter >> browserPage [
+	^ NotebookPage
+		title: 'Browser'
+		icon: (self iconNamed: #nautilusIcon)
+		provider: [ ClassMethodBrowser new
+				classes: self class environment allClasses;
+				yourself ]
+]
+
+{ #category : #pages }
+SpecDemoNotebookPresenter >> dynamicPage [
+	^ NotebookPage title: 'Dynamic' icon: (self iconNamed: #nautilusIcon) provider: [ DynamicWidgetChange new ]
+]
+
+{ #category : #initialization }
+SpecDemoNotebookPresenter >> initializePresenter [
+	super initializePresenter.
+
+	checkbox whenActivatedDo: [ notebook addPage: (dynamicPage := self dynamicPage) ].
+
+	checkbox
+		whenDeactivatedDo: [ dynamicPage
+				ifNotNil: [ :page | 
+					notebook removePage: page.
+					dynamicPage := nil ] ]
+]
+
+{ #category : #initialization }
+SpecDemoNotebookPresenter >> initializeWidgets [
+	notebook := self newNotebook.
+	checkbox := self newCheckBox.
+
+	notebook
+		addPage: self objectClassPage;
+		addPage: self objectInspectorPage;
+		addPage: self browserPage
+]
+
+{ #category : #pages }
+SpecDemoNotebookPresenter >> objectClassPage [
+	^ NotebookPage title: 'Object class' icon: (self iconNamed: #nautilusIcon) provider: [ MessageBrowser new messages: Object methods ]
+]
+
+{ #category : #pages }
+SpecDemoNotebookPresenter >> objectInspectorPage [
+	^ NotebookPage
+		title: 'Object inspector'
+		icon: (self iconNamed: #nautilusIcon)
+		provider: [ EyeInspector new
+				inspect: Object;
+				yourself ]
+		layoutSpec: #inspectorSpec
+]

--- a/src/Spec-MorphicAdapters/MorphicNotebookAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicNotebookAdapter.class.st
@@ -15,29 +15,33 @@ MorphicNotebookAdapter class >> cellInset [
 
 { #category : #factory }
 MorphicNotebookAdapter >> addModelTo: aNotebook [
-	
 	self model pages ifEmpty: [ ^ self ].
-	self model pages do: [ :each |
-		aNotebook 
-			addLazyPage: [ self buildContentForPage: each ] 
-			label: (self buildLabelForPage: each).
-		"Since I do not have the page added, I need to take it from the list. 
+	self model pages
+		do: [ :each | 
+			"Since I do not have the page added, I need to take it from the list. 
 		 But I know this will be the last added :)"
-		aNotebook pages last model: each ].
+			self addPage: each to: aNotebook ].
 	"force first page to be drawn"
-	self model selectedPage ifNil: [ 
-		self model selectedPageIndex: 1 ].
-	aNotebook selectedPageIndex: self model selectedPageIndex. 
-	aNotebook announcer 
-		when: NotebookPageChanged 
-		send: #pageChanged:
-		to: self
+	self model selectedPage ifNil: [ self model selectedPageIndex: 1 ].
+	aNotebook selectedPageIndex: self model selectedPageIndex.
+	aNotebook announcer when: NotebookPageChanged send: #pageChanged: to: self
+]
+
+{ #category : #factory }
+MorphicNotebookAdapter >> addPage: each to: aNotebook [
+
+	aNotebook addLazyPage: [ self buildContentForPage: each ] label: (self buildLabelForPage: each).
+	"Since I do not have the page added, I need to take it from the list. But I know this will be the last added :)"
+	aNotebook pages last model: each
 ]
 
 { #category : #factory }
 MorphicNotebookAdapter >> buildContentForPage: aPage [
-		
-	^ aPage retrievePresenter ifNotNil: #buildWithSpec
+	^ aPage retrievePresenter
+		ifNotNil: [ :presenter |
+			aPage layoutSpec
+				ifNil: [ presenter buildWithSpec ]
+				ifNotNil: [ :spec | presenter buildWithSpec: spec ] ]
 ]
 
 { #category : #factory }
@@ -65,12 +69,13 @@ MorphicNotebookAdapter >> buildLabelForPage: aPage [
 { #category : #factory }
 MorphicNotebookAdapter >> buildWidget [
 	| notebookMorph |
-
 	notebookMorph := NotebookMorph new
 		vResizing: #spaceFill;
 		hResizing: #spaceFill;
 		yourself.
 	self addModelTo: notebookMorph.
+
+	self model whenPagesChangedDo: [ :pages | self updatePagesWith: pages ].
 
 	^ notebookMorph
 ]
@@ -105,4 +110,14 @@ MorphicNotebookAdapter >> updatePageTitle: aPage [
 		w 
 			relabelPage: (w pageWithModel: aPage) 
 			with: (self buildLabelForPage: aPage) ]
+]
+
+{ #category : #'as yet unclassified' }
+MorphicNotebookAdapter >> updatePagesWith: aCollection [
+	self
+		widgetDo: [ :aNotebook | 
+			| pagesToRemove |
+			pagesToRemove := aNotebook pages reject: [ :pageMorph | aCollection anySatisfy: [ :page | page = pageMorph model ] ].
+			pagesToRemove do: [ :pageMorph | aNotebook removePage: pageMorph ].
+			aCollection reject: [ :page | aNotebook hasPageWithModel: page ] thenDo: [ :page | self addPage: page to: aNotebook ] ]
 ]

--- a/src/Spec-MorphicAdapters/MorphicNotebookAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicNotebookAdapter.class.st
@@ -77,21 +77,19 @@ MorphicNotebookAdapter >> buildWidget [
 	self addModelTo: notebookMorph.
 
 	self model whenPagesChangedDo: [ :pages | self updatePagesWith: pages ].
+	self model whenSelectedPageChangedDo: [ :page | self selectPage: page ].
 
 	^ notebookMorph
 ]
 
 { #category : #private }
 MorphicNotebookAdapter >> pageChanged: ann [
-
-	self model basicSelectedPage: ann page model
+	self model selectedPage: ann page model
 ]
 
 { #category : #updating }
-MorphicNotebookAdapter >> selectedPage [
-	
-	self widgetDo: [ :w |
-		w page: (w pageWithModel: self model selectedPage) ]
+MorphicNotebookAdapter >> selectPage: aPage [
+	self widgetDo: [ :w | w page: (w pageWithModel: aPage) ]
 ]
 
 { #category : #updating }
@@ -113,7 +111,7 @@ MorphicNotebookAdapter >> updatePageTitle: aPage [
 			with: (self buildLabelForPage: aPage) ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #updating }
 MorphicNotebookAdapter >> updatePagesWith: aCollection [
 	self
 		widgetDo: [ :aNotebook | 

--- a/src/Spec-MorphicAdapters/MorphicNotebookAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicNotebookAdapter.class.st
@@ -72,6 +72,7 @@ MorphicNotebookAdapter >> buildWidget [
 	notebookMorph := NotebookMorph new
 		vResizing: #spaceFill;
 		hResizing: #spaceFill;
+		setBalloonText: self help;
 		yourself.
 	self addModelTo: notebookMorph.
 

--- a/src/Spec-MorphicAdapters/NotebookMorph.class.st
+++ b/src/Spec-MorphicAdapters/NotebookMorph.class.st
@@ -81,6 +81,13 @@ NotebookMorph >> buildLabelFrom: aStringOrMorph withAction: aMorph [
 			innerLabel ]
 ]
 
+{ #category : #testing }
+NotebookMorph >> hasPageWithModel: anObject [
+	"an utility to easy know if the notebook has a page for a model"
+
+	^ self pages anySatisfy: [ :each | each model = anObject ]
+]
+
 { #category : #accessing }
 NotebookMorph >> headerMorph [
 	^ headerMorph
@@ -175,22 +182,33 @@ NotebookMorph >> pageWithModel: anObject [
 
 { #category : #private }
 NotebookMorph >> removePage: aPage [
-	| removedPageIndex |
+	| removedPageIndex subscriptions |
 	removedPageIndex := self pages indexOf: aPage.
-	self announcer suspendAllWhile: [ super removePage: aPage ].
-	self announcer announce: 
-		(LazyTabPageRemoved new 
-			tabs: self; 
-			page: aPage; 
-			pageIndex: removedPageIndex;
-			newIndex: self tabSelectorMorph selectedIndex).
-	self pages isEmpty 
-		ifTrue: [ self contentMorph removeAllMorphs ]
+
+	self suspendAnnouncementsDuring: [ super removePage: aPage ].
+
+	self announcer
+		announce:
+			(LazyTabPageRemoved new
+				tabs: self;
+				page: aPage;
+				pageIndex: removedPageIndex;
+				newIndex: self tabSelectorMorph selectedIndex).
+	self pages isEmpty ifTrue: [ self contentMorph removeAllMorphs ]
 ]
 
 { #category : #private }
 NotebookMorph >> removePageIndex: anInteger [
 	self removePage: (self pages at: anInteger)
+]
+
+{ #category : #private }
+NotebookMorph >> suspendAnnouncementsDuring: aBlock [
+	| subscriptions |
+	subscriptions := self announcer subscriptions subscriptions.
+	subscriptions do: [ :sub | self announcer unsubscribe: sub ].
+	aBlock value.
+	subscriptions do: [ :sub | self announcer basicSubscribe: sub ]
 ]
 
 { #category : #private }

--- a/src/Spec-MorphicAdapters/NotebookTabSelectorMorph.class.st
+++ b/src/Spec-MorphicAdapters/NotebookTabSelectorMorph.class.st
@@ -3,3 +3,17 @@ Class {
 	#superclass : #TabSelectorMorph,
 	#category : #'Spec-MorphicAdapters-Notebook'
 }
+
+{ #category : #operations }
+NotebookTabSelectorMorph >> removeTabIndex: anInteger [
+	"Remove the tab at the given index and
+	adjust any selected (next or first if was last)."
+
+	self tabs removeAt: anInteger.
+
+	self tabs
+		ifNotEmpty: [ self selectedIndex: (self selectedIndex - 1) \\ self tabs size + 1 ]
+		ifEmpty: [ self selectedIndex: 0 ].
+
+	self updateTabs
+]

--- a/src/Spec-MorphicBackendTests/MorphicNotebookAdapter.extension.st
+++ b/src/Spec-MorphicBackendTests/MorphicNotebookAdapter.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : #MorphicNotebookAdapter }
+
+{ #category : #'*Spec-MorphicBackendTests' }
+MorphicNotebookAdapter >> clickTab: anIndex [
+	| evt tab |
+	evt := MouseButtonEvent new
+		setType: nil
+		position: widget center
+		which: MouseButtonEvent redButton
+		buttons: MouseButtonEvent redButton
+		hand: nil
+		stamp: nil.
+	tab := self widget tabSelectorMorph tabs at: anIndex.
+
+	(tab handlesMouseDown: evt)
+		ifTrue: [ tab mouseDown: evt.
+			tab mouseUp: evt ]
+]
+
+{ #category : #'*Spec-MorphicBackendTests' }
+MorphicNotebookAdapter >> numberOfTabs [
+	^ self widget tabSelectorMorph tabs size
+]
+
+{ #category : #'*Spec-MorphicBackendTests' }
+MorphicNotebookAdapter >> selectedPageName [
+	^ (self widget tabSelectorMorph selectedTab label submorphs detect: [ :each | each isKindOf: StringMorph ]) contents
+]

--- a/src/Spec-Tests/NotebookPresenterTest.class.st
+++ b/src/Spec-Tests/NotebookPresenterTest.class.st
@@ -1,0 +1,106 @@
+Class {
+	#name : #NotebookPresenterTest,
+	#superclass : #SpecTestCase,
+	#category : #'Spec-Tests-Core-Widgets'
+}
+
+{ #category : #running }
+NotebookPresenterTest >> classToTest [
+	^ NotebookPresenter
+]
+
+{ #category : #'as yet unclassified' }
+NotebookPresenterTest >> mockPage [
+	^ NotebookPage
+		title: 'Mock'
+		icon: (self iconNamed: #changeUpdate)
+		provider: [ ButtonPresenter new ]
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testAddPage [
+	self assertEmpty: presenter pages.
+	presenter addPage: self mockPage.
+	self assert: presenter pages size equals: 1
+	
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testPageAt [
+	| page |
+	presenter addPage: self mockPage.
+	page := NotebookPage title: 'test' provider: [ ButtonPresenter new ].
+	presenter addPage: page.
+	self assert: (presenter pageAt: 2) equals: page
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testRemovePage [
+	| page |
+	presenter addPage: self mockPage.
+	page := NotebookPage title: 'test' provider: [ ButtonPresenter new ].
+	presenter addPage: page.
+	self assert: presenter pages size equals: 2.
+	presenter removePage: page.
+	self assert: presenter pages size equals: 1
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testRemovePageAt [
+	| page |
+	presenter addPage: self mockPage.
+	page := NotebookPage title: 'test' provider: [ ButtonPresenter new ].
+	presenter addPage: page.
+	self assert: presenter pages size equals: 2.
+	presenter removePageAt: 1.
+	self assertCollection: presenter pages hasSameElements: {page}
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testSelectPage [
+	| mock mock2 |
+	mock := self mockPage.
+	mock2 := NotebookPage title: 'test' provider: [ ButtonPresenter new ].
+	presenter addPage: mock.
+	presenter addPage: mock2.
+	presenter selectPage: mock2.
+	self assert: presenter selectedPage equals: mock2
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testSelectPageIndex [
+	| mock mock2 |
+	mock := self mockPage.
+	mock2 := NotebookPage title: 'test' provider: [ ButtonPresenter new ].
+	presenter addPage: mock.
+	presenter addPage: mock2.
+	presenter selectPageIndex: 2.
+	self assert: presenter selectedPage equals: mock2
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testWhenPagesChangedDo [
+	| counter |
+	counter := 0.
+	self assertEmpty: presenter pages.
+	presenter whenPagesChangedDo: [ counter := counter + 1 ].
+	presenter addPage: self mockPage.
+	self assert: counter equals: 1
+]
+
+{ #category : #tests }
+NotebookPresenterTest >> testWhenSelectedPageChangedDo [
+	| mock mock2 counter selected |
+	counter := 0.
+	mock := self mockPage.
+	mock2 := NotebookPage title: 'test' provider: [ ButtonPresenter new ].
+	presenter
+		whenSelectedPageChangedDo: [ :page | 
+			selected := page.
+			counter := counter + 1 ].
+	presenter addPage: mock.
+	presenter addPage: mock2.
+	presenter selectPageIndex: 2.
+	self assert: counter equals: 1.
+	self assert: selected equals: mock2
+]


### PR DESCRIPTION
Work on Notebook presenter.

- Add possibility to use a non default spec
- Add/Remove page
- Add presenter and backend tests
- Improve API - Fix programmatic selection 

Fixes #466
Fixes #468Fixes #226