### PR TITLE
689-should-use-toolbar-and-not-toolBar

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
@@ -36,7 +36,7 @@ SpMorphicWindowAdapter >> addContent: aMorph toWindow: aSpecWindow [
 
 	"add all decorations (menu, toolbar and statusbar)"
 	self model hasMenu ifTrue: [ self addMenuTo: containerMorph ].
-	self model hasToolBar ifTrue: [ self addToolBarTo: containerMorph ].
+	self model hasToolbar ifTrue: [ self addToolBarTo: containerMorph ].
 	containerMorph addMorphBack: aMorph.
 	aMorph
 		hResizing: #spaceFill;

--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -208,10 +208,8 @@ SpWindowPresenter >> hasStatusBar [
 ]
 
 { #category : #testing }
-SpWindowPresenter >> hasToolBar [
-	
-	^ self toolBar notNil
-	and: [ self toolBar notEmpty ]
+SpWindowPresenter >> hasToolbar [
+	^ self toolBar notNil and: [ self toolBar notEmpty ]
 ]
 
 { #category : #api }

--- a/src/Spec2-Deprecated/SpWindowPresenter.extension.st
+++ b/src/Spec2-Deprecated/SpWindowPresenter.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #SpWindowPresenter }
 
 { #category : #'*Spec2-Deprecated' }
+SpWindowPresenter >> hasToolBar [
+	self deprecated: 'Use #hasToolbar instead. cf https://www.dictionary.com/browse/toolbar' transformWith: '`@receiver hasToolBar' -> '`@receiver hasToolbar'.
+	^ self hasToolbar
+]
+
+{ #category : #'*Spec2-Deprecated' }
 SpWindowPresenter >> modalRelativeTo: aWindow [
 	self deprecated: 'Do not use this directly. Use #openModalWithSpec (and family) instead.' on: '2019-02-26' in: #Pharo8.
 


### PR DESCRIPTION
Rename hasToolBar into hasToolbar.

Fixes #689