### PR TITLE
730-TextPresenter-placeholder-does-not-work-in-Pharo-7

### DIFF
--- a/src/Spec2-Pharo7To8Compatibility/SpRubScrolledTextMorph.class.st
+++ b/src/Spec2-Pharo7To8Compatibility/SpRubScrolledTextMorph.class.st
@@ -27,6 +27,21 @@ SpRubScrolledTextMorph >> canDiscardEdits [
 ]
 
 { #category : #accessing }
+SpRubScrolledTextMorph >> ghostText [
+	^ (self rulerNamed: #ghostText) ghostText text
+]
+
+{ #category : #accessing }
+SpRubScrolledTextMorph >> ghostText: aText [
+	self withGhostText: aText
+]
+
+{ #category : #accessing }
+SpRubScrolledTextMorph >> ghostTextRuler [
+	^ self rulerNamed: #ghostText
+]
+
+{ #category : #accessing }
 SpRubScrolledTextMorph >> initialize [
 	askBeforeDiscardingEdits := true.
 	super initialize


### PR DESCRIPTION
Compatibility for Pharo 7 with TextPresenter 

FIxes #730