### PR TITLE
748-Use-correct-Spec2-prefix-also-for-traits

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
@@ -209,6 +209,13 @@ SpAbstractMorphicAdapter >> extent [
 	^ self widget extent
 ]
 
+{ #category : #'api-focus' }
+SpAbstractMorphicAdapter >> gtInspectorPreviewIn: composite [
+	<gtInspectorPresentationOrder: 30>
+	
+	self widgetDo: [ :w | w gtInspectorMorphIn: composite ]
+]
+
 { #category : #protocol }
 SpAbstractMorphicAdapter >> hRigid [
 	

--- a/src/Spec2-Adapters-Morphic/SpMorphicTableDataSource.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableDataSource.class.st
@@ -6,8 +6,8 @@ I use a builder (MorphicTableCellBuilder) to realise the cell content.
 Class {
 	#name : #SpMorphicTableDataSource,
 	#superclass : #FTSimpleDataSource,
-	#traits : 'TSpMorphicTableDataSourceCommons',
-	#classTraits : 'TSpMorphicTableDataSourceCommons classTrait',
+	#traits : 'SpTMorphicTableDataSourceCommons',
+	#classTraits : 'SpTMorphicTableDataSourceCommons classTrait',
 	#category : #'Spec2-Adapters-Morphic-Table'
 }
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableDataSource.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableDataSource.class.st
@@ -6,8 +6,8 @@ I use a builder (MorphicTreeTableCellBuilder) to realise the cell content.
 Class {
 	#name : #SpMorphicTreeTableDataSource,
 	#superclass : #FTTreeDataSource,
-	#traits : 'TSpMorphicTableDataSourceCommons',
-	#classTraits : 'TSpMorphicTableDataSourceCommons classTrait',
+	#traits : 'SpTMorphicTableDataSourceCommons',
+	#classTraits : 'SpTMorphicTableDataSourceCommons classTrait',
 	#category : #'Spec2-Adapters-Morphic-Table'
 }
 

--- a/src/Spec2-Adapters-Morphic/SpTMorphicTableDataSourceCommons.trait.st
+++ b/src/Spec2-Adapters-Morphic/SpTMorphicTableDataSourceCommons.trait.st
@@ -1,5 +1,5 @@
 Trait {
-	#name : #TSpMorphicTableDataSourceCommons,
+	#name : #SpTMorphicTableDataSourceCommons,
 	#instVars : [
 		'model'
 	],
@@ -7,7 +7,7 @@ Trait {
 }
 
 { #category : #accessing }
-TSpMorphicTableDataSourceCommons >> headerColumn: column [
+SpTMorphicTableDataSourceCommons >> headerColumn: column [
 
 	column id ifNil: [ ^ nil ].
 	^ FTCellMorph new 
@@ -17,7 +17,7 @@ TSpMorphicTableDataSourceCommons >> headerColumn: column [
 ]
 
 { #category : #accessing }
-TSpMorphicTableDataSourceCommons >> menuColumn: column row: rowIndex [
+SpTMorphicTableDataSourceCommons >> menuColumn: column row: rowIndex [
 	| menuPresenter |
 
 	menuPresenter := self model contextMenu.
@@ -28,13 +28,13 @@ TSpMorphicTableDataSourceCommons >> menuColumn: column row: rowIndex [
 ]
 
 { #category : #accessing }
-TSpMorphicTableDataSourceCommons >> model [
+SpTMorphicTableDataSourceCommons >> model [
 
 	^ model
 ]
 
 { #category : #accessing }
-TSpMorphicTableDataSourceCommons >> model: aTablePresenter [
+SpTMorphicTableDataSourceCommons >> model: aTablePresenter [
 
 	model := aTablePresenter
 ]

--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #SpAbstractListPresenter,
 	#superclass : #SpAbstractWidgetPresenter,
-	#traits : 'TSpHaveWrappingScrollBars',
-	#classTraits : 'TSpHaveWrappingScrollBars classTrait',
+	#traits : 'SpTHaveWrappingScrollBars',
+	#classTraits : 'SpTHaveWrappingScrollBars classTrait',
 	#instVars : [
 		'#selectionMode',
 		'#activationBlock',

--- a/src/Spec2-Core/SpAbstractPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractPresenter.class.st
@@ -5,8 +5,8 @@ I define common behaviours for widget presenters and also for composable present
 Class {
 	#name : #SpAbstractPresenter,
 	#superclass : #Model,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#owner',
 		'#adapter',

--- a/src/Spec2-Core/SpAbstractSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractSelectionMode.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #SpAbstractSelectionMode,
 	#superclass : #Object,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'widget'
 	],

--- a/src/Spec2-Core/SpAbstractTreeSingleSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractTreeSingleSelectionMode.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #SpAbstractTreeSingleSelectionMode,
 	#superclass : #Object,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#selection => SpObservableSlot',
 		'#presenter'

--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #SpCollectionListModel,
 	#superclass : #Object,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#announcer',
 		'#collection',

--- a/src/Spec2-Core/SpDynamicPresenter.class.st
+++ b/src/Spec2-Core/SpDynamicPresenter.class.st
@@ -24,8 +24,8 @@ todo
 Class {
 	#name : #SpDynamicPresenter,
 	#superclass : #SpPresenter,
-	#traits : 'TSpDynamicPresenter',
-	#classTraits : 'TSpDynamicPresenter classTrait',
+	#traits : 'SpTDynamicPresenter',
+	#classTraits : 'SpTDynamicPresenter classTrait',
 	#category : #'Spec2-Core-Base'
 }
 

--- a/src/Spec2-Core/SpNotebookPage.class.st
+++ b/src/Spec2-Core/SpNotebookPage.class.st
@@ -7,8 +7,8 @@ In particular, I contain a presenterProvider, a block who's responsibility is to
 Class {
 	#name : #SpNotebookPage,
 	#superclass : #Object,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#owner',
 		'#title => SpObservableSlot',

--- a/src/Spec2-Core/SpObservablePoint.class.st
+++ b/src/Spec2-Core/SpObservablePoint.class.st
@@ -7,8 +7,8 @@ I use TObservable that has methods to ease the usage of my observable properties
 Class {
 	#name : #SpObservablePoint,
 	#superclass : #Object,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#x => SpObservableSlot',
 		'#y'

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -481,6 +481,23 @@ SpPresenter >> giveFocusToPreviousFrom: aModel [
 			true ]
 ]
 
+{ #category : #'api-focus' }
+SpPresenter >> gtInspectorPreviewIn: composite [
+	<gtInspectorPresentationOrder: 30>
+	self widget ifNotNil: [ :w | w gtInspectorPreviewIn: composite ]
+]
+
+{ #category : #'api-focus' }
+SpPresenter >> gtInspectorSubPresentersIn: composite [
+	<gtInspectorPresentationOrder: 20>
+	composite tree
+		title: 'Sub presenters';
+		rootsExpanded;
+		display: [ :each | {each} ];
+		children: [ :each | each presenters ];
+		when: [ :each | each presenters isNotEmpty ]
+]
+
 { #category : #'private-focus' }
 SpPresenter >> handlesKeyboard: evt [
 

--- a/src/Spec2-Core/SpProgressBarFixed.class.st
+++ b/src/Spec2-Core/SpProgressBarFixed.class.st
@@ -19,8 +19,8 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #SpProgressBarFixed,
 	#superclass : #SpProgressBarState,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#value => SpObservableSlot'
 	],

--- a/src/Spec2-Core/SpProgressBarProgressing.class.st
+++ b/src/Spec2-Core/SpProgressBarProgressing.class.st
@@ -23,8 +23,8 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #SpProgressBarProgressing,
 	#superclass : #SpProgressBarState,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#refreshDelay',
 		'#progression',

--- a/src/Spec2-Core/SpTDynamicPresenter.trait.st
+++ b/src/Spec2-Core/SpTDynamicPresenter.trait.st
@@ -3,7 +3,7 @@ I'm a trait that add ""dynamic"" behavior to presenters.
 I can be used to create components that may have variable number of children.
 "
 Trait {
-	#name : #TSpDynamicPresenter,
+	#name : #SpTDynamicPresenter,
 	#instVars : [
 		'presenters'
 	],
@@ -11,19 +11,19 @@ Trait {
 }
 
 { #category : #'private accessing' }
-TSpDynamicPresenter >> basicPresenters [
+SpTDynamicPresenter >> basicPresenters [
 
 	^ presenters ifNil: [ presenters := OrderedDictionary new ]
 ]
 
 { #category : #accessing }
-TSpDynamicPresenter >> presenterAt: aName [
+SpTDynamicPresenter >> presenterAt: aName [
 
 	^ self basicPresenters at: aName 
 ]
 
 { #category : #accessing }
-TSpDynamicPresenter >> presenterAt: aName ifAbsent: aBlock [
+SpTDynamicPresenter >> presenterAt: aName ifAbsent: aBlock [
 	^ self basicPresenters
 		at: aName
 		ifAbsent: [ [ self readSlotNamed: aName ]
@@ -32,7 +32,7 @@ TSpDynamicPresenter >> presenterAt: aName ifAbsent: aBlock [
 ]
 
 { #category : #accessing }
-TSpDynamicPresenter >> presenterAt: aName put: aPresenter [
+SpTDynamicPresenter >> presenterAt: aName put: aPresenter [
 
 	^ self basicPresenters 
 		at: aName 
@@ -40,13 +40,13 @@ TSpDynamicPresenter >> presenterAt: aName put: aPresenter [
 ]
 
 { #category : #accessing }
-TSpDynamicPresenter >> presenters [
+SpTDynamicPresenter >> presenters [
 
 	^ self basicPresenters values
 ]
 
 { #category : #enumerating }
-TSpDynamicPresenter >> presentersDo: aBlock [
+SpTDynamicPresenter >> presentersDo: aBlock [
 
 	self basicPresenters valuesDo: aBlock
 ]

--- a/src/Spec2-Core/SpTHaveWrappingScrollBars.trait.st
+++ b/src/Spec2-Core/SpTHaveWrappingScrollBars.trait.st
@@ -9,7 +9,7 @@ if your backend of choice supports it.
 THIS CANNOT BE CHANGED ONCE THE WIDGET IS CREATED.
 "
 Trait {
-	#name : #TSpHaveWrappingScrollBars,
+	#name : #SpTHaveWrappingScrollBars,
 	#instVars : [
 		'wrapScrollBars'
 	],
@@ -17,7 +17,7 @@ Trait {
 }
 
 { #category : #testing }
-TSpHaveWrappingScrollBars >> hasScrollBars [
+SpTHaveWrappingScrollBars >> hasScrollBars [
 	"Some backends like Morphic forces the scrollbars in their Tables and Lists. 
 	 But some others like Gtk3 don't. This option allows you to configure the precence 
 	 of scrollbars for platforms who do not have them automatically.
@@ -29,7 +29,7 @@ TSpHaveWrappingScrollBars >> hasScrollBars [
 ]
 
 { #category : #accessing }
-TSpHaveWrappingScrollBars >> withScrollBars [
+SpTHaveWrappingScrollBars >> withScrollBars [
 	"Some backends like Morphic forces the scrollbars in their Tables and Lists. 
 	 But some others like Gtk3 don't. This option allows you to configure the precence 
 	 of scrollbars for platforms who do not have them automatically.
@@ -41,7 +41,7 @@ TSpHaveWrappingScrollBars >> withScrollBars [
 ]
 
 { #category : #accessing }
-TSpHaveWrappingScrollBars >> withoutScrollBars [
+SpTHaveWrappingScrollBars >> withoutScrollBars [
 	"Some backends like Morphic forces the scrollbars in their Tables and Lists. 
 	 But some others like Gtk3 don't. This option allows you to configure the precence 
 	 of scrollbars for platforms who do not have them automatically.

--- a/src/Spec2-Core/SpTObservable.trait.st
+++ b/src/Spec2-Core/SpTObservable.trait.st
@@ -1,16 +1,16 @@
 Trait {
-	#name : #TSpObservable,
+	#name : #SpTObservable,
 	#category : #'Spec2-Core-Observable'
 }
 
 { #category : #events }
-TSpObservable >> notifyPropertyChanged: aName [
+SpTObservable >> notifyPropertyChanged: aName [
 	self flag: #todo.	"This is used for collections but collections should be managed in a better way and this method removed."
 	(self observablePropertyNamed: aName) valueChanged
 ]
 
 { #category : #events }
-TSpObservable >> observablePropertyNamed: aName [
+SpTObservable >> observablePropertyNamed: aName [
 	| slot |
 	
 	slot := self class slotNamed: aName.
@@ -23,14 +23,14 @@ TSpObservable >> observablePropertyNamed: aName [
 ]
 
 { #category : #events }
-TSpObservable >> property: aName rawValue: anObject [
+SpTObservable >> property: aName rawValue: anObject [
 	"Write in the slot without announcing it."
 
 	(self observablePropertyNamed: aName) rawValue: anObject
 ]
 
 { #category : #events }
-TSpObservable >> property: aName whenChangedDo: aBlockClosure [ 
+SpTObservable >> property: aName whenChangedDo: aBlockClosure [ 
 	
 	"Obtain the raw value.
 	We need to access the underlying value holder to subscribe to it"

--- a/src/Spec2-Core/SpTextPresenter.class.st
+++ b/src/Spec2-Core/SpTextPresenter.class.st
@@ -20,8 +20,8 @@ I provide the following methods
 Class {
 	#name : #SpTextPresenter,
 	#superclass : #SpAbstractTextPresenter,
-	#traits : 'TSpHaveWrappingScrollBars',
-	#classTraits : 'TSpHaveWrappingScrollBars classTrait',
+	#traits : 'SpTHaveWrappingScrollBars',
+	#classTraits : 'SpTHaveWrappingScrollBars classTrait',
 	#instVars : [
 		'#scrollValue => SpObservableSlot'
 	],

--- a/src/Spec2-Core/SpTimeline.class.st
+++ b/src/Spec2-Core/SpTimeline.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #SpTimeline,
 	#superclass : #Object,
-	#traits : 'TSpObservable',
-	#classTraits : 'TSpObservable classTrait',
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
 	#instVars : [
 		'#ticks => SpObservableSlot',
 		'#highestValue',

--- a/src/Spec2-Core/SpTreeTablePresenter.class.st
+++ b/src/Spec2-Core/SpTreeTablePresenter.class.st
@@ -9,8 +9,8 @@ self example
 Class {
 	#name : #SpTreeTablePresenter,
 	#superclass : #SpAbstractWidgetPresenter,
-	#traits : 'TSpHaveWrappingScrollBars',
-	#classTraits : 'TSpHaveWrappingScrollBars classTrait',
+	#traits : 'SpTHaveWrappingScrollBars',
+	#classTraits : 'SpTHaveWrappingScrollBars classTrait',
 	#instVars : [
 		'#columns => SpObservableSlot',
 		'#showColumnHeaders => SpObservableSlot',

--- a/src/Spec2-Core/SpVersatileDialogPresenter.class.st
+++ b/src/Spec2-Core/SpVersatileDialogPresenter.class.st
@@ -18,8 +18,8 @@ I have:
 Class {
 	#name : #SpVersatileDialogPresenter,
 	#superclass : #SpDynamicPresenter,
-	#traits : 'TSpDynamicPresenter',
-	#classTraits : 'TSpDynamicPresenter classTrait',
+	#traits : 'SpTDynamicPresenter',
+	#classTraits : 'SpTDynamicPresenter classTrait',
 	#instVars : [
 		'mainMessage',
 		'mainIcon',

--- a/src/Spec2-Deprecated/TSpDynamicPresenter.trait.st
+++ b/src/Spec2-Deprecated/TSpDynamicPresenter.trait.st
@@ -1,0 +1,13 @@
+Trait {
+	#name : #TSpDynamicPresenter,
+	#traits : 'SpTDynamicPresenter',
+	#classTraits : 'SpTDynamicPresenter classTrait',
+	#category : #'Spec2-Deprecated'
+}
+
+{ #category : #testing }
+TSpDynamicPresenter classSide >> isDeprecated [
+	"Use SpTDynamicPresenter instead"
+
+	^ true
+]

--- a/src/Spec2-Deprecated/TSpHaveWrappingScrollBars.trait.st
+++ b/src/Spec2-Deprecated/TSpHaveWrappingScrollBars.trait.st
@@ -1,0 +1,13 @@
+Trait {
+	#name : #TSpHaveWrappingScrollBars,
+	#traits : 'SpTHaveWrappingScrollBars',
+	#classTraits : 'SpTHaveWrappingScrollBars classTrait',
+	#category : #'Spec2-Deprecated'
+}
+
+{ #category : #testing }
+TSpHaveWrappingScrollBars classSide >> isDeprecated [
+	"Use SpTHaveWrappingScrollBars instead"
+
+	^ true
+]

--- a/src/Spec2-Deprecated/TSpMorphicTableDataSourceCommons.trait.st
+++ b/src/Spec2-Deprecated/TSpMorphicTableDataSourceCommons.trait.st
@@ -1,0 +1,13 @@
+Trait {
+	#name : #TSpMorphicTableDataSourceCommons,
+	#traits : 'SpTMorphicTableDataSourceCommons',
+	#classTraits : 'SpTMorphicTableDataSourceCommons classTrait',
+	#category : #'Spec2-Deprecated'
+}
+
+{ #category : #testing }
+TSpMorphicTableDataSourceCommons classSide >> isDeprecated [
+	"Use SpTMorphicTableDataSourceCommons instead"
+
+	^ true
+]

--- a/src/Spec2-Deprecated/TSpObservable.trait.st
+++ b/src/Spec2-Deprecated/TSpObservable.trait.st
@@ -1,0 +1,13 @@
+Trait {
+	#name : #TSpObservable,
+	#traits : 'SpTObservable',
+	#classTraits : 'SpTObservable classTrait',
+	#category : #'Spec2-Deprecated'
+}
+
+{ #category : #testing }
+TSpObservable classSide >> isDeprecated [
+	"Use SpTObservable instead"
+
+	^ true
+]


### PR DESCRIPTION
Use SpT prefix instead of TSp for traits.

Fixes #748