### PR TITLE
704-Commander2-should-provide-easier-way-to-use-command-group-on-list-tree-etc

### DIFF
--- a/src/Spec2-Commander2-ContactBook/SpContactBookPresenter.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpContactBookPresenter.class.st
@@ -99,11 +99,11 @@ SpContactBookPresenter >> initializeWidgets [
 		addColumn: (SpStringTableColumn title: 'Name' evaluated: #name);
 		addColumn: (SpStringTableColumn title: 'Phone' evaluated: #phone).
 	
-	table contextMenu: [ (self rootCommandsGroup / 'Context Menu') beRoot asMenuPresenter ].
+	table contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'Context Menu' ].
 	
 	table items: contactBook contents.
 	
-	menuBar := (self rootCommandsGroup / 'MenuBar')  asMenuBarPresenter.
+	menuBar := (self rootCommandsGroup / 'MenuBar') asMenuBarPresenter.
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Commander2/SpAbstractListPresenter.extension.st
+++ b/src/Spec2-Commander2/SpAbstractListPresenter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #SpAbstractListPresenter }
+
+{ #category : #'*Spec2-Commander2' }
+SpAbstractListPresenter >> contextMenuFromCommandsGroup: aValuable [
+	self contextMenu: [ aValuable value beRoot asMenuPresenter ]
+]

--- a/src/Spec2-Commander2/SpAbstractTextPresenter.extension.st
+++ b/src/Spec2-Commander2/SpAbstractTextPresenter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #SpAbstractTextPresenter }
+
+{ #category : #'*Spec2-Commander2' }
+SpAbstractTextPresenter >> contextMenuFromCommandsGroup: aValuable [
+	self contextMenu: [ aValuable value beRoot asMenuPresenter ]
+]

--- a/src/Spec2-Commander2/SpButtonPresenter.extension.st
+++ b/src/Spec2-Commander2/SpButtonPresenter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #SpButtonPresenter }
+
+{ #category : #'*Spec2-Commander2' }
+SpButtonPresenter >> contextMenuFromCommandsGroup: aValuable [
+	self contextMenu: [ aValuable value beRoot asMenuPresenter ]
+]

--- a/src/Spec2-Commander2/SpTreeTablePresenter.extension.st
+++ b/src/Spec2-Commander2/SpTreeTablePresenter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #SpTreeTablePresenter }
+
+{ #category : #'*Spec2-Commander2' }
+SpTreeTablePresenter >> contextMenuFromCommandsGroup: aValuable [
+	self contextMenu: [ aValuable value beRoot asMenuPresenter ]
+]


### PR DESCRIPTION
Introduced #contextMenuFromCommandsGroup: method that wrap the repetitive code required to convert a group of command as a MenuPresenter.

Fix #704 