### PR TITLE
647-Use-theme-instead-of-hardcoded-color-in-Modal-adapter

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicModalWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicModalWindowAdapter.class.st
@@ -38,7 +38,7 @@ SpMorphicModalWindowAdapter >> open [
 	self model windowIsOpening.
 
 	backdropMorph := FullscreenMorph new
-		color: (Color black alpha: 0.7);
+		color: self theme modalBackdropColor;
 		on: #click send: #mouseClick:onBackdrop: to: self;
 		openInWorld;
 		yourself.

--- a/src/Spec2-Adapters-Morphic/UITheme.extension.st
+++ b/src/Spec2-Adapters-Morphic/UITheme.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #UITheme }
+
+{ #category : #'*Spec2-Adapters-Morphic' }
+UITheme >> modalBackdropColor [
+	self flag: #pharoTodo. "This method should probably be moved to Pharo later."
+
+	^ Color black alpha: 0.7
+]

--- a/src/Spec2-Examples/SpDemo.class.st
+++ b/src/Spec2-Examples/SpDemo.class.st
@@ -119,7 +119,7 @@ SpDemo >> initializeWidgets [
 
 	list
 		items: self availablePages;
-		displayBlock: [ :item | item pageName ];
+		display: [ :item | item pageName ];
 		contextMenu:
 			(self newMenu
 				addItem: [ :item | 

--- a/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
@@ -209,7 +209,6 @@ SpDemoStandaloneFormPresenter >> initializePresenter [
 
 { #category : #initialization }
 SpDemoStandaloneFormPresenter >> initializeWidgets [
-
 	nameLabel := self newLabel label: 'name:'.
 	nameTextInput := self newTextInput autoAccept: true.
 
@@ -220,7 +219,13 @@ SpDemoStandaloneFormPresenter >> initializeWidgets [
 	number1Input := self newNumberInput autoAccept: true.
 
 	number2Label := self newLabel label: 'number 2:'.
-	number2Input := self newNumberInput autoAccept: true; beFloat; digits: 3; climbRate: 0.005; minimum: 10.005; maximum: 20.05.
+	number2Input := self newNumberInput
+		autoAccept: true;
+		beFloat;
+		digits: 3;
+		climbRate: 0.005;
+		minimum: 10.005;
+		maximum: 20.05.
 
 	scaleLabel := self newLabel label: 'scale:'.
 	scaleInput := self newSlider.
@@ -234,16 +239,13 @@ SpDemoStandaloneFormPresenter >> initializeWidgets [
 
 	dateLabel := self newLabel label: 'date:'.
 	dateInput := self instantiate: SpDatePresenter.
-	dateInput displayBlock: [ :item | item yyyymmdd ].
-	
-	maleButton := self newRadioButton label: 'male'. 
+	dateInput display: [ :item | item yyyymmdd ].
+
+	maleButton := self newRadioButton label: 'male'.
 	femaleButton := self newRadioButton label: 'female'.
-	maleButton associatedRadioButtons: { femaleButton }.
-	genderButtons := Dictionary newFrom: { 
-		#male -> maleButton.
-		#female -> femaleButton
-	}.
-		
+	maleButton associatedRadioButtons: {femaleButton}.
+	genderButtons := Dictionary newFrom: {(#male -> maleButton) . (#female -> femaleButton)}.
+
 	genderLabel := self newLabel label: 'gender:'.
 	itemsLabel := self newLabel label: 'items:'.
 	itemsInput := self newList.


### PR DESCRIPTION
Do not hardcode backdrop color.

Fixes #647