### PR TITLE
758-SpAbstractPresenter-should-be-abstract

### DIFF
--- a/src/Spec2-Core/SpAbstractAdapter.class.st
+++ b/src/Spec2-Core/SpAbstractAdapter.class.st
@@ -48,6 +48,11 @@ SpAbstractAdapter class >> allAdapters [
 	^ self subclassResponsibility
 ]
 
+{ #category : #testing }
+SpAbstractAdapter class >> isAbstract [
+	^ self = SpAbstractAdapter
+]
+
 { #category : #accessing }
 SpAbstractAdapter class >> owner: anOwner [
 

--- a/src/Spec2-Core/SpAbstractFormButtonPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractFormButtonPresenter.class.st
@@ -27,6 +27,11 @@ Class {
 	#category : #'Spec2-Core-Widgets'
 }
 
+{ #category : #testing }
+SpAbstractFormButtonPresenter class >> isAbstract [
+	^ self = SpAbstractFormButtonPresenter
+]
+
 { #category : #api }
 SpAbstractFormButtonPresenter >> activationAction: aBlock [
 	"This method is used to set the action to perform when I am activated"

--- a/src/Spec2-Core/SpAbstractPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractPresenter.class.st
@@ -41,6 +41,11 @@ SpAbstractPresenter class >> inputTextHeight [
 	^ self defaultFont height + 12
 ]
 
+{ #category : #testing }
+SpAbstractPresenter class >> isAbstract [
+	^ self = SpAbstractPresenter
+]
+
 { #category : #TOREMOVE }
 SpAbstractPresenter class >> labelHeight [
 

--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -17,6 +17,11 @@ Class {
 	#category : #'Spec2-Core-Widgets'
 }
 
+{ #category : #testing }
+SpAbstractTextPresenter class >> isAbstract [
+	^ self = SpAbstractTextPresenter
+]
+
 { #category : #api }
 SpAbstractTextPresenter >> accept [
 	"Accep the current pendingtext"

--- a/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
@@ -55,6 +55,11 @@ SpAbstractWidgetPresenter class >> defaultSpec [
 	^ SpAbstractWidgetLayout for: self adapterName
 ]
 
+{ #category : #testing }
+SpAbstractWidgetPresenter class >> isAbstract [
+	^ self = SpAbstractWidgetPresenter
+]
+
 { #category : #'drag and drop' }
 SpAbstractWidgetPresenter >> acceptDropBlock [
 	^ acceptDropBlock

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -120,6 +120,11 @@ SpPresenter class >> iconWidth [
 	^ 24
 ]
 
+{ #category : #testing }
+SpPresenter class >> isAbstract [
+	^ self = SpPresenter
+]
+
 { #category : #'labelled-presenters' }
 SpPresenter class >> labelWidth [
 	^ 100


### PR DESCRIPTION
Add #isAbstract methods in Spec2-Core

Fixes #758