### PR TITLE
519-CodePresenterTesttestContextMenu-is-failing

### DIFF
--- a/src/Spec-Tests/CodePresenterTest.class.st
+++ b/src/Spec-Tests/CodePresenterTest.class.st
@@ -15,3 +15,17 @@ CodePresenterTest >> testContextKeyBindings [
 
 	self assert: presenter contextKeyBindings notNil
 ]
+
+{ #category : #tests }
+CodePresenterTest >> testContextMenu [
+	| menu changed |
+	
+	self assert: presenter contextMenu isNotNil. "The code presenter comes with a menu by default"
+	menu := MenuPresenter new.
+	changed := false.
+	presenter whenMenuChangedDo: [ 
+		changed := true. ].
+	presenter contextMenu: menu.
+	self assert: presenter contextMenu equals: menu.
+	self assert: changed
+]


### PR DESCRIPTION
Fix test of code presenter context menu

Fixes #519