### PR TITLE
540-withwithoutSyntaxHighligh-should-be-observable-and-update-the-adaptor

### DIFF
--- a/src/Spec-BackendTests/CodeAdapterTest.class.st
+++ b/src/Spec-BackendTests/CodeAdapterTest.class.st
@@ -81,3 +81,15 @@ CodeAdapterTest >> testTextWithStyle [
 	self assertText: text atInterval: "test" (6 to: 11) isStyle: #comment.	
 	self assertText: text atInterval: "42" (13 to: 14) isStyle: #number.
 ]
+
+{ #category : #tests }
+CodeAdapterTest >> testWithSyntaxHighlight [
+	presenter withSyntaxHighlight.
+	self assert: self adapter hasSyntaxHighlightEnabled
+]
+
+{ #category : #tests }
+CodeAdapterTest >> testWithoutSyntaxHighlight [
+	presenter withoutSyntaxHighlight.
+	self deny: self adapter hasSyntaxHighlightEnabled
+]

--- a/src/Spec-BackendTests/MorphicCodeAdapter.extension.st
+++ b/src/Spec-BackendTests/MorphicCodeAdapter.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #MorphicCodeAdapter }
 
 { #category : #'*Spec-BackendTests' }
 MorphicCodeAdapter >> hasSyntaxHighlightEnabled [
-	^ self widget shoutStyler isNotNil
+	^ (self widget textArea editingMode isKindOf: RubPlainTextMode) not
 ]

--- a/src/Spec-BackendTests/MorphicCodeAdapter.extension.st
+++ b/src/Spec-BackendTests/MorphicCodeAdapter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #MorphicCodeAdapter }
+
+{ #category : #'*Spec-BackendTests' }
+MorphicCodeAdapter >> hasSyntaxHighlightEnabled [
+	^ self widget shoutStyler isNotNil
+]

--- a/src/Spec-Core/AbstractTextPresenter.class.st
+++ b/src/Spec-Core/AbstractTextPresenter.class.st
@@ -331,16 +331,6 @@ AbstractTextPresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #'api-shout' }
-AbstractTextPresenter >> isAboutToStyle [
-	"Return if the text zone is shouted or not"
-
-	self 
-		deprecated: 'This has been moved to specific presenters' 
-		on: '2019-04-15'
-		in: #Pharo8
-]
-
 { #category : #NOCompletion }
 AbstractTextPresenter >> isCodeCompletionAllowed [
 	"Return if code completion is allowed"

--- a/src/Spec-Core/CodePresenter.class.st
+++ b/src/Spec-Core/CodePresenter.class.st
@@ -9,7 +9,7 @@ Class {
 		'#doItContext => SpecObservableSlot',
 		'#doItReceiver => SpecObservableSlot',
 		'#behavior => SpecObservableSlot',
-		'#syntaxHighlight',
+		'#syntaxHighlight => SpecObservableSlot',
 		'#contextKeyBindings'
 	],
 	#category : #'Spec-Core-Widgets'
@@ -141,6 +141,11 @@ CodePresenter >> selectedBehavior [
 	^ self behavior
 ]
 
+{ #category : #accessing }
+CodePresenter >> syntaxHighlight: aBoolean [
+	syntaxHighlight := aBoolean 
+]
+
 { #category : #'api-events' }
 CodePresenter >> whenBehaviorChangedDo: aBlock [
 	"Set a block to perform when the behavior class changed"
@@ -150,14 +155,19 @@ CodePresenter >> whenBehaviorChangedDo: aBlock [
 		whenChangedDo: aBlock
 ]
 
-{ #category : #accessing }
-CodePresenter >> withSyntaxHighlight [
+{ #category : #'api-events' }
+CodePresenter >> whenSyntaxHighlightChangedDo: aBlock [
+	"Set a block to perform when the syntax highlight is enabled/disabled"
 
-	syntaxHighlight := true
+	self property: #syntaxHighlight whenChangedDo: aBlock
 ]
 
-{ #category : #accessing }
-CodePresenter >> withoutSyntaxHighlight [
+{ #category : #api }
+CodePresenter >> withSyntaxHighlight [
+	self syntaxHighlight: true
+]
 
-	syntaxHighlight := false
+{ #category : #api }
+CodePresenter >> withoutSyntaxHighlight [
+	self syntaxHighlight: false
 ]

--- a/src/Spec-Deprecated80/AbstractTextPresenter.extension.st
+++ b/src/Spec-Deprecated80/AbstractTextPresenter.extension.st
@@ -1,6 +1,16 @@
 Extension { #name : #AbstractTextPresenter }
 
 { #category : #'*Spec-Deprecated80' }
+AbstractTextPresenter >> isAboutToStyle [
+	"Return if the text zone is shouted or not"
+
+	self 
+		deprecated: 'This has been moved to specific presenters' 
+		on: '2019-04-15'
+		in: #Pharo8
+]
+
+{ #category : #'*Spec-Deprecated80' }
 AbstractTextPresenter >> whenAboutToStyleBlockChanged: aBlock [
 	self deprecated: 'Use #whenAboutToStyleBlockChangedDo: instead.' transformWith: '`@receiver whenAboutToStyleBlockChanged: `@statements' -> '`@receiver whenAboutToStyleBlockChangedDo: `@statements'.
 	self whenAboutToStyleBlockChangedDo: aBlock

--- a/src/Spec-Deprecated80/CodePresenter.extension.st
+++ b/src/Spec-Deprecated80/CodePresenter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #CodePresenter }
+
+{ #category : #'*Spec-Deprecated80' }
+CodePresenter >> aboutToStyle: aBoolean [
+	self deprecated: 'Use #withSyntaxHighlight, #withoutSyntaxHighlight or #syntaxHighlight: instead.' transformWith: '`@receiver aboutToStyle: `@argument' -> '`@receiver syntaxHighlight: `@argument'.
+	self syntaxHighlight: aBoolean
+]

--- a/src/Spec-Examples/MethodBrowser.class.st
+++ b/src/Spec-Examples/MethodBrowser.class.st
@@ -97,8 +97,7 @@ MethodBrowser >> initializeWidgets [
 	self focusOrder
 		add: listModel;
 		add: toolbarModel;
-		add: textModel.
-	textModel aboutToStyle: true
+		add: textModel
 ]
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeAbstractInspector.class.st
+++ b/src/Spec-Inspector/EyeAbstractInspector.class.st
@@ -219,9 +219,7 @@ EyeAbstractInspector >> shortCuts [
 
 { #category : #accessing }
 EyeAbstractInspector >> text [
-	^ text ifNil: [ 
-		text := self newCode.
-		text aboutToStyle: true. ]
+	^ text ifNil: [ text := self newCode ]
 ]
 
 { #category : #accessing }

--- a/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
@@ -36,16 +36,15 @@ MorphicCodeAdapter >> guessTypeForName: aString [
 	^nil
 ]
 
+{ #category : #private }
+MorphicCodeAdapter >> hasSyntaxHighlight [
+	^ self model hasSyntaxHighlight
+]
+
 { #category : #NOCompletion }
 MorphicCodeAdapter >> isCodeCompletionAllowed [
 
 	^ true
-]
-
-{ #category : #'private-shout' }
-MorphicCodeAdapter >> okToStyle [
-
-	^ self model hasSyntaxHighlight
 ]
 
 { #category : #NOCompletion }
@@ -67,9 +66,8 @@ MorphicCodeAdapter >> selectedClassOrMetaClass [
 ]
 
 { #category : #private }
-MorphicCodeAdapter >> setEditingModeFor: textArea [ 
-
-	self setEditingModeFor: textArea withBehavior: self behavior
+MorphicCodeAdapter >> setEditingModeFor: textArea [
+	self hasSyntaxHighlight ifTrue: [ self setEditingModeFor: textArea withBehavior: self behavior ] ifFalse: [ textArea beForPlainText ]
 ]
 
 { #category : #private }
@@ -78,12 +76,6 @@ MorphicCodeAdapter >> setEditingModeFor: textArea withBehavior: aBehavior [
 	aBehavior
 		ifNotNil: [ textArea beForSmalltalkCodeInClass: aBehavior ]		
 		ifNil: [ textArea beForSmalltalkScripting ]
-]
-
-{ #category : #shout }
-MorphicCodeAdapter >> shoutAboutToStyle: aMorph [
-	
-	^ self isAboutToStyle
 ]
 
 { #category : #private }

--- a/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
@@ -10,6 +10,16 @@ MorphicCodeAdapter >> behavior [
 	^ self model behavior
 ]
 
+{ #category : #factory }
+MorphicCodeAdapter >> buildWidget [
+	| newWidget |
+	newWidget := super buildWidget.
+
+	self presenter whenSyntaxHighlightChangedDo: [ :hasSyntaxHighlight | self setEditingModeFor: newWidget ].
+	
+	^ newWidget
+]
+
 { #category : #'private-shout' }
 MorphicCodeAdapter >> classOrMetaClass: aClass [
 
@@ -67,7 +77,9 @@ MorphicCodeAdapter >> selectedClassOrMetaClass [
 
 { #category : #private }
 MorphicCodeAdapter >> setEditingModeFor: textArea [
-	self hasSyntaxHighlight ifTrue: [ self setEditingModeFor: textArea withBehavior: self behavior ] ifFalse: [ textArea beForPlainText ]
+	self hasSyntaxHighlight
+		ifTrue: [ self setEditingModeFor: textArea withBehavior: self behavior ]
+		ifFalse: [ super setEditingModeFor: textArea ]
 ]
 
 { #category : #private }

--- a/src/Spec-Tests/CodePresenterTest.class.st
+++ b/src/Spec-Tests/CodePresenterTest.class.st
@@ -29,3 +29,17 @@ CodePresenterTest >> testContextMenu [
 	self assert: presenter contextMenu equals: menu.
 	self assert: changed
 ]
+
+{ #category : #tests }
+CodePresenterTest >> testWhenSyntaxHighlightChangedDo [
+	| count result |
+	count := 0.
+	result := true.
+	presenter
+		whenSyntaxHighlightChangedDo: [ :syntaxHighlight | 
+			count := count + 1.
+			result := syntaxHighlight ].
+	presenter withoutSyntaxHighlight.
+	self assert: count equals: 1.
+	self deny: result
+]

--- a/src/Spec-Tools/ChangeSorterModel.class.st
+++ b/src/Spec-Tools/ChangeSorterModel.class.st
@@ -4,8 +4,39 @@ A ChangeSorterModel is a model used by Change Sorter UIs for computation
 Class {
 	#name : #ChangeSorterModel,
 	#superclass : #AbstractTool,
+	#classVars : [
+		'ClassDescriptionsMap'
+	],
 	#category : #'Spec-Tools-ChangeSorter'
 }
+
+{ #category : #accessing }
+ChangeSorterModel class >> classDescriptionsMap [
+	^ ClassDescriptionsMap
+]
+
+{ #category : #accessing }
+ChangeSorterModel class >> classDescriptionsMap: anObject [
+	ClassDescriptionsMap := anObject
+]
+
+{ #category : #default }
+ChangeSorterModel class >> defaultClassDescriptionsMap [
+	^ Dictionary new
+		at: #remove put: 'Entire class was removed.';
+		at: #addedThenRemoved put: 'Class was added then removed.';
+		at: #rename put: 'Class name was changed.';
+		at: #add put: 'Class definition was added.';
+		at: #change put: 'Class definition was changed.';
+		at: #reorganize put: 'Class organization was changed.';
+		at: #comment put: 'New class comment.';
+		yourself
+]
+
+{ #category : #'class initialization' }
+ChangeSorterModel class >> initialize [
+	self classDescriptionsMap: self defaultClassDescriptionsMap
+]
 
 { #category : #'change set' }
 ChangeSorterModel >> addPreambleTo: aChangeSet [
@@ -29,26 +60,10 @@ ChangeSorterModel >> buildChangeSetDescriptionFor: changeSet [
 
 { #category : #text }
 ChangeSorterModel >> buildClassDescriptionFor: changeSet class: class [
-	| stream |
-
-	stream := (String new: 100) writeStream.
-		(changeSet classChangeAt: class name)
-			do: [:each | 
-				each = #remove
-					ifTrue: [ stream nextPutAll: 'Entire class was removed.'; cr ].
-				each = #addedThenRemoved
-					ifTrue: [ stream nextPutAll: 'Class was added then removed.'; cr ].
-				each = #rename
-					ifTrue: [ stream nextPutAll: 'Class name was changed.'; cr ].
-				each = #add
-					ifTrue: [ stream nextPutAll: 'Class definition was added.'; cr ].
-				each = #change
-					ifTrue: [ stream nextPutAll: 'Class definition was changed.'; cr ].
-				each = #reorganize
-					ifTrue: [ stream nextPutAll: 'Class organization was changed.'; cr ].
-				each = #comment 
-					ifTrue: [ stream nextPutAll: 'New class comment.'; cr ]].
-		^ stream contents
+	^ String streamContents: [ :stream |
+			(changeSet classChangeAt: class name)
+				do: [ :each | stream nextPutAll: (self classDescriptionsMap at: each) ]
+				separatedBy: [ stream cr ] ]
 ]
 
 { #category : #text }
@@ -68,6 +83,11 @@ ChangeSorterModel >> buildSelectorDescriptionFor: changeSet class: class selecto
 	code := class sourceCodeAt: selector.
 		
 	^ code asText
+]
+
+{ #category : #accessing }
+ChangeSorterModel >> classDescriptionsMap [
+	^ self class classDescriptionsMap
 ]
 
 { #category : #'change set' }

--- a/src/Spec-Tools/ChangeSorterPresenter.class.st
+++ b/src/Spec-Tools/ChangeSorterPresenter.class.st
@@ -381,6 +381,7 @@ ChangeSorterPresenter >> initializeWidgets [
 	classesListPresenter := self newList.
 	changesListPresenter := self newList.
 	textPresenter := self newCode.
+	textPresenter withoutSyntaxHighlight.
 
 	self setFocus.
 

--- a/src/Spec-Tools/ChangeSorterPresenter.class.st
+++ b/src/Spec-Tools/ChangeSorterPresenter.class.st
@@ -372,7 +372,7 @@ ChangeSorterPresenter >> initializePresenter [
 	self registerClassActions.
 	self registerSelectorActions.
 
-	changesListPresenter items ifNotEmpty: [ changesListPresenter selectedIndex: 1 ]
+	changesListPresenter items ifNotEmpty: [ changesListPresenter selectIndex: 1 ]
 ]
 
 { #category : #initialization }
@@ -381,7 +381,6 @@ ChangeSorterPresenter >> initializeWidgets [
 	classesListPresenter := self newList.
 	changesListPresenter := self newList.
 	textPresenter := self newCode.
-	textPresenter withoutSyntaxHighlight.
 
 	self setFocus.
 
@@ -395,8 +394,7 @@ ChangeSorterPresenter >> initializeWidgets [
 
 	changesListPresenter items: self model allChanges.
 	changesListPresenter displayBlock: [ :item | item name ].
-	classesListPresenter sortingBlock: [ :a :b | a name < b name ].
-	textPresenter aboutToStyle: true
+	classesListPresenter sortingBlock: [ :a :b | a name < b name ]
 ]
 
 { #category : #initialization }
@@ -542,7 +540,7 @@ ChangeSorterPresenter >> registerClassActions [
 		whenSelectionChangedDo: [ :selection | 
 			self updateTextContents.
 			textPresenter behavior: selection selectedItem.
-			textPresenter aboutToStyle: false.
+			textPresenter syntaxHighlight: false.
 			selection selectedItem
 				ifNil: [ methodsListPresenter items: {} ]
 				ifNotNil: [ :class | 
@@ -764,9 +762,10 @@ ChangeSorterPresenter >> updateMessagesList [
 ChangeSorterPresenter >> updateTextContents [
 	| text |
 	text := self model setContentsOfChangeSet: self selectedChangeSet forClass: self selectedClass andSelector: self selectedSelector.
-	({'Method was added, but cannot be found!' . 'Added then removed (see versions)' . 'Method has been removed (see versions)'} includes: text)
-		ifTrue: [ textPresenter aboutToStyle: false ]
-		ifFalse: [ textPresenter aboutToStyle: true ].
+	(text asString lines
+		anySatisfy: [ :line | 
+			self model classDescriptionsMap values , {'Method was added, but cannot be found!' . 'Added then removed (see versions)' . 'Method has been removed (see versions)' . 'Class organization was changed.'}
+				includes: line ]) ifTrue: [ textPresenter withoutSyntaxHighlight ] ifFalse: [ textPresenter withSyntaxHighlight ].
 	textPresenter text: text
 ]
 

--- a/src/Spec-Tools/MessageBrowser.class.st
+++ b/src/Spec-Tools/MessageBrowser.class.st
@@ -468,7 +468,6 @@ MessageBrowser >> initializeWidgets [
 		addColumn: (StringTableColumn title: 'Package' evaluated: [ :item | self packageOf: item ]);
 		beResizable.
 
-	textModel aboutToStyle: true.
 	textModel whenBuiltDo: [ :ann | ann widget font: self codeFont ].
 	refreshingBlockHolder := [ :item | true ] asValueHolder.
 
@@ -812,7 +811,7 @@ MessageBrowser >> textConverter [
 MessageBrowser >> textConverter: aTextConverter [
 
 	textConverterHolder value: (aTextConverter method: self textConverter method).
-	textModel aboutToStyle: self textConverter shouldShout .
+	textModel syntaxHighlight: self textConverter shouldShout .
 	textModel text: self textConverter getText.
 ]
 


### PR DESCRIPTION
Now updating the value of #syntaxHighlight update the rubric open instances.

I also migrated the Spec tools using #aboutToStyle: and I cleaned a little the ChangeSorterModel. 
I also fixed a bug in the ChangeSorter were some text was highlighted when it should not have been.

Fixes #540