### PR TITLE
534-ItemFilterBlock-update-on-open-list-does-not-update-the-list

### DIFF
--- a/src/Spec-BackendTests/ListCommonPropertiestTest.class.st
+++ b/src/Spec-BackendTests/ListCommonPropertiestTest.class.st
@@ -10,6 +10,15 @@ ListCommonPropertiestTest >> classToTest [
 ]
 
 { #category : #running }
+ListCommonPropertiestTest >> testEnablingFilteringUpdateOpenedList [
+	self deny: self adapter hasFilter.
+	presenter enableItemSubstringFilter.
+	self assert: self adapter hasFilter.
+	presenter itemFilterBlock: nil.
+	self deny: self adapter hasFilter
+]
+
+{ #category : #running }
 ListCommonPropertiestTest >> testRemoveHeaderTitleInPresenterRemovesColumnHeaderMorph [
 	SystemVersion current major = 7 ifTrue: [ "Test failing in Pharo7 due to a bug in FastTable" ^ self skip ].
 

--- a/src/Spec-Core/AbstractListPresenter.class.st
+++ b/src/Spec-Core/AbstractListPresenter.class.st
@@ -370,6 +370,11 @@ AbstractListPresenter >> whenActivatedDo: aBlockClosure [
 ]
 
 { #category : #'api-events' }
+AbstractListPresenter >> whenItemFilterBlockChangedDo: aBlock [
+	itemFilterBlockHolder whenChangedDo: aBlock
+]
+
+{ #category : #'api-events' }
 AbstractListPresenter >> whenMenuChangedDo: aBlock [
 	"Set a block to value when the menu block has changed"
 	

--- a/src/Spec-Core/SpecCollectionListModel.class.st
+++ b/src/Spec-Core/SpecCollectionListModel.class.st
@@ -6,7 +6,6 @@ Class {
 		'collection',
 		'filter',
 		'shownCollection',
-		'changedBlock',
 		'sortingBlockHolder'
 	],
 	#category : #'Spec-Core-Widgets-Table'

--- a/src/Spec-MorphicAdapters/MorphicListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicListAdapter.class.st
@@ -37,45 +37,38 @@ MorphicListAdapter >> backgroundColorFor: anItem at: index [
 { #category : #factory }
 MorphicListAdapter >> buildWidget [
 	| datasource |
-	
 	datasource := SpecListFastTableDataSource new.
 	datasource model: self model.
 	widget := FTTableMorph new
 		dataSource: datasource;
 		hideColumnHeaders;
 		beResizable;
-		columns: { self newListColumn };
+		columns: {self newListColumn};
 		setMultipleSelection: self model isMultipleSelection;
 		dragEnabled: self dragEnabled;
 		dropEnabled: self dropEnabled;
 		setBalloonText: self help;
 		hResizing: #spaceFill;
 		vResizing: #spaceFill;
-		onAnnouncement: FTSelectionChanged
-			send: #selectionChanged:
-			to: self;
-		onAnnouncement: FTStrongSelectionChanged
-			send: #strongSelectionChanged:
-			to: self;
+		onAnnouncement: FTSelectionChanged send: #selectionChanged: to: self;
+		onAnnouncement: FTStrongSelectionChanged send: #strongSelectionChanged: to: self;
 		yourself.
 	self presenter whenModelChangedDo: [ widget refresh ].
-	self presenter
-		whenSelectionChangedDo: [ self refreshWidgetSelection ].
-	self presenter selection
-		whenChangedDo: [ self refreshWidgetSelection ].
+	self presenter whenSelectionChangedDo: [ self refreshWidgetSelection ].
+	self presenter selection whenChangedDo: [ self refreshWidgetSelection ].
 	self refreshWidgetHeaderTitle.
 	self refreshWidgetSelection.
-	self itemFilterBlock
-		ifNotNil: [ :block | 
-			widget
-				enableFilter: (FTSpecFilter block: block);
-				explicitFunction ].
-			
-	widget		
-		bindKeyCombination: Character space
-		toAction: [ self model clickOnSelectedItem ].
-		
+	self presenter whenItemFilterBlockChangedDo: [ :block | self updateItemFilterBlockWith: block ].
+	self updateItemFilterBlockWith: self itemFilterBlock.
+
+	widget bindKeyCombination: Character space toAction: [ self model clickOnSelectedItem ].
+
 	^ widget
+]
+
+{ #category : #emulating }
+MorphicListAdapter >> hasFilter [
+	^ self widget submorphs anySatisfy: [ :each | each isKindOf: RubTextFieldMorph	"This morph is the explicit filter of the list" ]
 ]
 
 { #category : #accessing }
@@ -205,6 +198,15 @@ MorphicListAdapter >> strongSelectionChanged: aFTStrongSelectionChanged [
 	self presenter activatesOnDoubleClick
 		ifTrue: [ self presenter
 				doubleClickAtIndex: aFTStrongSelectionChanged selectedIndex ]
+]
+
+{ #category : #factory }
+MorphicListAdapter >> updateItemFilterBlockWith: block [
+	^ block
+		ifNotNil: [ widget
+				enableFilter: (FTSpecFilter block: block);
+				explicitFunction ]
+		ifNil: [ widget disableFunction ]
 ]
 
 { #category : #events }


### PR DESCRIPTION
Ensure the list is updated if the user add a filter or disable it.

Fixes #534