### PR TITLE
724-Move-spec-related-methods-on-class-side-of-CmCommand-and-CmCommandGroup-to-spec-integration-package

### DIFF
--- a/src/Spec2-Commander2/CmCommand.extension.st
+++ b/src/Spec2-Commander2/CmCommand.extension.st
@@ -27,3 +27,28 @@ CmCommand >> asSpecCommandWithShortcutKey: aKMKeyCombination [
 		shortcutKey: aKMKeyCombination;
 		yourself
 ]
+
+{ #category : #'*Spec2-Commander2' }
+CmCommand class >> forSpec [
+	^ self new
+		asSpecCommand
+]
+
+{ #category : #'*Spec2-Commander2' }
+CmCommand class >> forSpecContext: anObject [
+
+	^ self forSpec 
+	context: anObject;
+	yourself
+]
+
+{ #category : #'*Spec2-Commander2' }
+CmCommand class >> forSpecWithIconNamed: aSymbol [
+	^ self new asSpecCommandWithIconNamed: aSymbol
+]
+
+{ #category : #'*Spec2-Commander2' }
+CmCommand class >> forSpecWithIconNamed: aSymbol shortcutKey: aKMKeyCombination [
+	^ self new
+		asSpecCommandWithIconNamed: aSymbol shortcutKey: aKMKeyCombination
+]

--- a/src/Spec2-Commander2/CmCommandGroup.extension.st
+++ b/src/Spec2-Commander2/CmCommandGroup.extension.st
@@ -12,3 +12,13 @@ CmCommandGroup >> asSpecGroupWithIconNamed: aSymbol [
 		iconName: aSymbol;
 		yourself
 ]
+
+{ #category : #'*Spec2-Commander2' }
+CmCommandGroup class >> forSpec [
+	^ self new asSpecGroup
+]
+
+{ #category : #'*Spec2-Commander2' }
+CmCommandGroup class >> forSpecWithIconNamed: aSymbol [
+	^ self new asSpecGroupWithIconNamed: aSymbol
+]


### PR DESCRIPTION
Did the move, these methods are not in Commander2 repository anymore.

Fixes #724