### PR TITLE
Fixing issue #787.

### DIFF
--- a/src/BaselineOfSpec2/BaselineOfSpec2.class.st
+++ b/src/BaselineOfSpec2/BaselineOfSpec2.class.st
@@ -30,7 +30,8 @@ BaselineOfSpec2 >> baseline: spec [
 				package: 'Spec2-Commander2-ContactBook-Extensions' with: [ spec requires: #('Spec2-Commander2-ContactBook') ];
 				package: 'Spec2-Tests' with: [ spec requires: #('Spec2-Examples') ];
 				package: 'Spec2-Morphic-Backend-Tests' with: [ spec requires: #('Spec2-Adapters-Morphic') ];
-				package: 'Spec2-Backend-Tests' with: [ spec requires: #('Spec2-Adapters-Morphic') ] ].
+				package: 'Spec2-Backend-Tests' with: [ spec requires: #('Spec2-Adapters-Morphic') ];
+				package: 'Spec2-Adapters-Morphic-Tests' with: [ spec requires: #('Spec2-Tests' 'Spec2-Adapters-Morphic') ]].
 
 	spec
 		for: #'pharo7.x'

--- a/src/Spec2-Adapters-Morphic-Tests/SpStyleTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStyleTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #SpStyleTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'aClass'
+	],
+	#category : #'Spec2-Adapters-Morphic-Tests'
+}
+
+{ #category : #tests }
+SpStyleTest >> tearDown [ 
+
+	aClass ifNotNil: [ :e | e removeFromSystem ].
+	super tearDown
+]
+
+{ #category : #tests }
+SpStyleTest >> testParsingAStyleIsNotAffectedByExistingClass [
+
+	| aStylesheet |
+
+	aClass := Object subclass: #Font.
+	aStylesheet := SpStyle createDefaultStyleSheet.
+	
+	self assert: aStylesheet styles isNotEmpty
+	
+	
+]

--- a/src/Spec2-Adapters-Morphic-Tests/package.st
+++ b/src/Spec2-Adapters-Morphic-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Spec2-Adapters-Morphic-Tests' }

--- a/src/Spec2-Adapters-Morphic/SpStyleSTONReader.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleSTONReader.class.st
@@ -25,6 +25,20 @@ SpStyleSTONReader >> isStyleClassChar: char [
 	^ char = $.
 ]
 
+{ #category : #private }
+SpStyleSTONReader >> lookupClass: name [
+
+	"The SpStyleSTONReader only looks for ston names in the hierarchy of SpStyle"
+	
+	^ classes 
+		at: name 
+		ifAbsentPut: [
+			(SpStyle allSubclasses , Color withAllSubclasses) 
+				detect: [ :class | class isMeta not and: [ class stonName = name ]  ]
+				ifNone: [ NotFound signalFor: name ] ]
+	
+]
+
 { #category : #parsing }
 SpStyleSTONReader >> parseSimpleValue [
 	| char |


### PR DESCRIPTION
Having a class with the same name of the elements in the STON breaks the parsing.