### PR TITLE
Remove-dependency-on-Glamour

### DIFF
--- a/src/BaselineOfSpec2/BaselineOfSpec2.class.st
+++ b/src/BaselineOfSpec2/BaselineOfSpec2.class.st
@@ -31,7 +31,7 @@ BaselineOfSpec2 >> baseline: spec [
 				package: 'Spec2-Tests' with: [ spec requires: #('Spec2-Examples') ];
 				package: 'Spec2-Morphic-Backend-Tests' with: [ spec requires: #('Spec2-Adapters-Morphic') ];
 				package: 'Spec2-Backend-Tests' with: [ spec requires: #('Spec2-Adapters-Morphic') ];
-				package: 'Spec2-Adapters-Morphic-Tests' with: [ spec requires: #('Spec2-Tests' 'Spec2-Adapters-Morphic') ]].
+				package: 'Spec2-Adapters-Morphic-Tests' with: [ spec requires: #('Spec2-Tests' 'Spec2-Backend-Tests') ]].
 
 	spec
 		for: #'pharo7.x'

--- a/src/Spec2-Backend-Tests/SpMorphicBackendForTest.class.st
+++ b/src/Spec2-Backend-Tests/SpMorphicBackendForTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : #SpMorphicBackendForTest,
 	#superclass : #SpAbstractBackendForTest,
+	#traits : 'SpTMorphicUIRedrawer',
+	#classTraits : 'SpTMorphicUIRedrawer classTrait',
 	#instVars : [
-		'uiWaitingSemaphore',
 		'app'
 	],
 	#category : #'Spec2-Backend-Tests'
@@ -102,17 +103,10 @@ SpMorphicBackendForTest >> doubleClickFirstRowAndColumn: anAdapter [
 
 ]
 
-{ #category : #running }
+{ #category : #initialization }
 SpMorphicBackendForTest >> initialize [
-
 	super initialize.
-	uiWaitingSemaphore := Semaphore new
-]
-
-{ #category : #running }
-SpMorphicBackendForTest >> isRunningInUIProcess [
-
-	^ UIManager default uiProcess == Processor activeProcess
+	self initializeSemaphore
 ]
 
 { #category : #opening }
@@ -131,22 +125,4 @@ SpMorphicBackendForTest >> runTest: aBlock [
 	app := SpApplication new.
 	app useBackend: #Morphic.
 	aBlock value
-]
-
-{ #category : #running }
-SpMorphicBackendForTest >> waitUntilUIRedrawed [
-
-	"I wait until the UI has been redrawn. 
-	I take care of selecting how to do it. 
-	If I am in the CI I should defer a semaphore signal. 
-	If I am running in the UI process I can directly execute a doOneCycle on the World.
-	If I am in the CI the tests and the UI run in different process. So I should not do a #doOneCycle.
-	If I do it, I am in a race condition!"
-	self isRunningInUIProcess ifTrue: [ 
-		self currentWorld doOneCycle.
-		^ self.	
-	]. 
-
-	self currentWorld defer: [ uiWaitingSemaphore ifNotNil: #signal ].	
-	uiWaitingSemaphore wait: 500 milliSecond
 ]

--- a/src/Spec2-Backend-Tests/SpTMorphicUIRedrawer.trait.st
+++ b/src/Spec2-Backend-Tests/SpTMorphicUIRedrawer.trait.st
@@ -11,6 +11,11 @@ Trait {
 	#category : #'Spec2-Backend-Tests'
 }
 
+{ #category : #running }
+SpTMorphicUIRedrawer >> defaultWaitDuration [
+	^ 500 milliSecond
+]
+
 { #category : #initialization }
 SpTMorphicUIRedrawer >> initializeSemaphore [
 	uiWaitingSemaphore := Semaphore new

--- a/src/Spec2-Backend-Tests/SpTMorphicUIRedrawer.trait.st
+++ b/src/Spec2-Backend-Tests/SpTMorphicUIRedrawer.trait.st
@@ -1,0 +1,39 @@
+"
+I am a class giving the user the hability to wait for an UI redraw in Morphic. 
+
+I am useful for tests when they need to be executed in a CI in non interactive mode.
+"
+Trait {
+	#name : #SpTMorphicUIRedrawer,
+	#instVars : [
+		'uiWaitingSemaphore'
+	],
+	#category : #'Spec2-Backend-Tests'
+}
+
+{ #category : #initialization }
+SpTMorphicUIRedrawer >> initializeSemaphore [
+	uiWaitingSemaphore := Semaphore new
+]
+
+{ #category : #testing }
+SpTMorphicUIRedrawer >> isRunningInUIProcess [
+	^ UIManager default uiProcess == Processor activeProcess
+]
+
+{ #category : #utilities }
+SpTMorphicUIRedrawer >> waitUntilUIRedrawed [
+	"I wait until the UI has been redrawn. 
+	I take care of selecting how to do it. 
+	If I am in the CI I should defer a semaphore signal. 
+	If I am running in the UI process I can directly execute a doOneCycle on the World.
+	If I am in the CI the tests and the UI run in different process. So I should not do a #doOneCycle.
+	If I do it, I am in a race condition!"
+
+	self isRunningInUIProcess
+		ifTrue: [ self currentWorld doOneCycle.
+			^ self ].
+
+	self currentWorld defer: [ uiWaitingSemaphore ifNotNil: #signal ].
+	uiWaitingSemaphore wait: self defaultWaitDuration
+]

--- a/src/Spec2-Morphic-Backend-Tests/SpPresenterFocusOrderTest.class.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpPresenterFocusOrderTest.class.st
@@ -1,6 +1,8 @@
 Class {
 	#name : #SpPresenterFocusOrderTest,
-	#superclass : #AbstractMorphicUITest,
+	#superclass : #TestCase,
+	#traits : 'SpTMorphicUIRedrawer',
+	#classTraits : 'SpTMorphicUIRedrawer classTrait',
 	#instVars : [
 		'mock'
 	],
@@ -69,6 +71,12 @@ SpPresenterFocusOrderTest >> pressTab [
 		control: false
 		option: false.
 	self waitUntilUIRedrawed		
+]
+
+{ #category : #running }
+SpPresenterFocusOrderTest >> setUp [
+	super setUp.
+	self initializeSemaphore
 ]
 
 { #category : #emulating }


### PR DESCRIPTION
Remove dependency on Glamour.

We already copied some code of Glamour in Spec. To avoid to have 3 time the same code in Pharo I extracted it in a trait used by spec. (I did not update Glamour since we plan to remove it)

Maybe later this trait should go in Morphic tests?