### PR TITLE
676-Observable-slot-should-not-launch-a-Value-changed-event-when-the-value-is-the-same-than-the-previous-one

### DIFF
--- a/src/Spec2-Core/SpButtonPresenter.class.st
+++ b/src/Spec2-Core/SpButtonPresenter.class.st
@@ -213,7 +213,7 @@ SpButtonPresenter >> performAction [
 	self action value.
 
 	" Here I set a dummy value just to make the holder raise an event "
-	actionPerformed := nil
+	actionPerformed := (actionPerformed ifNil: [ 0 ]) + 1
 ]
 
 { #category : #private }

--- a/src/Spec2-Core/SpMorphPresenter.class.st
+++ b/src/Spec2-Core/SpMorphPresenter.class.st
@@ -19,6 +19,11 @@ SpMorphPresenter >> defineInputPorts [
 	^ { SpMorphPort new }
 ]
 
+{ #category : #initialization }
+SpMorphPresenter >> initialize [
+	super initialize.
+]
+
 { #category : #accessing }
 SpMorphPresenter >> morph [
 	^ morph

--- a/src/Spec2-Core/SpValueHolder.class.st
+++ b/src/Spec2-Core/SpValueHolder.class.st
@@ -77,6 +77,9 @@ SpValueHolder >> value: anObject [
 	"Handle circular references as explained in the class comment"
 	lock ifTrue: [ ^ self ].
 	
+	"In case the value does not change, no need to update the value holder."
+	anObject = value ifTrue: [ ^ self ].
+	
 	lock := true.
 	
 	[ | oldValue |

--- a/src/Spec2-Tests/SpListPresenterSingleSelectionTest.class.st
+++ b/src/Spec2-Tests/SpListPresenterSingleSelectionTest.class.st
@@ -136,8 +136,8 @@ SpListPresenterSingleSelectionTest >> testSelectMultipleIndexesRaisesSelectionCh
 { #category : #'tests-select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexOutsideRangeRaisesSelectionChangeEventWithUnsetIndex [
 	| selectedIndex |
-	presenter
-		whenSelectionChangedDo: [ :selection | selectedIndex := selection selectedIndex ].
+	presenter selectIndex: 1.
+	presenter whenSelectionChangedDo: [ :selection | selectedIndex := selection selectedIndex ].
 	presenter selectIndex: 4.
 	self assert: selectedIndex equals: 0
 ]
@@ -192,9 +192,8 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionItemChang
 { #category : #'tests-select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelectionChangeEventWithUnsetIndex [
 	| selectedIndex |
-
-	presenter
-		whenSelectionChangedDo: [ :selection | selectedIndex := selection selectedIndex ].
+	presenter selectIndex: 1.
+	presenter whenSelectionChangedDo: [ :selection | selectedIndex := selection selectedIndex ].
 	presenter selectItem: 40.
 	self assert: selectedIndex equals: 0
 ]
@@ -248,8 +247,10 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionItemChange
 { #category : #'tests-unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectAllRaisesSelectionEventOnce [
 	"Because it does nothing in single selection mode"
+
 	| events |
 	events := 0.
+	presenter selectIndex: 1.
 	presenter whenSelectionChangedDo: [ :selection | events := events + 1 ].
 
 	presenter unselectAll.

--- a/src/Spec2-Tests/SpObservablePoint.class.st
+++ b/src/Spec2-Tests/SpObservablePoint.class.st
@@ -13,7 +13,7 @@ Class {
 		'#x => SpObservableSlot',
 		'#y'
 	],
-	#category : #'Spec2-Core-Observable'
+	#category : #'Spec2-Tests-Observable'
 }
 
 { #category : #initialization }

--- a/src/Spec2-Tests/SpObservableSlotTest.class.st
+++ b/src/Spec2-Tests/SpObservableSlotTest.class.st
@@ -69,6 +69,18 @@ SpObservableSlotTest >> testObservableSlotWorksAsNormalSlot [
 ]
 
 { #category : #tests }
+SpObservableSlotTest >> testSettingTwoTimesTheSameValueRaiseDeclareOnlyOnePropertyChange [
+	| count |
+	count := 0.
+	point property: #x whenChangedDo: [ count := count + 1 ].
+
+	point x: 17.
+	point x: 17.
+
+	self assert: count equals: 1
+]
+
+{ #category : #tests }
 SpObservableSlotTest >> testSubscribeBlockWithoutParametersIsCalled [
 
 	| called |


### PR DESCRIPTION
Do not update observable value holder if the value did not changed.

Fixes #676