### PR TITLE
541-Spec-should-not-use-RubPluggableTextMorph

### DIFF
--- a/src/Spec-Deprecated80/MorphicCodeAdapter.extension.st
+++ b/src/Spec-Deprecated80/MorphicCodeAdapter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #MorphicCodeAdapter }
+
+{ #category : #'*Spec-Deprecated80' }
+MorphicCodeAdapter >> isAboutToStyle [
+	self deprecated: 'Use #okToStle instead' transformWith: '`@receiver isAboutToStyle' -> '`@receiver okToStyle'.
+	^ self okToStyle
+]

--- a/src/Spec-Inspector/EyeAbstractInspector.class.st
+++ b/src/Spec-Inspector/EyeAbstractInspector.class.st
@@ -84,8 +84,7 @@ EyeAbstractInspector >> initialize [
 { #category : #initialization }
 EyeAbstractInspector >> initializePresenter [
 	object whenChangedDo: [ self objectChanged ].
-	self text
-		whenBuiltDo: [ :w | w widget editingMode classOrMetaClass: self object class ].
+	self text whenBuiltDo: [ :w | self text behavior: self object class ].
 	self initializeShortcuts
 ]
 

--- a/src/Spec-Inspector/EyeInspector.class.st
+++ b/src/Spec-Inspector/EyeInspector.class.st
@@ -301,8 +301,7 @@ EyeInspector >> objectChanged [
 	self description doItReceiver: self object.
 	self text doItContext: self doItContext.
 	self description doItContext: self doItContext.
-	self text adapter
-		ifNotNil: [ :w | w editingMode classOrMetaClass: self objectClass ]
+	self text ifNotNil: [ :w | w behavior: self objectClass ]
 ]
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyePointerExplorer.class.st
+++ b/src/Spec-Inspector/EyePointerExplorer.class.st
@@ -75,8 +75,7 @@ EyePointerExplorer >> object: anObject [
 { #category : #'event-handling' }
 EyePointerExplorer >> objectChanged [
 	self text doItReceiver: self object.
-	self text widget
-		ifNotNil: [ :w | w editingMode classOrMetaClass: self object class ].
+	self text ifNotNil: [ :w | w behavior: self object class ].
 	self tree roots: self roots
 ]
 

--- a/src/Spec-Inspector/EyeTreeInspector.class.st
+++ b/src/Spec-Inspector/EyeTreeInspector.class.st
@@ -40,10 +40,7 @@ EyeTreeInspector >> childrenForObject: anObject [
 { #category : #'event-handling' }
 EyeTreeInspector >> elementChanged [
 	self text doItReceiver: self selectedElement value.
-	self text adapter
-		ifNotNil: [ :w | 
-			w widget editingMode
-				classOrMetaClass: self selectedElement value class ]
+	self text ifNotNil: [ :w | w behavior: self selectedElement value class ]
 ]
 
 { #category : #api }
@@ -93,8 +90,7 @@ EyeTreeInspector >> labelFor: anEyeElement [
 { #category : #'event-handling' }
 EyeTreeInspector >> objectChanged [
 	self text doItReceiver: self object.
-	self text adapter
-		ifNotNil: [ :w | w editingMode classOrMetaClass: self object class ].
+	self text ifNotNil: [ :w | w behavior: self object class ].
 	self tree
 		roots: self roots;
 		expandRoots

--- a/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
@@ -36,18 +36,6 @@ MorphicCodeAdapter >> guessTypeForName: aString [
 	^nil
 ]
 
-{ #category : #initialization }
-MorphicCodeAdapter >> initialize [
-
-	super initialize.
-]
-
-{ #category : #shout }
-MorphicCodeAdapter >> isAboutToStyle [
-
-	^ self okToStyle
-]
-
 { #category : #NOCompletion }
 MorphicCodeAdapter >> isCodeCompletionAllowed [
 

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -59,14 +59,12 @@ MorphicTextAdapter >> autoAccept: aBoolean [
 { #category : #factory }
 MorphicTextAdapter >> buildWidget [
 	| newWidget |
-
-	newWidget := RubPluggableTextMorph new
-		on: self
-			text: #getText
-			accept: #accept:notifying:
-			readSelection: #readSelection
-			menu: #codePaneMenu:shifted:
-			setSelection: #setSelection:;
+	newWidget := (RubScrolledTextMorph on: self)
+		getTextSelector: #getText;
+		setTextSelector: #accept:notifying:;
+		getSelectionSelector: #readSelection;
+		menuProvider: self selector: #codePaneMenu:shifted:;
+		setSelectionSelector: #setSelection:;
 		beWrapped;
 		enabled: self enabled;
 		askBeforeDiscardingEdits: self askBeforeDiscardingEdits;
@@ -78,12 +76,9 @@ MorphicTextAdapter >> buildWidget [
 		dropEnabled: self dropEnabled;
 		registerScrollChanges: #scrollValueChanged:;
 		yourself.
-		
 	self setEditingModeFor: newWidget.
-	self model additionalKeyBindings ifNotNil: [ :bindings |
-		bindings keysAndValuesDo: [ :shortcut :action | 
-			newWidget bindKeyCombination: shortcut toAction: action ] ].
-	
+	self model additionalKeyBindings ifNotNil: [ :bindings | bindings keysAndValuesDo: [ :shortcut :action | newWidget bindKeyCombination: shortcut toAction: action ] ].
+	self presenter whenTextChangedDo: [ :text | newWidget setText: text ].
 	^ newWidget
 ]
 
@@ -94,7 +89,7 @@ MorphicTextAdapter >> canChangeText [
 
 { #category : #'undo-redo' }
 MorphicTextAdapter >> clearUndoManager [
-	self widget clearUndoManager
+	self widget textArea editingState clearUndoManager: nil
 ]
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -59,7 +59,8 @@ MorphicTextAdapter >> autoAccept: aBoolean [
 { #category : #factory }
 MorphicTextAdapter >> buildWidget [
 	| newWidget |
-	newWidget := (RubScrolledTextMorph on: self)
+	self flag: #pharo7.	"When support for P7 will be dropped, remove this compatibility hack."
+	newWidget := ((self class environment at: #SpecRubScrolledTextMorph ifAbsent: [ RubScrolledTextMorph ]) on: self)
 		getTextSelector: #getText;
 		setTextSelector: #accept:notifying:;
 		getSelectionSelector: #readSelection;

--- a/src/Spec-MorphicAdapters/RubScrolledTextMorph.extension.st
+++ b/src/Spec-MorphicAdapters/RubScrolledTextMorph.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #RubScrolledTextMorph }
 
 { #category : #'*Spec-MorphicAdapters' }
+RubScrolledTextMorph >> registerScrollChanges: aSelector [
+	self scrollPane announcer when: PaneScrolling send: aSelector to: self model
+]
+
+{ #category : #'*Spec-MorphicAdapters' }
 RubScrolledTextMorph >> setSelectionSelector: aSelector [
 	setSelectionSelector := aSelector
 ]

--- a/src/Spec-Pharo7To8Compatibility/SpecRubScrolledTextMorph.class.st
+++ b/src/Spec-Pharo7To8Compatibility/SpecRubScrolledTextMorph.class.st
@@ -1,0 +1,33 @@
+"
+I am the common morph to represent a text area. I should be created by my model, a RubScrolledTextModel. The tool should talk to my model and not me directly 
+"
+Class {
+	#name : #SpecRubScrolledTextMorph,
+	#superclass : #RubScrolledTextMorph,
+	#instVars : [
+		'askBeforeDiscardingEdits'
+	],
+	#category : #'Spec-Pharo7To8Compatibility'
+}
+
+{ #category : #'instance creation' }
+SpecRubScrolledTextMorph class >> on: aModel [ 
+	^ self new on: aModel
+]
+
+{ #category : #accessing }
+SpecRubScrolledTextMorph >> askBeforeDiscardingEdits: anObject [
+	askBeforeDiscardingEdits := anObject
+]
+
+{ #category : #accessing }
+SpecRubScrolledTextMorph >> canDiscardEdits [
+	^ (self hasUnacceptedEdits and: [askBeforeDiscardingEdits]) not
+
+]
+
+{ #category : #accessing }
+SpecRubScrolledTextMorph >> initialize [
+	askBeforeDiscardingEdits := true.
+	super initialize
+]


### PR DESCRIPTION
Remove dependency on RubPluggableTextMorph

It also fix direct interaction of the inspector on morph.

Fixes #541