### PR TITLE
643-Use-the-direction-strategy-instead-of-performs-in-paned-layout

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpLayoutDirection.extension.st
+++ b/src/Spec2-Adapters-Morphic/SpLayoutDirection.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #SpLayoutDirection }
 
 { #category : #'*Spec2-Adapters-Morphic' }
+SpLayoutDirection >> newSplitter [
+	^ self subclassResponsibility
+]
+
+{ #category : #'*Spec2-Adapters-Morphic' }
 SpLayoutDirection >> setRigidityOfNonExpendedMorph: aMorph [ 
 	self subclassResponsibility
 ]

--- a/src/Spec2-Adapters-Morphic/SpLayoutDirectionHorizontal.extension.st
+++ b/src/Spec2-Adapters-Morphic/SpLayoutDirectionHorizontal.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #SpLayoutDirectionHorizontal }
 
 { #category : #'*Spec2-Adapters-Morphic' }
+SpLayoutDirectionHorizontal >> newSplitter [
+	^ SpPanedResizerMorph newHorizontal
+]
+
+{ #category : #'*Spec2-Adapters-Morphic' }
 SpLayoutDirectionHorizontal >> setRigidityOfNonExpendedMorph: aMorph [ 
 	aMorph 
 		vResizing: #spaceFill; 

--- a/src/Spec2-Adapters-Morphic/SpLayoutDirectionVertical.extension.st
+++ b/src/Spec2-Adapters-Morphic/SpLayoutDirectionVertical.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #SpLayoutDirectionVertical }
 
 { #category : #'*Spec2-Adapters-Morphic' }
+SpLayoutDirectionVertical >> newSplitter [
+	^ SpPanedResizerMorph newVertical
+]
+
+{ #category : #'*Spec2-Adapters-Morphic' }
 SpLayoutDirectionVertical >> setRigidityOfNonExpendedMorph: aMorph [ 
 	aMorph 
 		hResizing: #spaceFill; 

--- a/src/Spec2-Adapters-Morphic/SpMorphicPanedAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicPanedAdapter.class.st
@@ -25,9 +25,9 @@ SpMorphicPanedAdapter >> addConstraits: constraints toChild: childMorph [
 
 { #category : #private }
 SpMorphicPanedAdapter >> addSplitterIn: aPanel for: childMorph [
-	
+
 	aPanel submorphs size = 1 ifFalse: [ ^ self ].
-	aPanel addMorphBack: (SpPanedResizerMorph perform: self selector)
+	aPanel addMorphBack: self direction newSplitter
 ]
 
 { #category : #private }


### PR DESCRIPTION
Do not use perform to create new splitters.

Fixes #643