### PR TITLE
538-ListPresenter-filteringBlock-is-broken

### DIFF
--- a/src/Spec-Core/AbstractListPresenter.class.st
+++ b/src/Spec-Core/AbstractListPresenter.class.st
@@ -123,21 +123,6 @@ AbstractListPresenter >> enableItemSubstringFilter [
 	self itemFilterBlock: [ :each :pattern | each asLowercase includesSubstring: pattern asLowercase ]
 ]
 
-{ #category : #api }
-AbstractListPresenter >> filteringBlock [
-	"<api: #inspect>"
-	"Return the filtering of the items"
-	
-	^ filteringBlockHolder value
-]
-
-{ #category : #api }
-AbstractListPresenter >> filteringBlock: aBlock [
-	"To set the filtering of the items. This filter will be used to filter the visible elements."
-
-	filteringBlockHolder value: aBlock
-]
-
 { #category : #initialization }
 AbstractListPresenter >> initialize [
 
@@ -157,7 +142,6 @@ AbstractListPresenter >> initialize [
 
 { #category : #initialization }
 AbstractListPresenter >> initializeValueHolders [
-	filteringBlockHolder := self defaultFilteringBlock asValueHolder.
 	itemFilterBlockHolder := nil asValueHolder.
 	doubleClickActionHolder := [ ] asValueHolder.
 	contextMenuHolder := nil asValueHolder.
@@ -208,7 +192,7 @@ AbstractListPresenter >> items: aCollection [
 AbstractListPresenter >> listElementAt: anIndex [
 	"Return the item at index _anIndex_"
 
-	^ self model shownItems at: anIndex ifAbsent: [ nil ]
+	^ self model at: anIndex ifAbsent: [ nil ]
 ]
 
 { #category : #private }
@@ -224,7 +208,7 @@ AbstractListPresenter >> listSize [
 
 	"Return the size of the list"
 
-	^ self model shownItems size
+	^ self model size
 ]
 
 { #category : #accessing }

--- a/src/Spec-Core/SpecCollectionListModel.class.st
+++ b/src/Spec-Core/SpecCollectionListModel.class.st
@@ -4,8 +4,6 @@ Class {
 	#instVars : [
 		'announcer',
 		'collection',
-		'filter',
-		'shownCollection',
 		'sortingBlockHolder'
 	],
 	#category : #'Spec-Core-Widgets-Table'
@@ -66,13 +64,6 @@ SpecCollectionListModel >> collection: anObject [
 ]
 
 { #category : #accessing }
-SpecCollectionListModel >> filterWith: aBlockClosure [ 
-	
-	filter := aBlockClosure.
-	self refreshList.
-]
-
-{ #category : #accessing }
 SpecCollectionListModel >> indexOf: anIndex ifAbsent: aBlock [
 
 	^ collection indexOf: anIndex ifAbsent: aBlock
@@ -80,9 +71,7 @@ SpecCollectionListModel >> indexOf: anIndex ifAbsent: aBlock [
 
 { #category : #initialization }
 SpecCollectionListModel >> initialize [
-
 	super initialize.
-	filter := [ true ].
 	sortingBlockHolder := nil asValueHolder
 ]
 
@@ -94,8 +83,7 @@ SpecCollectionListModel >> items [
 
 { #category : #refreshing }
 SpecCollectionListModel >> refreshList [
-	self sortingBlock ifNotNil: [ :aSortFunction | collection sort: aSortFunction ].
-	shownCollection := collection select: [ :elem | filter cull: elem cull: collection ].
+	self sortingBlock ifNotNil: [ :aSortFunction | collection sort: aSortFunction ]
 ]
 
 { #category : #collection }
@@ -106,12 +94,6 @@ SpecCollectionListModel >> removeAll [
 	self refreshList.
 	self announcer announce: (ValueChanged newValue: self)
 		
-]
-
-{ #category : #accessing }
-SpecCollectionListModel >> shownItems [
-	
-	^ shownCollection
 ]
 
 { #category : #accessing }

--- a/src/Spec-Deprecated80/AbstractListPresenter.extension.st
+++ b/src/Spec-Deprecated80/AbstractListPresenter.extension.st
@@ -12,6 +12,19 @@ AbstractListPresenter >> doubleClickAction: aBlockClosure [
 ]
 
 { #category : #'*Spec-Deprecated80' }
+AbstractListPresenter >> filteringBlock [
+	self
+		deprecated: 'This feature is now removed from Spec 2. If the visible elements of the list need to be changed, it''s the users of the lists that should manage it and update the list of items of the list.'.
+	^ nil
+]
+
+{ #category : #'*Spec-Deprecated80' }
+AbstractListPresenter >> filteringBlock: aBlock [
+	self
+		deprecated: 'This feature is now removed from Spec 2. If the visible elements of the list need to be changed, it''s the users of the lists that should manage it and update the list of items of the list.'
+]
+
+{ #category : #'*Spec-Deprecated80' }
 AbstractListPresenter >> getSelectionStateFor: anIndex [
 	self deprecated: 'This method from the old API will be removed.' transformWith: '`@receiver getSelectionStateFor: `@statements' -> '`@receiver selection selectedIndexes includes: `@statements'.
 
@@ -36,8 +49,8 @@ AbstractListPresenter >> listItems [
 	self
 		deprecated: 'Please use the #model instead'
 		transformWith: '`@receiver listItems' 
-						-> '`@receiver model shownItems'.	
-	^ self model shownItems
+						-> '`@receiver model items'.	
+	^ self model items
 ]
 
 { #category : #'*Spec-Deprecated80' }

--- a/src/Spec-Deprecated80/LabelledList.extension.st
+++ b/src/Spec-Deprecated80/LabelledList.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #LabelledList }
+
+{ #category : #'*Spec-Deprecated80' }
+LabelledList >> filteringBlock: aBlock [
+	self
+		deprecated: 'This feature is now removed from Spec 2. If the visible elements of the list need to be changed, it''s the users of the lists that should manage it and update the list of items of the list.'
+]

--- a/src/Spec-Inspector/EyeInspector.class.st
+++ b/src/Spec-Inspector/EyeInspector.class.st
@@ -186,7 +186,7 @@ EyeInspector >> doItContext [
 
 { #category : #accessing }
 EyeInspector >> elements [
-	^ self list model shownItems
+	^ self list items
 ]
 
 { #category : #inspecting }
@@ -478,7 +478,7 @@ EyeInspector >> updateList [
 	| elements |
 	"	self haltOnce."
 	elements := self generateElements.
-	self list model shownItems = elements
+	self list items = elements
 		ifTrue: [ ^ self ].
 	"first reset the items to make sure we don't interfere with the display block"
 	"self list items: #()."
@@ -486,7 +486,7 @@ EyeInspector >> updateList [
 	self list items: elements.
 
 	"handle when last item of list is removed"
-	self list selection selectedIndex > self list model shownItems size
+	self list selection selectedIndex > self list items size
 		ifTrue: [ self list setSelectedIndex: self list listItems size ].
 
 	"handle when selected dictionary key is removed"

--- a/src/Spec-PolyWidgets-Tests/SearchableListTest.class.st
+++ b/src/Spec-PolyWidgets-Tests/SearchableListTest.class.st
@@ -11,7 +11,7 @@ SearchableListTest >> classToTest [
 
 { #category : #tests }
 SearchableListTest >> testFiltering [
-	presenter listPresenter items: {'aa' . 'bb' . 'ab' . 'ba'}.
+	presenter items: {'aa' . 'bb' . 'ab' . 'ba'}.
 	presenter searchPresenter text: 'a'.
-	self assert: presenter listPresenter model shownItems asArray equals: {'aa' . 'ab'}
+	self assertCollection: presenter listPresenter items hasSameElements: {'aa' . 'ab'}
 ]

--- a/src/Spec-PolyWidgets/EditableList.class.st
+++ b/src/Spec-PolyWidgets/EditableList.class.st
@@ -164,10 +164,10 @@ EditableList >> list: aList [
 { #category : #private }
 EditableList >> moveElementAt: index to: newIndex [
 	| elementToMove orderedList |
-	(newIndex < 1 or: [ newIndex > list model shownItems size ])
+	(newIndex < 1 or: [ newIndex > list items size ])
 		ifTrue: [ ^ self ].
-	elementToMove := list model shownItems at: index.
-	orderedList := list model items copy asOrderedCollection
+	elementToMove := list itemAt: index.
+	orderedList := list items copy asOrderedCollection
 		removeAt: index;
 		add: elementToMove beforeIndex: newIndex;
 		yourself.

--- a/src/Spec-PolyWidgets/LabelledList.class.st
+++ b/src/Spec-PolyWidgets/LabelledList.class.st
@@ -24,11 +24,6 @@ LabelledList >> displayBlock: aBlock [
 	^self list displayBlock: aBlock
 ]
 
-{ #category : #'api-shortcuts' }
-LabelledList >> filteringBlock: aBlock [
-	^ self list filteringBlock: aBlock
-]
-
 { #category : #initialization }
 LabelledList >> initializeWidgets [
 super initializeWidgets.

--- a/src/Spec-PolyWidgets/SearchableList.class.st
+++ b/src/Spec-PolyWidgets/SearchableList.class.st
@@ -13,7 +13,8 @@ Class {
 	#superclass : #ComposablePresenter,
 	#instVars : [
 		'listPresenter',
-		'searchPresenter'
+		'searchPresenter',
+		'baseItems'
 	],
 	#category : #'Spec-PolyWidgets-ListAndTree'
 }
@@ -30,14 +31,11 @@ SearchableList class >> defaultSpec [
 { #category : #initialization }
 SearchableList >> initializePresenter [
 	searchPresenter
-		whenTextChangedDo: [ :newText | 
-			| text |
-			text := searchPresenter getText asLowercase.
-			text isEmpty
-				ifTrue: [ listPresenter model resetFilter ]
-				ifFalse: [ listPresenter model
-						filterWith:
-							[ :element :col | element asLowercase beginsWith: searchPresenter getText asLowercase ] ] ]
+		whenTextChangedDo:
+			[ :newText |
+			searchPresenter getText asLowercase
+				ifEmpty: [ listPresenter items: baseItems ]
+				ifNotEmpty: [ :text | listPresenter items: (baseItems select: [ :element | element asLowercase beginsWith: text ]) ] ]
 ]
 
 { #category : #initialization }
@@ -46,11 +44,12 @@ SearchableList >> initializeWidgets [
 	searchPresenter := self newTextInput.
 	searchPresenter
 		autoAccept: true;
-		placeholder: 'filter'
+		placeholder: 'Filter'
 ]
 
 { #category : #accessing }
 SearchableList >> items: aCollection [
+	baseItems := aCollection.
 	listPresenter items: aCollection
 ]
 

--- a/src/Spec-Tools/MessageBrowser.class.st
+++ b/src/Spec-Tools/MessageBrowser.class.st
@@ -324,7 +324,7 @@ MessageBrowser >> findFirstOccurrenceOf: searchedString in: textToSearchIn [
 { #category : #announcements }
 MessageBrowser >> handleClassRenamed: anAnnouncement [
 	| items selectedIndex |
-	items := listModel model shownItems
+	items := listModel items
 		collect: [ :rgMethod | 
 			| interestedClassName interestedClass |
 			interestedClassName := anAnnouncement oldName.
@@ -381,7 +381,7 @@ MessageBrowser >> handleMethodModified: anAnnouncement [
 	edits
 		ifTrue: [ text := textModel pendingText ].
 	index := listModel selection selectedIndex.
-	list := listModel model shownItems
+	list := listModel items
 		remove: sel ifAbsent: [  ];
 		add: item asFullRingDefinition;
 		"to ensure it's still a RGMethod"
@@ -415,7 +415,7 @@ MessageBrowser >> handleMethodRemoved: anAnnouncement [
 		ifTrue: [ textModel hasUnacceptedEdits: false ].
 	self
 		messages:
-			(listModel model shownItems
+			(listModel items
 				remove: item asFullRingDefinition ifAbsent: [ nil ];
 				yourself).
 	listModel selectIndex: selection


### PR DESCRIPTION
Remove broken filtering system and clean code.

We discussed this with Julien and with Esteban and we agree that initial filtering should be managed by the user and not spec to reduce code complexity. Spec should only manage the final user filtering of the list and not initial filtering.

Fixes #538 
Fixes #537