### PR TITLE
599-Finish-cleaning-of-modal-

### DIFF
--- a/src/Spec2-Adapters-Morphic/Morph.extension.st
+++ b/src/Spec2-Adapters-Morphic/Morph.extension.st
@@ -31,30 +31,6 @@ Morph >> heightToDisplayInTree: aTree [
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-Morph >> setModal: aSystemWindow [
-	|area mySysWin keyboardFocus|
-
-	keyboardFocus := self activeHand keyboardFocus.
-	mySysWin := self isSystemWindow ifTrue: [self] ifFalse: [self ownerThatIsA: SystemWindow].
-	mySysWin ifNil: [mySysWin := self].
-	mySysWin modalLockTo: aSystemWindow.
-	area := RealEstateAgent maximumUsableArea.
-	aSystemWindow extent: aSystemWindow initialExtent.
-	aSystemWindow position = (0@0)
-		ifTrue: [aSystemWindow
-				position: self activeHand position - (aSystemWindow extent // 2)].
-	aSystemWindow
-		bounds: (aSystemWindow bounds translatedToBeWithin: area).
-	[ |aWidget | 
-	aWidget := aSystemWindow.
-	[aWidget world notNil] whileTrue: [
-		aWidget outermostWorldMorph doOneCycle]]
-		ensure: [mySysWin modalUnlockFrom: aSystemWindow.
-				self activeHand newKeyboardFocus: keyboardFocus].
-	^aSystemWindow
-]
-
-{ #category : #'*Spec2-Adapters-Morphic' }
 Morph >> treeRenderOn: aCanvas bounds: drawBounds color: drawColor font: aFont from: aMorph [
 
 	self bounds: drawBounds.

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
@@ -368,12 +368,6 @@ SpAbstractMorphicAdapter >> setBalloonText: aString [
 	self widget ifNotNil: [ :w | w setBalloonText: aString ]
 ]
 
-{ #category : #'spec protocol' }
-SpAbstractMorphicAdapter >> setModal: aWindow [ 
-
-	self widgetDo: [ :w | w setModal: aWindow ]
-]
-
 { #category : #protocol }
 SpAbstractMorphicAdapter >> show [ 
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
@@ -190,12 +190,6 @@ SpMorphicWindowAdapter >> minimize [
 	self widgetDo: [ :w | w minimize ]
 ]
 
-{ #category : #'spec protocol' }
-SpMorphicWindowAdapter >> modalRelativeTo: aWindow [
-
-	self widgetDo: [ :w | aWindow setModal: w ]
-]
-
 { #category : #private }
 SpMorphicWindowAdapter >> newContainerMorph [
 		

--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -335,12 +335,6 @@ SpWindowPresenter >> minimize [
 	self changed: #minimize with: #()
 ]
 
-{ #category : #api }
-SpWindowPresenter >> modalRelativeTo: aWindow [
-
-	self changed: #modalRelativeTo: with: { aWindow }
-]
-
 { #category : #notifying }
 SpWindowPresenter >> notify: aSpecNotification [
 	"Receives a notification and delivers it as required"

--- a/src/Spec2-Deprecated/Morph.extension.st
+++ b/src/Spec2-Deprecated/Morph.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #Morph }
+
+{ #category : #'*Spec2-Deprecated' }
+Morph >> spSetModal: aSystemWindow [
+	|area mySysWin keyboardFocus|
+
+	keyboardFocus := self activeHand keyboardFocus.
+	mySysWin := self isSystemWindow ifTrue: [self] ifFalse: [self ownerThatIsA: SystemWindow].
+	mySysWin ifNil: [mySysWin := self].
+	mySysWin modalLockTo: aSystemWindow.
+	area := RealEstateAgent maximumUsableArea.
+	aSystemWindow extent: aSystemWindow initialExtent.
+	aSystemWindow position = (0@0)
+		ifTrue: [aSystemWindow
+				position: self activeHand position - (aSystemWindow extent // 2)].
+	aSystemWindow
+		bounds: (aSystemWindow bounds translatedToBeWithin: area).
+	[ |aWidget | 
+	aWidget := aSystemWindow.
+	[aWidget world notNil] whileTrue: [
+		aWidget outermostWorldMorph doOneCycle]]
+		ensure: [mySysWin modalUnlockFrom: aSystemWindow.
+				self activeHand newKeyboardFocus: keyboardFocus].
+	^aSystemWindow
+]

--- a/src/Spec2-Deprecated/SpAbstractMorphicAdapter.extension.st
+++ b/src/Spec2-Deprecated/SpAbstractMorphicAdapter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpAbstractMorphicAdapter }
+
+{ #category : #'*Spec2-Deprecated' }
+SpAbstractMorphicAdapter >> setModal: aWindow [ 
+
+	self widgetDo: [ :w | w spSetModal: aWindow ]
+]

--- a/src/Spec2-Deprecated/SpMorphicWindowAdapter.extension.st
+++ b/src/Spec2-Deprecated/SpMorphicWindowAdapter.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #SpMorphicWindowAdapter }
+
+{ #category : #'*Spec2-Deprecated' }
+SpMorphicWindowAdapter >> modalRelativeTo: aWindow [
+	self deprecated: 'Do not use this directly. Use #openModalWithSpec (and family) instead.' on: '2019-02-26' in: #Pharo8.
+
+	self widgetDo: [ :w | aWindow spSetModal: w ]
+]

--- a/src/Spec2-Deprecated/SpWindowPresenter.extension.st
+++ b/src/Spec2-Deprecated/SpWindowPresenter.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #SpWindowPresenter }
 
 { #category : #'*Spec2-Deprecated' }
+SpWindowPresenter >> modalRelativeTo: aWindow [
+	self deprecated: 'Do not use this directly. Use #openModalWithSpec (and family) instead.' on: '2019-02-26' in: #Pharo8.
+
+	self changed: #modalRelativeTo: with: {aWindow}
+]
+
+{ #category : #'*Spec2-Deprecated' }
 SpWindowPresenter >> model [
 	self deprecated: 'Model was renamed Presenter in Pharo 7' transformWith: '`@receiver model' -> '`@receiver presenter'.
 	

--- a/src/Spec2-Examples/SpDatePresenter.extension.st
+++ b/src/Spec2-Examples/SpDatePresenter.extension.st
@@ -9,5 +9,5 @@ SpDatePresenter class >> example [
 { #category : #'*Spec2-Examples' }
 SpDatePresenter class >> exampleModal [
 	<sampleInstance>
-	^ self new openDialogWithSpec modalRelativeTo: self currentWorld
+	^ self new openModalWithSpec
 ]


### PR DESCRIPTION
Move everything related to #setModal: in deprecated.

+ Rename conflicting extensions.

Fixes #599