### PR TITLE
53-Adapters-bindings-default-fonts-methods-are-not-used

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicAdapterBindings.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicAdapterBindings.class.st
@@ -11,9 +11,3 @@ Class {
 SpMorphicAdapterBindings >> abstractAdapterClass [
 	^ SpAbstractMorphicAdapter
 ]
-
-{ #category : #fonts }
-SpMorphicAdapterBindings >> defaultFont [
-
-	^ StandardFonts defaultFont
-]

--- a/src/Spec2-Adapters-Stub/SpStubAdapterBindings.class.st
+++ b/src/Spec2-Adapters-Stub/SpStubAdapterBindings.class.st
@@ -19,9 +19,3 @@ Class {
 SpStubAdapterBindings >> abstractAdapterClass [
 	^ SpStubAbstractAdapter
 ]
-
-{ #category : #font }
-SpStubAdapterBindings >> defaultFont [
-
-	^ StubFixedFont new
-]


### PR DESCRIPTION
Remove #defaultFont on adapter bindings.

Fixes #53