### PR TITLE
471-Pharo-7-CI-is-timeouting

### DIFF
--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -13,6 +13,8 @@ BaselineOfSpec >> baseline: spec [
 	spec
 		for: #common
 		do: [ 
+			spec postLoadDoIt: #recompileAll.
+
 			"Dependencies"
 			self parametrizedTests: spec.
 
@@ -52,4 +54,13 @@ Then Spec-Deprecated80 is loaded but it does not migrate the subclasses of the o
 	^ super project
 		loadType: #atomic;
 		yourself
+]
+
+{ #category : #public }
+BaselineOfSpec >> recompileAll [
+	"In Pharo 7 we need to recompile the code of the image to make it work."
+
+	SystemVersion current major = 7 ifFalse: [ ^ self ].
+
+	OpalCompiler recompileAll
 ]


### PR DESCRIPTION
In Pharo 7 we need to recompile the code after loading Spec 2.

Fixes #471