### PR TITLE
Add-possiblity-to-pass-action-to-link-presenter

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicLinkAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicLinkAdapter.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Spec2-Adapters-Morphic-Base'
 }
 
+{ #category : #accessing }
+SpMorphicLinkAdapter >> action [
+	^ self model action
+]
+
 { #category : #factory }
 SpMorphicLinkAdapter >> buildWidget [
 	"Since Pharo does not yet have a real morph for URL, I create my own. Maybe later we will have real links in Morphic?"
@@ -55,12 +60,7 @@ SpMorphicLinkAdapter >> mouseLeave: anEvent from: aMorph [
 { #category : #'event handling' }
 SpMorphicLinkAdapter >> mouseUp: anEvent from: aMorph [
 	aMorph color: self urlHoverColor.
-	WebBrowser openOn: self url
-]
-
-{ #category : #accessing }
-SpMorphicLinkAdapter >> url [
-	^ self model url
+	self action value
 ]
 
 { #category : #'accessing colors' }

--- a/src/Spec2-Core/SpLinkPresenter.class.st
+++ b/src/Spec2-Core/SpLinkPresenter.class.st
@@ -34,7 +34,7 @@ Class {
 	#superclass : #SpAbstractWidgetPresenter,
 	#instVars : [
 		'#label => SpObservableSlot',
-		'#url => SpObservableSlot'
+		'#action => SpObservableSlot'
 	],
 	#category : #'Spec2-Core-Widgets'
 }
@@ -42,6 +42,16 @@ Class {
 { #category : #specs }
 SpLinkPresenter class >> adapterName [
 	^ #LinkAdapter
+]
+
+{ #category : #api }
+SpLinkPresenter >> action [
+	^ action
+]
+
+{ #category : #api }
+SpLinkPresenter >> action: aBlock [
+	action := aBlock
 ]
 
 { #category : #initialization }
@@ -58,7 +68,7 @@ SpLinkPresenter >> initialize [
 
 { #category : #api }
 SpLinkPresenter >> label [
-	^ label ifNil: [ self url ]
+	^ label
 ]
 
 { #category : #api }
@@ -67,13 +77,14 @@ SpLinkPresenter >> label: aString [
 ]
 
 { #category : #api }
-SpLinkPresenter >> url [
-	^ url
+SpLinkPresenter >> url: aString [
+	self action: [ WebBrowser openOn: aString ].
+	self label ifNil: [ self label: aString ]
 ]
 
-{ #category : #api }
-SpLinkPresenter >> url: aString [
-	url := aString
+{ #category : #enumerating }
+SpLinkPresenter >> whenActionChangedDo: aBlock [
+	self property: #action whenChangedDo: aBlock
 ]
 
 { #category : #enumerating }

--- a/src/Spec2-Examples/SpDemoLinksPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoLinksPresenter.class.st
@@ -10,7 +10,8 @@ Class {
 	#instVars : [
 		'link1',
 		'link2',
-		'link3'
+		'link3',
+		'link4'
 	],
 	#category : #'Spec2-Examples-Demo-Other'
 }
@@ -21,6 +22,7 @@ SpDemoLinksPresenter class >> defaultSpec [
 		add: #link1;
 		add: #link2;
 		add: #link3;
+		add: #link4;
 		yourself
 ]
 
@@ -35,6 +37,7 @@ SpDemoLinksPresenter >> initializeWidgets [
 	link1 := self newLink.
 	link2 := self newLink.
 	link3 := self newLink.
+	link4 := self newLink.
 
 	link1 url: 'https://pharo.org'.
 
@@ -45,20 +48,9 @@ SpDemoLinksPresenter >> initializeWidgets [
 	link3
 		url: 'https://pharo.org';
 		label: 'Pharo website';
-		color: Color purple
-]
+		color: Color purple.
 
-{ #category : #accessing }
-SpDemoLinksPresenter >> link1 [
-	^ link1
-]
-
-{ #category : #accessing }
-SpDemoLinksPresenter >> link2 [
-	^ link2
-]
-
-{ #category : #accessing }
-SpDemoLinksPresenter >> link3 [
-	^ link3
+	link4
+		action: [ Object browse ];
+		label: 'Browse Object'
 ]

--- a/src/Spec2-Tests/SpLinkPresenterTest.class.st
+++ b/src/Spec2-Tests/SpLinkPresenterTest.class.st
@@ -12,13 +12,24 @@ SpLinkPresenterTest >> classToTest [
 { #category : #tests }
 SpLinkPresenterTest >> testLabelIsUrlByDefault [
 	self assert: presenter label isNil.
-	self assert: presenter url isNil.
 	presenter url: 'Test'.
-	self assert: presenter url equals: 'Test'.
 	self assert: presenter label equals: 'Test'.
 	presenter label: 'Label'.
-	self assert: presenter url equals: 'Test'.
 	self assert: presenter label equals: 'Label'
+]
+
+{ #category : #tests }
+SpLinkPresenterTest >> testWhenActionChangedDo [
+	| count result |
+	count := 0.
+	presenter
+		whenActionChangedDo: [ :block | 
+			count := count + 1.
+			result := block ].
+	presenter action: [ 'Test' ].
+	self assert: result isBlock.
+	self assert: result value equals: 'Test'.
+	self assert: count equals: 1
 ]
 
 { #category : #tests }
@@ -30,19 +41,6 @@ SpLinkPresenterTest >> testWhenLabelChangedDo [
 			count := count + 1.
 			result := label ].
 	presenter label: 'Test'.
-	self assert: result equals: 'Test'.
-	self assert: count equals: 1
-]
-
-{ #category : #tests }
-SpLinkPresenterTest >> testWhenUrlChangedDo [
-	| count result |
-	count := 0.
-	presenter
-		whenUrlChangedDo: [ :label | 
-			count := count + 1.
-			result := label ].
-	presenter url: 'Test'.
 	self assert: result equals: 'Test'.
 	self assert: count equals: 1
 ]


### PR DESCRIPTION
Add possibility to use action with links.

This will allow us to be able to browse classes for example with a link.

Fixes #181