### PR TITLE
575-autoScale-in-ImagePresenter-not-changeable

### DIFF
--- a/src/Spec-BackendTests/ImageAdapterTest.class.st
+++ b/src/Spec-BackendTests/ImageAdapterTest.class.st
@@ -19,6 +19,15 @@ ImageAdapterTest >> imageForm [
 ]
 
 { #category : #building }
+ImageAdapterTest >> testAutoscale [
+	self presenter autoScale: false.
+	self deny: self adapter hasImageAutoscaled.
+	self presenter autoScale: true.
+	self assert: self adapter hasImageAutoscaled.
+
+]
+
+{ #category : #building }
 ImageAdapterTest >> testSettingAnImageSetsTheImage [
 
 	self presenter image: self imageForm.

--- a/src/Spec-Core/ImagePresenter.class.st
+++ b/src/Spec-Core/ImagePresenter.class.st
@@ -37,8 +37,12 @@ ImagePresenter >> action: aBlock [
 
 { #category : #api }
 ImagePresenter >> autoScale [
-
 	^ autoScale
+]
+
+{ #category : #api }
+ImagePresenter >> autoScale: aBoolean [
+	autoScale := aBoolean
 ]
 
 { #category : #api }
@@ -70,6 +74,11 @@ ImagePresenter >> initialize [
 ImagePresenter >> switchAutoscale [
 	autoScale := autoScale not.
 
+]
+
+{ #category : #events }
+ImagePresenter >> whenAutoScaleChangeDo: aBlockClosure [
+	self property: #autoScale whenChangedDo: aBlockClosure
 ]
 
 { #category : #events }

--- a/src/Spec-MorphicAdapters/MorphicImageAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicImageAdapter.class.st
@@ -32,10 +32,9 @@ MorphicImageAdapter >> buildWidget [
 		setBalloonText: self help;
 		update: #getImage.
 
-	self model whenImageChangeDo: [ 
-		self getImage
-			ifNotNil: [ :x | alphaImage image: x ]
-			ifNil: [ alphaImage image: (Form extent: 1 @ 1 depth: 32) ] ].
+	self model
+		whenImageChangeDo: [ alphaImage image: (self getImage ifNil: [ Form extent: 1 @ 1 depth: 32 ]) ];
+		whenAutoScaleChangeDo: [ widget layout: self layoutValue ].
 
 	^ alphaImage
 ]

--- a/src/Spec-MorphicBackendTests/MorphicImageAdapter.extension.st
+++ b/src/Spec-MorphicBackendTests/MorphicImageAdapter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #MorphicImageAdapter }
+
+{ #category : #'*Spec-MorphicBackendTests' }
+MorphicImageAdapter >> hasImageAutoscaled [
+	^ self widget layout = #scaledAspect
+]

--- a/src/Spec-Tests/ImagePresenterTest.class.st
+++ b/src/Spec-Tests/ImagePresenterTest.class.st
@@ -10,6 +10,19 @@ ImagePresenterTest >> classToTest [
 ]
 
 { #category : #tests }
+ImagePresenterTest >> testAutoScale [
+	| count result |
+	count := 0.
+	presenter
+		whenAutoScaleChangeDo: [ :value | 
+			result := value.
+			count := count + 1 ].
+	presenter autoScale: true.
+	self assert: count equals: 1.
+	self assert: result
+]
+
+{ #category : #tests }
 ImagePresenterTest >> testSwitchAutoScale [
 	| autoState |
 	autoState := presenter autoScale.


### PR DESCRIPTION
Add tests + image presenter should update when we change the autoscale parameter.

Fixes #575