### PR TITLE
720-Implement-method-to-convert-spec-command-as-ButtonPresenter

### DIFF
--- a/src/Spec2-Commander2-Tests/SpCommandTest.class.st
+++ b/src/Spec2-Commander2-Tests/SpCommandTest.class.st
@@ -28,6 +28,54 @@ SpCommandTest >> setUp [
 ]
 
 { #category : #test }
+SpCommandTest >> testAsButtonPresenter [
+	| buttonPresenter |
+	command := CmCommand forSpec
+					basicName: 'foo';
+					basicDescription: 'bar';
+					yourself.
+					
+	
+	buttonPresenter := command asButtonPresenter.
+	
+	self assert: buttonPresenter label equals: 'foo'.
+	self assert: buttonPresenter help equals: 'bar'.
+	self assert: buttonPresenter icon isNil
+]
+
+{ #category : #test }
+SpCommandTest >> testAsButtonPresenter2 [
+	| buttonPresenter |
+	command := CmCommand forSpec
+					basicName: 'foo';
+					basicDescription: 'bar';
+					iconName: #blank;
+					yourself.
+					
+	
+	buttonPresenter := command asButtonPresenter.
+	
+	self assert: buttonPresenter label equals: 'foo'.
+	self assert: buttonPresenter help equals: 'bar'.
+	self assert: buttonPresenter icon equals: (buttonPresenter iconNamed: #blank)
+]
+
+{ #category : #test }
+SpCommandTest >> testAsButtonPresenterExecutesOnClick [
+	| flag buttonPresenter |
+	flag := false.
+	command := CmBlockCommand new
+					block: [ flag := true ];
+					yourself.
+	
+	buttonPresenter := command asSpecCommand asButtonPresenter.
+	
+	buttonPresenter click.
+	
+	self assert: flag equals: true
+]
+
+{ #category : #test }
 SpCommandTest >> testHasIcon [
 	self deny: command hasIcon.
 	

--- a/src/Spec2-Commander2/SpCommand.class.st
+++ b/src/Spec2-Commander2/SpCommand.class.st
@@ -4,6 +4,9 @@ I am a command decorator adding informations useful when for usage in context of
 Basically, I add:
 - an #icon (#blank by default)
 - a #shortcutKey (optional)
+- a #displayStrategy to handle how to show the command if it is not executable on a context (default is to be disabled)
+- a actionBarStrategy to handle on which side of the action bar I should be (default is left)
+
 "
 Class {
 	#name : #SpCommand,
@@ -12,10 +15,25 @@ Class {
 		'iconProvider',
 		'iconName',
 		'shortcutKey',
-		'displayStrategy'
+		'displayStrategy',
+		'actionBarStrategy'
 	],
 	#category : #'Spec2-Commander2-Core'
 }
+
+{ #category : #converting }
+SpCommand >> asButtonPresenter [
+	self flag: #TODO. "Needs to use inform user display strategy when available, no other available strategy can be used in this context. See issue #705"
+	^ SpButtonPresenter new
+		label: self name;
+		help: self description;
+		in: [ :button |
+			self hasIcon
+				ifTrue: [ button iconName: self iconName ] ];
+		action: [ self execute ]
+		yourself
+		
+]
 
 { #category : #configuring }
 SpCommand >> beDisabledWhenCantBeRun [


### PR DESCRIPTION
Created #asButtonPresenter and tests.The implementation does not handle when command can not be executed yet because the required strategy does not exist yet.This will be done later.Fixes #720