### PR TITLE
597-Remove-extensions-methods-that-are-now-in-Pharo-8

### DIFF
--- a/src/Spec2-Pharo7To8Compatibility/FTBasicItem.extension.st
+++ b/src/Spec2-Pharo7To8Compatibility/FTBasicItem.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #FTBasicItem }
 
-{ #category : #'*Spec2-Adapters-Morphic' }
+{ #category : #'*Spec2-Pharo7To8Compatibility' }
 FTBasicItem >> expandedChildren [
 	self isExpanded ifFalse: [ ^ { self } ].
 	^ {self} , (self children flatCollect: [ :e | e expandedChildren ])
 ]
 
-{ #category : #'*Spec2-Adapters-Morphic' }
+{ #category : #'*Spec2-Pharo7To8Compatibility' }
 FTBasicItem >> withExpandedChildren [
 	^ self expandedChildren
 ]

--- a/src/Spec2-Pharo7To8Compatibility/LayoutFrame.extension.st
+++ b/src/Spec2-Pharo7To8Compatibility/LayoutFrame.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #LayoutFrame }
 
-{ #category : #'*Spec2-Adapters-Morphic' }
+{ #category : #'*Spec2-Pharo7To8Compatibility' }
 LayoutFrame >> isHorizontallyResizeable [
 
 	^ self rightFraction ~= self leftFraction
 ]
 
-{ #category : #'*Spec2-Adapters-Morphic' }
+{ #category : #'*Spec2-Pharo7To8Compatibility' }
 LayoutFrame >> isVerticallyResizeable [
 
 	^ self bottomFraction ~= self topFraction


### PR DESCRIPTION
Move extensions methods that are now in Pharo directly in the compatibility package.

Fixes #597