### PR TITLE
521-Some-backend-tests-should-use-the-adapter-method

### DIFF
--- a/src/Spec-BackendTests/CodeAdapterTest.class.st
+++ b/src/Spec-BackendTests/CodeAdapterTest.class.st
@@ -64,19 +64,19 @@ CodeAdapterTest >> testTextWithStyle [
 		type: 'self asString.'.
 	self openInstance.
 	
-	text := presenter adapter textWithStyle.
+	text := self adapter textWithStyle.
 	self assertText: text atInterval: "self" (1 to: 4) isStyle: #self.
 	self assertText: text atInterval: "asString" (6 to: 13) isStyle: #unary.
 
 	presenter type: '10 + 42.0'.
-	text := presenter adapter textWithStyle.
+	text := self adapter textWithStyle.
 	self assertText: text atInterval: "10" (1 to: 2) isStyle: #integer.
 	self assertText: text atInterval: "+" (4 to: 4) isStyle: #binary.
 	self assertText: text atInterval: "42.0" (6 to: 9) isStyle: #number.
 
 	presenter behavior: Object.
 	presenter type: 'm1 ^ "test" 42'.
-	text := presenter adapter textWithStyle.
+	text := self adapter textWithStyle.
 	self assertText: text atInterval: "m1" (1 to: 2) isStyle: #patternKeyword.
 	self assertText: text atInterval: "^" (4 to: 4) isStyle: #return.
 	self assertText: text atInterval: "test" (6 to: 11) isStyle: #comment.	

--- a/src/Spec-BackendTests/TextAdapterTest.class.st
+++ b/src/Spec-BackendTests/TextAdapterTest.class.st
@@ -18,9 +18,8 @@ TextAdapterTest >> testKeyBindings [
 	presenter 
 		bindKeyCombination: $t meta 
 		toAction: [ handled := true ].
-	self openInstance.
 
-	presenter adapter 
+	self adapter 
 		keyPressed: $t asciiValue 
 		shift: false 
 		meta: true


### PR DESCRIPTION
Is `self adapter` instead of asking the presenter.

Fixes #521