### PR TITLE
489-Do-not-break-backward-compatibility-on-menus

### DIFF
--- a/src/Spec-Core/AbstractListPresenter.class.st
+++ b/src/Spec-Core/AbstractListPresenter.class.st
@@ -190,12 +190,6 @@ AbstractListPresenter >> itemAt: anInteger [
 ]
 
 { #category : #api }
-AbstractListPresenter >> itemBeginsWithFilter [
-	self deprecated: 'Use #enableItemBeginsWithFilter instead' transformWith: '`@receiver itemBeginsWithFilter' -> '`@receiver enableItemBeginsWithFilter'.
-	self enableItemBeginsWithFilter
-]
-
-{ #category : #api }
 AbstractListPresenter >> itemFilterBlock [
 	^ itemFilterBlockHolder value
 ]
@@ -205,12 +199,6 @@ AbstractListPresenter >> itemFilterBlock: aBlock [
 	"This block will be used with the search field of the list to filter it with the user input dynamically."
 
 	itemFilterBlockHolder value: aBlock
-]
-
-{ #category : #api }
-AbstractListPresenter >> itemSubstringFilter [
-	self deprecated: 'Use #enableItemSubstringFilter instead' transformWith: '`@receiver itemSubstringFilter' -> '`@receiver enableItemSubstringFilter'.
-	self enableItemSubstringFilter
 ]
 
 { #category : #private }
@@ -249,27 +237,6 @@ AbstractListPresenter >> listSize [
 	"Return the size of the list"
 
 	^ self model shownItems size
-]
-
-{ #category : #api }
-AbstractListPresenter >> menu [
-	"Return the block used to defined the menu"
-	self 
-		deprecated: 'Use #contextMenu instead.' 
-		transformWith: '`@receiver menu' 
-						-> '`@receiver contextMenu'.
-	
-	^ self contextMenu
-]
-
-{ #category : #private }
-AbstractListPresenter >> menu: aMenu shifted: aBoolean [
-	"Build the menu when you right click on an item"
-
-	self halt.
-	^ contextMenuHolder value 
-		cull: aMenu 
-		cull: aBoolean
 ]
 
 { #category : #accessing }

--- a/src/Spec-Deprecated80/AbstractListPresenter.extension.st
+++ b/src/Spec-Deprecated80/AbstractListPresenter.extension.st
@@ -12,6 +12,18 @@ AbstractListPresenter >> doubleClickAction: aBlockClosure [
 ]
 
 { #category : #'*Spec-Deprecated80' }
+AbstractListPresenter >> itemBeginsWithFilter [
+	self deprecated: 'Use #enableItemBeginsWithFilter instead' transformWith: '`@receiver itemBeginsWithFilter' -> '`@receiver enableItemBeginsWithFilter'.
+	self enableItemBeginsWithFilter
+]
+
+{ #category : #'*Spec-Deprecated80' }
+AbstractListPresenter >> itemSubstringFilter [
+	self deprecated: 'Use #enableItemSubstringFilter instead' transformWith: '`@receiver itemSubstringFilter' -> '`@receiver enableItemSubstringFilter'.
+	self enableItemSubstringFilter
+]
+
+{ #category : #'*Spec-Deprecated80' }
 AbstractListPresenter >> listItems [
 	
 	self
@@ -22,15 +34,48 @@ AbstractListPresenter >> listItems [
 ]
 
 { #category : #'*Spec-Deprecated80' }
+AbstractListPresenter >> menu [
+	"Return the block used to defined the menu"
+	self 
+		deprecated: 'Use #contextMenu instead.' 
+		transformWith: '`@receiver menu' 
+						-> '`@receiver contextMenu'.
+	
+	^ self contextMenu
+]
+
+{ #category : #'*Spec-Deprecated80' }
 AbstractListPresenter >> menu: aBlock [
 	"Set the block used to defined the menu"
 
 	self
-		deprecated: 'Use #contextMenu: instead'
+		deprecated:
+			'Use #contextMenu: instead. The old way to create a MenuPresenter was this method taking a MenuMorph as parameter. This will not work with other backend and will be totally removed in Pharo7. Now you should use #contextMenu takin a MeruPresenter (or a block returning a menu presenter) as parameter.'
 		on: '2019-03-07'
-		in: #Pharo8
-		transformWith: '`@receiver menu: `@arg' -> '`@receiver contextMenu: [ `@arg cull: nil cull: false ]'.
-	self contextMenu: [ aBlock cull: nil cull: false ]
+		in: #Pharo8.
+	self
+		contextMenu: [ aBlock
+				cull:
+					(MenuMorph new
+						defaultTarget: self;
+						yourself)
+				cull: false ]
+]
+
+{ #category : #'*Spec-Deprecated80' }
+AbstractListPresenter >> menu: aBlock shifted: aBoolean [
+	self
+		deprecated:
+			'Use #contextMenu: instead. The old way to create a MenuPresenter was this method taking a MenuMorph as parameter. This will not work with other backend and will be totally removed in Pharo7. Now you should use #contextMenu takin a MeruPresenter (or a block returning a menu presenter) as parameter.'
+		on: '2019-03-07'
+		in: #Pharo8.
+	self
+		contextMenu: [ aBlock
+				cull:
+					(MenuMorph new
+						defaultTarget: self;
+						yourself)
+				cull: true ]
 ]
 
 { #category : #'*Spec-Deprecated80' }

--- a/src/Spec-Deprecated80/MenuMorph.extension.st
+++ b/src/Spec-Deprecated80/MenuMorph.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #MenuMorph }
+
+{ #category : #'*Spec-Deprecated80' }
+MenuMorph >> buildWithSpec [
+	^ self
+]


### PR DESCRIPTION
Correct context menu using morphs to ease transition to Spec2.

Fixes #489