### PR TITLE
554-Pharo-7-WSL-RubTextFieldAreaObjectdoesNotUnderstand-wrapped

### DIFF
--- a/src/Spec-Pharo7To8Compatibility/RubTextFieldArea.extension.st
+++ b/src/Spec-Pharo7To8Compatibility/RubTextFieldArea.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RubTextFieldArea }
+
+{ #category : #'*Spec-Pharo7To8Compatibility' }
+RubTextFieldArea >> wrapped: aBoolean [
+	self deprecated: 'Obsolete' transformWith: '`@receiver wrapped: `@statements' -> ''
+]


### PR DESCRIPTION
More backward compatibility

Fixes #554