### PR TITLE
568-ToolBar-classes-implement-help-mechanism-already-present-in-superclass

### DIFF
--- a/src/Spec-Core/ToolBarButton.class.st
+++ b/src/Spec-Core/ToolBarButton.class.st
@@ -40,32 +40,6 @@ ToolBarButton >> badge: aString [
 	badge := aString
 ]
 
-{ #category : #factory }
-ToolBarButton >> buildMorphOnToolbar: aToolbar [
-	| button |
-	
-	button := (ToolBarButtonMorph
-			on: self 
-			getState: nil 
-			action:  #execute)
-		helpText: self help;
-		font: aToolbar toolbarItemFont;
-		beIconTop;
-		hResizing: #rigid;
-		vResizing: #spaceFill;
-		borderWidth: 0;
-		borderColor: Color transparent;		
-		cellPositioning: #center;
-		width: aToolbar toolbarItemSize;
-		yourself.
-		
-	aToolbar displayMode 
-		configureButton: button 
-		item: self.
-
-	^ button
-]
-
 { #category : #simulating }
 ToolBarButton >> click [
 	
@@ -75,16 +49,6 @@ ToolBarButton >> click [
 { #category : #execution }
 ToolBarButton >> execute [
 	self action cull: self
-]
-
-{ #category : #accessing }
-ToolBarButton >> help [
-	^ help
-]
-
-{ #category : #accessing }
-ToolBarButton >> help: anObject [
-	help := anObject
 ]
 
 { #category : #accessing }

--- a/src/Spec-Core/ToolBarButton.class.st
+++ b/src/Spec-Core/ToolBarButton.class.st
@@ -8,8 +8,7 @@ Class {
 		'label',
 		'icon',
 		'action',
-		'badge',
-		'help'
+		'badge'
 	],
 	#category : #'Spec-Core-Widgets-Toolbar'
 }

--- a/src/Spec-Core/ToolBarItemPresenter.class.st
+++ b/src/Spec-Core/ToolBarItemPresenter.class.st
@@ -6,9 +6,3 @@ Class {
 	#superclass : #AbstractWidgetPresenter,
 	#category : #'Spec-Core-Widgets-Toolbar'
 }
-
-{ #category : #factory }
-ToolBarItemPresenter >> buildMorphOnToolbar: aToolbar [
-
-	self subclassResponsibility
-]

--- a/src/Spec-Core/ToolBarLabel.class.st
+++ b/src/Spec-Core/ToolBarLabel.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #ToolBarLabel,
 	#superclass : #ToolBarItemPresenter,
 	#instVars : [
-		'help',
 		'contents'
 	],
 	#category : #'Spec-Core-Widgets-Toolbar'
@@ -17,14 +16,6 @@ ToolBarLabel class >> adapterName [
 	^ #ToolBarLabelAdapter
 ]
 
-{ #category : #factory }
-ToolBarLabel >> buildMorphOnToolbar: aToolbar [
-
-	^ (LabelMorph contents: contents)
-		setBalloonText: help;
-		yourself
-]
-
 { #category : #accessing }
 ToolBarLabel >> contents [
 	^ contents
@@ -33,14 +24,4 @@ ToolBarLabel >> contents [
 { #category : #accessing }
 ToolBarLabel >> contents: anObject [
 	contents := anObject
-]
-
-{ #category : #accessing }
-ToolBarLabel >> help [
-	^ help
-]
-
-{ #category : #accessing }
-ToolBarLabel >> help: anObject [
-	help := anObject
 ]

--- a/src/Spec-Core/ToolBarOptionButtonGroup.class.st
+++ b/src/Spec-Core/ToolBarOptionButtonGroup.class.st
@@ -29,29 +29,6 @@ ToolBarOptionButtonGroup >> addOption: anOption [
 	anOption buttonGroup: self.
 ]
 
-{ #category : #factory }
-ToolBarOptionButtonGroup >> buildMorphOnToolbar: aToolbar [
-
-	| groupbox |
-	groupbox := PanelMorph new 
-		changeTableLayout;
-		listDirection: #leftToRight;
-		hResizing: #spaceFill;
-		vResizing: #spaceFill.
-	options doWithIndex: [ :each :index | | optionMorph |
-		optionMorph := each buildMorphOnToolbar: aToolbar.
-		groupbox addMorphBack: optionMorph
-	].
-	groupbox
-		hResizing: #rigid;
-		vResizing: #spaceFill;
-		"borderWidth: 1;"
-		borderStyle: (Smalltalk ui theme buttonNormalBorderStyleFor: groupbox);
-		cellPositioning: #center;
-		width: aToolbar toolbarItemSize * options size.
-	^ groupbox
-]
-
 { #category : #initialization }
 ToolBarOptionButtonGroup >> initialize [
 	super initialize.

--- a/src/Spec-Core/ToolBarToggleButton.class.st
+++ b/src/Spec-Core/ToolBarToggleButton.class.st
@@ -28,32 +28,6 @@ ToolBarToggleButton >> beUnselected [
 	self setSelection: false
 ]
 
-{ #category : #factory }
-ToolBarToggleButton >> buildMorphOnToolbar: aToolbar [
-	| button |
-
-	button := (ITToggleButtonMorph
-			on: self 
-			getState: #isSelected
-			action: #execute:)
-		helpText: self help;
-		font: aToolbar toolbarItemFont;
-		beIconTop;
-		hResizing: #rigid;
-		vResizing: #spaceFill;
-		borderWidth: 0;
-		borderColor: Color transparent;		
-		cellPositioning: #center;
-		width: aToolbar toolbarItemSize;
-		yourself.
-		
-	aToolbar displayMode 
-		configureButton: button 
-		item: self.
-
-	^ button
-]
-
 { #category : #execution }
 ToolBarToggleButton >> execute: state [
 


### PR DESCRIPTION
Remove useless methods and variables.

Fixes #568