### PR TITLE
564-Remove-call-to-deprecated-window-methods

### DIFF
--- a/src/Spec-BackendTests/MockDynamicPresenter.class.st
+++ b/src/Spec-BackendTests/MockDynamicPresenter.class.st
@@ -55,5 +55,5 @@ MockDynamicPresenter >> label [
 
 { #category : #action }
 MockDynamicPresenter >> selectFirstElement [
-	list selectedIndex: 1
+	list selectIndex: 1
 ]

--- a/src/Spec-Core/SpecVersatileDialogPresenter.class.st
+++ b/src/Spec-Core/SpecVersatileDialogPresenter.class.st
@@ -253,11 +253,6 @@ SpecVersatileDialogPresenter >> footnoteIcon: aForm [
 	footnoteIcon := aForm.
 ]
 
-{ #category : #'api-window' }
-SpecVersatileDialogPresenter >> initialExtent [
-	^ 400@200
-]
-
 { #category : #initialization }
 SpecVersatileDialogPresenter >> initialize [
 
@@ -271,6 +266,7 @@ SpecVersatileDialogPresenter >> initialize [
 
 { #category : #initialization }
 SpecVersatileDialogPresenter >> initializeDialogWindow: aDialogWindowPresenter [
+	aDialogWindowPresenter initialExtent: 400 @ 200
 ]
 
 { #category : #initialization }

--- a/src/Spec-Deprecated80/AbstractTwoButtons.class.st
+++ b/src/Spec-Deprecated80/AbstractTwoButtons.class.st
@@ -20,12 +20,7 @@ Class {
 
 { #category : #deprecation }
 AbstractTwoButtons class >> abstractExample [
-	| example |
-	example := self new.
-	example
-		title: self name asString , ' example';
-		extent: 100 @ 100.
-	^ example
+	^ self new
 ]
 
 { #category : #specs }

--- a/src/Spec-Deprecated80/DropListButton.class.st
+++ b/src/Spec-Deprecated80/DropListButton.class.st
@@ -30,15 +30,14 @@ DropListButton class >> defaultSpec [
 DropListButton class >> example [
 	<sampleInstance>
 	| example |
-	
 	example := self new.
 	example
 		displayBlock: [ :item | item asString ];
 		items: {'Swordian' . 'Gardian' . 'Wizard' . 'Sniper'};
 		label: 'Add';
 		extent: 300 @ 70;
-		title: 'DropListButton example';
 		openWithSpec.
+	example withWindowDo: [ :window | window title: 'DropListButton example' ].
 	^ example
 ]
 

--- a/src/Spec-Examples/InputTextDropList.extension.st
+++ b/src/Spec-Examples/InputTextDropList.extension.st
@@ -3,12 +3,14 @@ Extension { #name : #InputTextDropList }
 { #category : #'*Spec-Examples' }
 InputTextDropList class >> example [
 	<sampleInstance>
-	^ self new
+	| example |
+	example := self new
 		placeholder: 'a Number';
 		displayBlock: [ :item | item asString ];
 		items: {'Potatoes' . 'Carrots' . 'Onions'};
 		extent: 350 @ 50;
-		title: 'InputTextDropList example';
 		openWithSpec;
-		yourself
+		yourself.
+	example withWindowDo: [ :window | window title: 'InputTextDropList example' ].
+	^ example
 ]

--- a/src/Spec-Examples/LabelledContainer.extension.st
+++ b/src/Spec-Examples/LabelledContainer.extension.st
@@ -4,9 +4,7 @@ Extension { #name : #LabelledContainer }
 LabelledContainer class >> abstractExample [
 	| example |
 	example := self new.
-	example
-		title: self name asString , ' example';
-		label: 'I am a label'.
+	example label: 'I am a label'.
 	^ example
 ]
 
@@ -15,9 +13,14 @@ LabelledContainer class >> example [
 	<sampleInstance>
 	| example |
 	example := self abstractExample.
-	example content: ButtonPresenter.
-	example subwidget
-		label: 'I am a button'.
+	self setUpExample: example.
 	example openDialogWithSpec.
+	example withWindowDo: [ :window | window title: self name asString , ' example' ].
 	^ example
+]
+
+{ #category : #'*Spec-Examples' }
+LabelledContainer class >> setUpExample: example [
+	example content: ButtonPresenter.
+	example subwidget label: 'I am a button'
 ]

--- a/src/Spec-Examples/LabelledDropList.extension.st
+++ b/src/Spec-Examples/LabelledDropList.extension.st
@@ -3,12 +3,13 @@ Extension { #name : #LabelledDropList }
 { #category : #'*Spec-Examples' }
 LabelledDropList class >> example [
 	<sampleInstance>
-	| example |
-	example := self abstractExample.
-example
+	^ super example
+]
+
+{ #category : #'*Spec-Examples' }
+LabelledDropList class >> setUpExample: example [
+	example
 		items: {'item 1' . 'item 2'};
 		displayBlock: [ :item | item asString ];
-		extent: 400 @ 50;
-		openWithSpec.
-	^ example
+		extent: 400 @ 50
 ]

--- a/src/Spec-Examples/LabelledList.extension.st
+++ b/src/Spec-Examples/LabelledList.extension.st
@@ -3,10 +3,10 @@ Extension { #name : #LabelledList }
 { #category : #'*Spec-Examples' }
 LabelledList class >> example [
 	<sampleInstance>
-	| example |
-	example := self abstractExample.
-	example
-		items: {'item 1' . 'item 2'};
-		openWithSpec.
-	^ example
+	^ super example
+]
+
+{ #category : #'*Spec-Examples' }
+LabelledList class >> setUpExample: example [
+	example items: {'item 1' . 'item 2'}
 ]

--- a/src/Spec-Examples/LabelledSliderInput.extension.st
+++ b/src/Spec-Examples/LabelledSliderInput.extension.st
@@ -3,14 +3,15 @@ Extension { #name : #LabelledSliderInput }
 { #category : #'*Spec-Examples' }
 LabelledSliderInput class >> example [
 	<sampleInstance>
-	| example |
-	example := self new
+	^ super example
+]
+
+{ #category : #'*Spec-Examples' }
+LabelledSliderInput class >> setUpExample: example [
+	example
 		min: 0;
 		max: 250;
 		autoAccept: true;
 		value: 120;
-		extent: 400 @ 50;
-		title: 'LabelledSliderInput example';
-		openWithSpec.
-	^ example
+		extent: 400 @ 50
 ]

--- a/src/Spec-Examples/LabelledTextInput.extension.st
+++ b/src/Spec-Examples/LabelledTextInput.extension.st
@@ -3,11 +3,11 @@ Extension { #name : #LabelledTextInput }
 { #category : #'*Spec-Examples' }
 LabelledTextInput class >> example [
 	<sampleInstance>
-	| example |
-	example := self abstractExample.
+	^ super example
+]
+
+{ #category : #'*Spec-Examples' }
+LabelledTextInput class >> setUpExample: example [
 	example input placeholder: 'Tilt'.
-	example
-		extent: 400 @ 50;
-		openWithSpec.
-	^ example
+	example extent: 400 @ 50
 ]

--- a/src/Spec-Examples/RGBSliders.extension.st
+++ b/src/Spec-Examples/RGBSliders.extension.st
@@ -4,10 +4,10 @@ Extension { #name : #RGBSliders }
 RGBSliders class >> example [
 	<sampleInstance>
 	| example |
-	example := self new.
-	example
-		title: 'RGBSliders example';
+	example := self new
 		extent: 300 @ 200;
-		openDialogWithSpec.
+		openDialogWithSpec;
+		yourself.
+	example withWindowDo: [ :window | window title: 'RGBSliders example' ].
 	^ example
 ]

--- a/src/Spec-Examples/RGBWidget.extension.st
+++ b/src/Spec-Examples/RGBWidget.extension.st
@@ -4,10 +4,10 @@ Extension { #name : #RGBWidget }
 RGBWidget class >> example [
 	<sampleInstance>
 	| example |
-	example := self new.
-	example
-		title: 'RGBWidget exampe';
+	example := self new
 		extent: 300 @ 250;
-		openDialogWithSpec.
+		openDialogWithSpec;
+		yourself.
+	example withWindowDo: [ :window | window title: 'RGBWidget example' ].
 	^ example
 ]

--- a/src/Spec-Examples/SliderInput.extension.st
+++ b/src/Spec-Examples/SliderInput.extension.st
@@ -10,7 +10,7 @@ SliderInput class >> example [
 		autoAccept: true;
 		value: 120;
 		extent: 400 @ 50;
-		title: 'SliderInput example';
 		openWithSpec.
+	example withWindowDo: [ :window | window title: 'SliderInput example' ].
 	^ example
 ]

--- a/src/Spec-PolyWidgets/CalendarPresenter.class.st
+++ b/src/Spec-PolyWidgets/CalendarPresenter.class.st
@@ -124,9 +124,7 @@ CalendarPresenter >> daysToDisplayCount [
 { #category : #initialization }
 CalendarPresenter >> initialize [
 	super initialize.
-	self
-		title: 'Calendar' translated;
-		whenDaySelectedBlock: [ :aDate | ]
+	self whenDaySelectedBlock: [ :aDate |  ]
 ]
 
 { #category : #initialization }
@@ -143,6 +141,11 @@ CalendarPresenter >> initializeWidgets [
 	namesOfDaysLabels := self newNullPresenter.
 	
 	daysButtons := self newNullPresenter
+]
+
+{ #category : #initialization }
+CalendarPresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter title: 'Calendar'
 ]
 
 { #category : #private }

--- a/src/Spec-PolyWidgets/RGBSliders.class.st
+++ b/src/Spec-PolyWidgets/RGBSliders.class.st
@@ -16,7 +16,7 @@ Class {
 		'greenSlider',
 		'blueSlider'
 	],
-	#category : #'Spec-PolyWidgets-Support'
+	#category : #'Spec-PolyWidgets-RGB'
 }
 
 { #category : #specs }

--- a/src/Spec-PolyWidgets/RGBWidget.class.st
+++ b/src/Spec-PolyWidgets/RGBWidget.class.st
@@ -19,7 +19,7 @@ Class {
 		'sliders',
 		'extentForPreview'
 	],
-	#category : #'Spec-PolyWidgets-RGBAndShape'
+	#category : #'Spec-PolyWidgets-RGB'
 }
 
 { #category : #specs }

--- a/src/Spec-Tests/SpecVersatileDialogPresenterTest.class.st
+++ b/src/Spec-Tests/SpecVersatileDialogPresenterTest.class.st
@@ -11,30 +11,30 @@ SpecVersatileDialogPresenterTest >> classToTest [
 
 { #category : #tests }
 SpecVersatileDialogPresenterTest >> testListBox [
-
 	| dialog app listPresenter |
-	
 	app := MockApplication new.
-	
+
 	dialog := SpecVersatileDialogPresenter newApplication: app.
-	dialog title: 'Confirmation'.
 	listPresenter := dialog newList.
 	listPresenter items: #(one two three).
 	dialog contentArea: listPresenter.
-	dialog addButton: #ok text: 'OK' value: #ok condition: [ listPresenter selection isEmpty not ].
+	dialog
+		addButton: #ok
+		text: 'OK'
+		value: #ok
+		condition: [ listPresenter selection isEmpty not ].
 	dialog addButton: #cancel text: 'Cancel' value: nil.
 	dialog mainIcon: (self iconNamed: #question).
 
-	dialog openModalWithSpec. 
-	
+	dialog openModalWithSpec.
+	dialog withWindowDo: [ :w | w title: 'Confirmation' ].
+
 	dialog contentArea selection selectIndex: 2.
 
 	(dialog buttons at: #ok) click.
 
-	self assert: dialog result equals: #ok.	
-	self assert: dialog contentArea selection selectedItem equals: #two.
-	
-
+	self assert: dialog result equals: #ok.
+	self assert: dialog contentArea selection selectedItem equals: #two
 ]
 
 { #category : #tests }
@@ -45,7 +45,6 @@ SpecVersatileDialogPresenterTest >> testResult [
 	app := MockApplication new.
 	
 	dialog := SpecVersatileDialogPresenter newApplication: app.
-	dialog title: 'Confirmation'.
 	dialog mainMessage: 'Save content' asText allBold.
 	dialog addButton: #save text: 'Save' value: true.
 	dialog addButton: #cancel text: 'Cancel' value: false.
@@ -53,6 +52,7 @@ SpecVersatileDialogPresenterTest >> testResult [
 	dialog moreOptionsArea: (dialog newCheckBox label: 'Save header').
 
 	dialog openModalWithSpec. 
+	dialog withWindowDo: [ :w | w title: 'Confirmation' ].
 	(dialog buttons at: #save) performAction.
 	dialog moreOptionsArea click.
 

--- a/src/Spec-Tests/SpecWindowTest.class.st
+++ b/src/Spec-Tests/SpecWindowTest.class.st
@@ -12,13 +12,17 @@ Class {
 
 { #category : #tests }
 SpecWindowTest >> testAboutText [
+	| presenter window |
 	windowPresenter := WindowPresenter new.
 	windowPresenter aboutText: 'test'.
 	self assert: windowPresenter aboutText equals: 'test'.
 	windowPresenter close.
-	
-	windowPresenter := TextPresenter new aboutText: 'test2'.
-	self assert: windowPresenter aboutText equals: 'test2'
+
+	presenter := TextPresenter new.
+	[ window := presenter openWithSpec.
+	presenter withWindowDo: [ :w | w aboutText: 'test2' ].
+	self assert: presenter window aboutText equals: 'test2' ]
+		ensure: [ window ifNotNil: #delete ]
 ]
 
 { #category : #tests }
@@ -39,12 +43,16 @@ SpecWindowTest >> testIsDisplayed [
 
 { #category : #tests }
 SpecWindowTest >> testTitle [
+	| presenter window |
 	windowPresenter := TextPresenter new openWithSpec.
-	
+
 	self assert: windowPresenter isDisplayed.
 	self assert: windowPresenter title equals: 'Text'.
-	
-	windowPresenter title: 'Test Window'.
-	self assert: windowPresenter title equals: 'Test Window'.
-	windowPresenter close
+	windowPresenter close.
+
+	presenter := TextPresenter new.
+	[ window := presenter openWithSpec.
+	presenter withWindowDo: [ :w | w title: 'Test Window' ].
+	self assert: presenter window title equals: 'Test Window' ]
+		ensure: [ window ifNotNil: #delete ]
 ]

--- a/src/Spec-Tools/MessageBrowser.class.st
+++ b/src/Spec-Tools/MessageBrowser.class.st
@@ -283,8 +283,6 @@ MessageBrowser >> handleMethodRemoved: anAnnouncement [
 { #category : #initialization }
 MessageBrowser >> initialize [
 	super initialize.
-	askOkToClose := true asValueHolder.
-	self windowIcon: self taskbarIcon.
 	self registerToAnnouncements.
 	self announcer when: WidgetBuilt send: #buildUpdateTitle to: self
 ]
@@ -320,7 +318,10 @@ MessageBrowser >> initializeWidgets [
 { #category : #initialization }
 MessageBrowser >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter.
-	aWindowPresenter title: self title
+	aWindowPresenter
+		title: self title;
+		windowIcon: self taskbarIcon;
+		askOkToClose: true
 ]
 
 { #category : #private }


### PR DESCRIPTION
Remove call to deprecated methods.

Fixes #564