### PR TITLE
716-Allows-one-to-change-the-default-context-set-on-commands-when-their-context-is-nil

### DIFF
--- a/src/Spec2-Commander2/SpPresenter.extension.st
+++ b/src/Spec2-Commander2/SpPresenter.extension.st
@@ -26,6 +26,14 @@ SpPresenter class >> buildRootCommandsGroupFor: presenterInstance [
 ]
 
 { #category : #'*Spec2-Commander2' }
+SpPresenter >> defaultCommandsContext [
+	"The default context set to commands is the presenter itself.
+	 This method might be overriden to change this behaviour.
+	"
+	^ self
+]
+
+{ #category : #'*Spec2-Commander2' }
 SpPresenter >> rootCommandsGroup [
-	^ SpRecursiveContextSetter visit: (self class buildRootCommandsGroupFor: self) toSetContext: self
+	^ SpRecursiveContextSetter visit: (self class buildRootCommandsGroupFor: self defaultCommandsContext) toSetContext: self defaultCommandsContext
 ]


### PR DESCRIPTION
Created #defaultCommandsContext that returns the presenter.
Can be overidden to change the default context set recursively to commands.Fixes #716