### PR TITLE
566-TSpecObservable-is-used-by-classes-which-have-a-superclass-already-using-it

### DIFF
--- a/src/Spec-Core/AbstractFormButtonPresenter.class.st
+++ b/src/Spec-Core/AbstractFormButtonPresenter.class.st
@@ -17,8 +17,6 @@ I provide the following methods
 Class {
 	#name : #AbstractFormButtonPresenter,
 	#superclass : #AbstractWidgetPresenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'#actionWhenActivatedHolder',
 		'#state => SpecObservableSlot',

--- a/src/Spec-Core/AthensAnimatedPresenter.class.st
+++ b/src/Spec-Core/AthensAnimatedPresenter.class.st
@@ -1,8 +1,6 @@
 Class {
 	#name : #AthensAnimatedPresenter,
 	#superclass : #AthensStaticPresenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'timeline',
 		'updateBlock'

--- a/src/Spec-Core/AthensStaticPresenter.class.st
+++ b/src/Spec-Core/AthensStaticPresenter.class.st
@@ -1,8 +1,6 @@
 Class {
 	#name : #AthensStaticPresenter,
 	#superclass : #AbstractWidgetPresenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'#drawBlock => SpecObservableSlot',
 		'#surfaceExtent => SpecObservableSlot'

--- a/src/Spec-Core/ComponentListPresenter.class.st
+++ b/src/Spec-Core/ComponentListPresenter.class.st
@@ -4,8 +4,6 @@ I am a list of components ( Widgets :) )
 Class {
 	#name : #ComponentListPresenter,
 	#superclass : #AbstractWidgetPresenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'#presenters => SpecObservableSlot'
 	],

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -86,8 +86,6 @@ It possible to define more than one method to give the possibility to use anothe
 Class {
 	#name : #ComposablePresenter,
 	#superclass : #Presenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'#layout',
 		'#application',
@@ -179,12 +177,6 @@ ComposablePresenter class >> owner: anOwningPresenter on: aDomainObject [
 		setModelBeforeInitialization: aDomainObject;
 		initialize;
 		yourself
-]
-
-{ #category : #'as yet unclassified' }
-ComposablePresenter class >> systemIconName [
-
-	^ #smallWindow
 ]
 
 { #category : #specs }

--- a/src/Spec-Core/ImagePresenter.class.st
+++ b/src/Spec-Core/ImagePresenter.class.st
@@ -9,8 +9,6 @@ I provide the following variables and their accessors
 Class {
 	#name : #ImagePresenter,
 	#superclass : #AbstractWidgetPresenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'#image => SpecObservableSlot',
 		'#action => SpecObservableSlot',

--- a/src/Spec-Core/Presenter.class.st
+++ b/src/Spec-Core/Presenter.class.st
@@ -56,6 +56,12 @@ Presenter class >> owner: anOwningPresenter [
 		yourself
 ]
 
+{ #category : #'as yet unclassified' }
+Presenter class >> systemIconName [
+
+	^ #smallWindow
+]
+
 { #category : #accessing }
 Presenter class >> toolName [
 	"The tool name can be used in some places such as the About window's title."

--- a/src/Spec-Core/TablePresenter.class.st
+++ b/src/Spec-Core/TablePresenter.class.st
@@ -1,8 +1,6 @@
 Class {
 	#name : #TablePresenter,
 	#superclass : #AbstractListPresenter,
-	#traits : 'TSpecObservable',
-	#classTraits : 'TSpecObservable classTrait',
 	#instVars : [
 		'#columns => SpecObservableSlot',
 		'#showColumnHeaders => SpecObservableSlot',

--- a/src/Spec-Core/TreeTablePresenter.class.st
+++ b/src/Spec-Core/TreeTablePresenter.class.st
@@ -9,8 +9,8 @@ self example
 Class {
 	#name : #TreeTablePresenter,
 	#superclass : #AbstractWidgetPresenter,
-	#traits : 'TSpecObservable + TSpecHaveWrappingScrollBars',
-	#classTraits : 'TSpecObservable classTrait + TSpecHaveWrappingScrollBars classTrait',
+	#traits : 'TSpecHaveWrappingScrollBars',
+	#classTraits : 'TSpecHaveWrappingScrollBars classTrait',
 	#instVars : [
 		'#columns',
 		'#showColumnHeaders => SpecObservableSlot',


### PR DESCRIPTION
Subclasses of Presenter do not need to use TSpecObservable.

Fixes #566