### PR TITLE
Did some renaming to remove typos from method names.

### DIFF
--- a/src/Spec2-Commander2/SpCommandGroup.class.st
+++ b/src/Spec2-Commander2/SpCommandGroup.class.st
@@ -64,14 +64,14 @@ SpCommandGroup >> asMenuPresenterWith: aBlock [
 ]
 
 { #category : #converting }
-SpCommandGroup >> asToolBarPresenter [
+SpCommandGroup >> asToolbarPresenter [
 	^ SpToolBarPresenterBuilder new
 		visit: self;
 		toolbarPresenter
 ]
 
 { #category : #converting }
-SpCommandGroup >> asToolBarPresenterWith: aBlock [
+SpCommandGroup >> asToolbarPresenterWith: aBlock [
 	| builder |
 	
 	builder := SpToolBarPresenterBuilder new.

--- a/src/Spec2-Deprecated/SpCommandGroup.extension.st
+++ b/src/Spec2-Deprecated/SpCommandGroup.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #SpCommandGroup }
+
+{ #category : #'*Spec2-Deprecated' }
+SpCommandGroup >> asToolBarPresenter [
+	self
+		deprecated: 'Use #asToolbarPresenter instead.'
+		transformWith: '`@receiver asToolBarPresenter' -> '`@receiver asToolbarPresenter'.
+	^ self asToolbarPresenter
+]
+
+{ #category : #'*Spec2-Deprecated' }
+SpCommandGroup >> asToolBarPresenterWith: aBlock [
+	self
+		deprecated: 'Use #asToolbarPresenterWith: instead.'
+		transformWith: '`@receiver asToolBarPresenterWith: `@arg' -> '`@receiver asToolbarPresenterWith: `@arg'.
+	
+	^ self asToolbarPresenterWith: aBlock
+]


### PR DESCRIPTION
Fix #694 

- Renamed #asToolBarPresenter -> #asToolbarPresenter with deprecation to ease migration.
- Renamed #asToolBarPresenterWith: -> #asToolbarPresenterWith: with deprecation to ease migration.