### PR TITLE
734-Migrate-Spec-to-use-Commander2-v200

### DIFF
--- a/src/BaselineOfSpec2/BaselineOfSpec2.class.st
+++ b/src/BaselineOfSpec2/BaselineOfSpec2.class.st
@@ -91,7 +91,7 @@ BaselineOfSpec2 >> baseline: spec [
 BaselineOfSpec2 >> commander2: spec [
 	spec
 		baseline: 'Commander2'
-		with: [ spec repository: 'github://pharo-spec/Commander2:v1.2.0/src' ]
+		with: [ spec repository: 'github://pharo-spec/Commander2:v2.x.x/src' ]
 ]
 
 { #category : #dependencies }

--- a/src/Spec2-Commander2-ContactBook-Extensions/SpChangePhoneCommand.class.st
+++ b/src/Spec2-Commander2-ContactBook-Extensions/SpChangePhoneCommand.class.st
@@ -22,8 +22,8 @@ SpChangePhoneCommand >> execute [
 SpChangePhoneCommand >> initialize [
 	super initialize.
 	self
-		basicName: 'Change phone';
-		basicDescription: 'Change the phone number of the contact.'
+		name: 'Change phone';
+		description: 'Change the phone number of the contact.'
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Commander2-ContactBook-Extensions/SpContactBookPresenter.extension.st
+++ b/src/Spec2-Commander2-ContactBook-Extensions/SpContactBookPresenter.extension.st
@@ -11,17 +11,21 @@ SpContactBookPresenter class >> changePhoneCommandWith: presenter forRootGroup: 
 SpContactBookPresenter class >> extraCommandsWith: presenter forRootGroup: aCmCommandsGroup [
 	<extensionCommands>
 	aCmCommandsGroup / 'Context Menu'
-		register: ((CmCommandGroup named: 'Extra') asSpecGroup
-						basicDescription: 'Extra commands to help during development.';
-						"Below is an example of reusing the same command for 2 different purposes."
-						register: ((SpInspectContactCommand forSpec context: [ presenter selectedContact ]) "Here context is computed at the moment the command is executed."
-											"The name and description can be adapted for its specific usage."
-											basicName: 'Inspect contact';
-											basicDescription: 'Open an inspector on the selected contact.';
-											yourself);
-						register: ((SpInspectContactCommand forSpec context: [ presenter contactBook ])
-											basicName: 'Inspect contact book';
-											basicDescription: 'Open an inspector on the contact book.';
-											yourself);
-						yourself)
+		register:
+			((CmCommandGroup named: 'Extra') asSpecGroup
+				description: 'Extra commands to help during development.';
+				"Below is an example of reusing the same command for 2 different purposes."
+					register:
+					((SpInspectContactCommand forSpec
+						context: [ presenter selectedContact ])
+						name: 'Inspect contact';
+						description: 'Open an inspector on the selected contact.';
+						yourself);
+				register:
+					((SpInspectContactCommand forSpec context: [ presenter contactBook ])
+						name: 'Inspect contact book';
+						description: 'Open an inspector on the contact book.';
+						yourself);
+				yourself)	"Here context is computed at the moment the command is executed."
+	"The name and description can be adapted for its specific usage."
 ]

--- a/src/Spec2-Commander2-ContactBook-Extensions/SpInspectContactCommand.class.st
+++ b/src/Spec2-Commander2-ContactBook-Extensions/SpInspectContactCommand.class.st
@@ -16,6 +16,6 @@ SpInspectContactCommand >> execute [
 SpInspectContactCommand >> initialize [
 	super initialize.
 	self
-		basicName: 'Inspect';
-		basicDescription: 'Inspect the context of this command.'
+		name: 'Inspect';
+		description: 'Inspect the context of this command.'
 ]

--- a/src/Spec2-Commander2-ContactBook/SpAddContactCommand.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpAddContactCommand.class.st
@@ -37,6 +37,7 @@ SpAddContactCommand >> execute [
 SpAddContactCommand >> initialize [
 	super initialize.
 	self
-		basicName: 'New contact'; "This is the name of the command that will be shown to the user."
-		basicDescription: 'Creates a new contact and add it to the contact book.' "This is the description of the command that will be shown to the user."
+		name: 'New contact';
+		"This is the name of the command that will be shown to the user."
+			description: 'Creates a new contact and add it to the contact book.'	"This is the description of the command that will be shown to the user."
 ]

--- a/src/Spec2-Commander2-ContactBook/SpContactBookPresenter.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpContactBookPresenter.class.st
@@ -19,7 +19,7 @@ Class {
 { #category : #commands }
 SpContactBookPresenter class >> buildAddingGroupWith: presenterIntance [
 	^ (CmCommandGroup named: 'Adding') asSpecGroup
-		basicDescription: 'Commands related to contact addition.';
+		description: 'Commands related to contact addition.';
 		register: SpAddContactCommand forSpec;
 		beDisplayedAsGroup;
 		yourself
@@ -44,7 +44,7 @@ SpContactBookPresenter class >> buildContextualMenuGroupWith: presenterIntance [
 { #category : #commands }
 SpContactBookPresenter class >> buildEditionGroupWith: presenterIntance [
 	^ (CmCommandGroup named: 'Edition') asSpecGroup
-		basicDescription: 'Commands related to contact edition.';
+		description: 'Commands related to contact edition.';
 		register: SpRenameContactCommand forSpec;
 		beDisplayedAsGroup;
 		yourself
@@ -60,7 +60,7 @@ SpContactBookPresenter class >> buildMenuBarGroupWith: presenterIntance [
 { #category : #commands }
 SpContactBookPresenter class >> buildRemovingGroupWith: presenterIntance [
 	^ (CmCommandGroup named: 'Removing') asSpecGroup
-		basicDescription: 'Command related to contact removal.';
+		description: 'Command related to contact removal.';
 		register: SpRemoveContactCommand forSpec;
 		beDisplayedAsGroup;
 		yourself

--- a/src/Spec2-Commander2-ContactBook/SpPrintContactBookInTranscript.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpPrintContactBookInTranscript.class.st
@@ -17,6 +17,7 @@ SpPrintContactBookInTranscript >> execute [
 SpPrintContactBookInTranscript >> initialize [
 	super initialize.
 	self
-		basicName: 'Print'; "This is the name of the command that will be shown to user."
-		basicDescription: 'Print the contact book in Transcript.' "This is the description of the command that will be shown to user."
+		name: 'Print';
+		"This is the name of the command that will be shown to user."
+			description: 'Print the contact book in Transcript.'	"This is the description of the command that will be shown to user."
 ]

--- a/src/Spec2-Commander2-ContactBook/SpRemoveContactCommand.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpRemoveContactCommand.class.st
@@ -33,6 +33,7 @@ SpRemoveContactCommand >> execute [
 SpRemoveContactCommand >> initialize [
 	super initialize.
 	self
-		basicName: 'Remove'; "This is the name of the command that will be shown to the user."
-		basicDescription: 'Removes the selected contact from the contact book.' "This is the description of the command that will be shown to the user."
+		name: 'Remove';
+		"This is the name of the command that will be shown to the user."
+			description: 'Removes the selected contact from the contact book.'	"This is the description of the command that will be shown to the user."
 ]

--- a/src/Spec2-Commander2-ContactBook/SpRenameContactCommand.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpRenameContactCommand.class.st
@@ -32,6 +32,7 @@ SpRenameContactCommand >> execute [
 SpRenameContactCommand >> initialize [
 	super initialize.
 	self
-		basicName: 'Rename'; "This is the name of the command that will be shown to the user."
-		basicDescription: 'Rename the selected contact.'. "This is the description of the command that will be shown to the user."
+		name: 'Rename';
+		"This is the name of the command that will be shown to the user."
+			description: 'Rename the selected contact.'	"This is the description of the command that will be shown to the user."
 ]


### PR DESCRIPTION
- Set dependency to Commander2 v2.x.x floating version- Adapted commander2 commands parts of Spec2 to use the new API introduced in Commander v2.0.0.Fixes #734