### PR TITLE
Adding the ability to defer a UI rendering operation to the backend.

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicBackend.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBackend.class.st
@@ -16,6 +16,11 @@ SpMorphicBackend >> adapterBindingsClass [
 	^ SpMorphicAdapterBindings
 ]
 
+{ #category : #'as yet unclassified' }
+SpMorphicBackend >> defer: aBlockClosure [ 
+	UIManager default defer: aBlockClosure.
+]
+
 { #category : #'private notifying' }
 SpMorphicBackend >> notifyError: aSpecNotification [
 	GrowlMorph

--- a/src/Spec2-Core/SpApplication.class.st
+++ b/src/Spec2-Core/SpApplication.class.st
@@ -48,6 +48,11 @@ SpApplication >> close [
 	self windows copy do: #close
 ]
 
+{ #category : #'as yet unclassified' }
+SpApplication >> defer: aBlockClosure [ 
+	self backend defer: aBlockClosure.
+]
+
 { #category : #windows }
 SpApplication >> hasWindow: aWindow [
 	

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -370,6 +370,11 @@ SpPresenter >> defaultWindowPresenterClass [
 	^ SpWindowPresenter
 ]
 
+{ #category : #'as yet unclassified' }
+SpPresenter >> defer: aBlockClosure [ 
+	self application defer: aBlockClosure
+]
+
 { #category : #private }
 SpPresenter >> delete [
 


### PR DESCRIPTION
Required to update the UI properly in Iceberg (Spec 2 version) PullRequestsBrowser.
The aim is to able to fork a process that will fetch the needed data to then ask the presenter to properly updates it's state in the right thread.
