### PR TITLE
Layouts-should-not-depend-on-Core

### DIFF
--- a/src/Spec2-Layout/SpNonObservableSlotError.class.st
+++ b/src/Spec2-Layout/SpNonObservableSlotError.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #SpNonObservableSlotError,
 	#superclass : #Error,
-	#category : #'Spec2-Core-Observable'
+	#category : #'Spec2-Layout-Observable'
 }

--- a/src/Spec2-Layout/SpObservablePoint.class.st
+++ b/src/Spec2-Layout/SpObservablePoint.class.st
@@ -13,7 +13,7 @@ Class {
 		'#x => SpObservableSlot',
 		'#y'
 	],
-	#category : #'Spec2-Core-Observable'
+	#category : #'Spec2-Layout-Observable'
 }
 
 { #category : #initialization }

--- a/src/Spec2-Layout/SpObservableSlot.class.st
+++ b/src/Spec2-Layout/SpObservableSlot.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SpObservableSlot,
 	#superclass : #IndexedSlot,
-	#category : #'Spec2-Core-Observable'
+	#category : #'Spec2-Layout-Observable'
 }
 
 { #category : #'code generation' }

--- a/src/Spec2-Layout/SpValueHolder.class.st
+++ b/src/Spec2-Layout/SpValueHolder.class.st
@@ -19,7 +19,7 @@ Class {
 		'lock',
 		'value'
 	],
-	#category : #'Spec2-Core-Observable'
+	#category : #'Spec2-Layout-Observable'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec2-Layout/TSpObservable.trait.st
+++ b/src/Spec2-Layout/TSpObservable.trait.st
@@ -1,6 +1,6 @@
 Trait {
 	#name : #TSpObservable,
-	#category : #'Spec2-Core-Observable'
+	#category : #'Spec2-Layout-Observable'
 }
 
 { #category : #events }


### PR DESCRIPTION
Move observable slots to Layouts since they use it. It's not the ideal place but they will be extracted from Spec in the end so it will be ok for now.