### PR TITLE
Add the #selectPaths to AbstractTreeSingleSelectionMode

### DIFF
--- a/src/Spec-Core/AbstractTreeSingleSelectionMode.class.st
+++ b/src/Spec-Core/AbstractTreeSingleSelectionMode.class.st
@@ -50,6 +50,11 @@ AbstractTreeSingleSelectionMode >> selectPath: aPath [
 	self subclassResponsibility
 ]
 
+{ #category : #selection }
+AbstractTreeSingleSelectionMode >> selectPaths: pathArray [
+	self subclassResponsibility
+]
+
 { #category : #selecting }
 AbstractTreeSingleSelectionMode >> unselectAll [
 


### PR DESCRIPTION
Its subclasses have to implement this method. 