### PR TITLE
717-Fix-calls-to-canBeRun-and-replace-them-with-canBeExecuted

### DIFF
--- a/src/Spec2-Commander2/SpDisableWhenCantBeRun.class.st
+++ b/src/Spec2-Commander2/SpDisableWhenCantBeRun.class.st
@@ -12,6 +12,6 @@ SpDisableWhenCantBeRun >> display: aCmSpecCommand in: aMenuOrGroupPresenter do: 
 	aMenuOrGroupPresenter
 		addItem: [ :item |
 			aBlock value: item.
-			item enabled: aCmSpecCommand canBeRun.
+			item enabled: aCmSpecCommand canBeExecuted.
 			item ]
 ]

--- a/src/Spec2-Commander2/SpHideWhenCantBeRun.class.st
+++ b/src/Spec2-Commander2/SpHideWhenCantBeRun.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #displaying }
 SpHideWhenCantBeRun >> display: aCmSpecCommand in: aMenuOrGroupPresenter do: aBlock [
-	aCmSpecCommand canBeRun "If can not be run, stop because we want to hide the command."
+	aCmSpecCommand canBeExecuted "If can not be run, stop because we want to hide the command."
 		ifFalse: [ ^ self ].
 	aMenuOrGroupPresenter
 		addItem: [ :item |

--- a/src/Spec2-Commander2/SpShortcutInstaller.class.st
+++ b/src/Spec2-Commander2/SpShortcutInstaller.class.st
@@ -26,6 +26,6 @@ SpShortcutInstaller >> visitCommand: aCmCommand [
 		ifFalse: [ ^ self ].
 	self presenter
 		bindKeyCombination: aCmCommand shortcutKey
-		toAction: [ aCmCommand canBeRun
+		toAction: [ aCmCommand canBeExecuted
 				ifTrue: [ aCmCommand execute ] ]
 ]


### PR DESCRIPTION
Replaced #canBeRun with #canBeExecuted.

Fixes #717