### PR TITLE
850-selection-not-reset-when-assigning-new-items-to-a-list

### DIFF
--- a/src/BaselineOfSpec2/BaselineOfSpec2.class.st
+++ b/src/BaselineOfSpec2/BaselineOfSpec2.class.st
@@ -24,6 +24,7 @@ BaselineOfSpec2 >> baseline: spec [
 			package: 'Spec2-Commands' with: [ spec requires: #('Commander2') ];
 			package: 'Spec2-Layout' with: [ spec requires: #('Spec2-ObservableSlot') ];
 			package: 'Spec2-Transmission';
+			package: 'Spec2-Transmission-Tests' with: [ spec requires: #('Spec2-Transmission') ];
 			package: 'Spec2-Code' with: [ spec requires: #('Complishon') ];
 			package: 'Spec2-Code-Tests' with: [ spec requires: #('Spec2-Code') ];
 			package: 'Spec2-Adapters-Morphic' with: [ spec requires: #( 'Spec2-Core' ) ];
@@ -80,7 +81,8 @@ BaselineOfSpec2 >> baseline: spec [
 	spec group: 'Tests' with: #( 
 		'Core' 
 		'Spec2-Tests' 
-		'Spec2-Commander2-Tests').
+		'Spec2-Commander2-Tests'
+		'Spec2-Transmission-Tests').
 	spec group: 'MorphicSupportTests' with: #( 
 		'MorphicSupport' 
 		'Spec2-Code-Tests'  
@@ -93,8 +95,7 @@ BaselineOfSpec2 >> baseline: spec [
 		'Core'
 		'Morphic' 
 		'MorphicSupport'
-		'Spec2-Tests'
-		'Spec2-Morphic-Tests'
+		'Tests'
 		'MorphicSupportTests' ).
 
 	spec for: #'pharo8.x' do: [

--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -176,7 +176,8 @@ SpAbstractListPresenter >> items: aCollection [
 	aCollection is a collection of your domain specific items.
 	This creates a collection model"
 	
-	model collection: aCollection
+	model collection: aCollection.
+	self unselectAll.
 ]
 
 { #category : #private }

--- a/src/Spec2-Core/SpDropListPresenter.class.st
+++ b/src/Spec2-Core/SpDropListPresenter.class.st
@@ -167,6 +167,7 @@ SpDropListPresenter >> items: aList [
 		and: [ startsWithSelection 
 		and: [ self selection isEmpty ] ])
 		ifTrue: [ self selectIndex: 1 ]
+		ifFalse: [ self resetSelection ]
 ]
 
 { #category : #api }

--- a/src/Spec2-Examples/SpClassMethodBrowser.class.st
+++ b/src/Spec2-Examples/SpClassMethodBrowser.class.st
@@ -54,12 +54,17 @@ SpClassMethodBrowser >> classes: aList [
 
 { #category : #initialization }
 SpClassMethodBrowser >> connectPresenters [
-	classListPresenter transmitTo: methodListPresenter transform: [ :class | class methods sort: #selector descending ] postTransmission: [ :destination | destination selectIndex: 1 ].
-
+	classListPresenter
+		transmitTo: methodListPresenter
+		transform: [ :class | class ifNil: [ #() ] ifNotNil: [ class methods sort: #selector descending ] ]
+		postTransmission: [ :destination | destination selectIndex: 1 ].
+		
 	methodListPresenter
 		transmitTo: textPresenter
 		transform: [ :method | method ifNil: [ '' ] ifNotNil: #sourceCode ]
-		postTransmission: [ :destination :origin :transmited | transmited ifNotNil: [ destination behavior: transmited methodClass ] ]
+		postTransmission:
+			[ :destination :origin :transmited | 
+			transmited ifNotNil: [ destination behavior: transmited methodClass ] ]
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Tests/SpMultipleSelectionModeTest.class.st
+++ b/src/Spec2-Tests/SpMultipleSelectionModeTest.class.st
@@ -22,6 +22,20 @@ SpMultipleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged 
 ]
 
 { #category : #tests }
+SpMultipleSelectionModeTest >> testSelectionIsResetAfterItemsAssignment [
+	presenter
+		beMultipleSelection;
+		openWithSpec;
+		selectIndexes: #(1 2 3).
+
+	presenter items: #(2 5).
+
+	self 
+		assert: presenter selection selectedItems asArray
+		equals: #()
+]
+
+{ #category : #tests }
 SpMultipleSelectionModeTest >> testSelectionIsResetAfterSorting [
 	presenter := SpTablePresenter new.	"use a TablePresenter since ListPresenter cannot sort"
 	presenter

--- a/src/Spec2-Tests/SpSingleSelectionModeTest.class.st
+++ b/src/Spec2-Tests/SpSingleSelectionModeTest.class.st
@@ -19,6 +19,20 @@ SpSingleSelectionModeTest >> testDropListSelectionIsNotAffectedBySorting [
 ]
 
 { #category : #tests }
+SpSingleSelectionModeTest >> testDropListSelectionIsResetAfterItemsAssignment [
+	presenter := SpDropListPresenter new.
+	presenter
+		items: (1 to: 10) asArray;
+		selectIndex: 1.
+
+	presenter items: #(2 5).
+
+	self 
+		assert: presenter selection selectedItem
+		equals: nil
+]
+
+{ #category : #tests }
 SpSingleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged [
 	presenter := SpTablePresenter new. "use a TablePresenter since ListPresenter cannot sort"
 	presenter 
@@ -31,6 +45,20 @@ SpSingleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged [
 		selectIndex: 3.
 	
 	self assert: presenter selection selectedItem equals: 8
+]
+
+{ #category : #tests }
+SpSingleSelectionModeTest >> testSelectionIsResetAfterItemsAssignment [
+	presenter
+		beSingleSelection;
+		openWithSpec;
+		selectIndex: 1.
+
+	presenter items: #(2 5).
+
+	self 
+		assert: presenter selection selectedItem 
+		equals: nil
 ]
 
 { #category : #tests }

--- a/src/Spec2-Tools-Tests/SpChooseMethodUITest.class.st
+++ b/src/Spec2-Tools-Tests/SpChooseMethodUITest.class.st
@@ -27,7 +27,10 @@ SpChooseMethodUITest >> testClickOnClassSideRadioButtonShouldFillTheMethodList [
 	biChooseMethod packageList selectItem: SpMethodChooserMockClass package.
 	biChooseMethod classList selectItem: SpMethodChooserMockClass.
 	biChooseMethod radioButtonClassSide click.
-	self assertCollection: biChooseMethod methodList items hasSameElements: SpMethodChooserMockClass class methods
+	biChooseMethod protocolList selectIndex: 1.
+	self
+		assertCollection: biChooseMethod methodList items
+		hasSameElements: SpMethodChooserMockClass class methods
 ]
 
 { #category : #tests }

--- a/src/Spec2-Tools/SpChooseMethodUI.class.st
+++ b/src/Spec2-Tools/SpChooseMethodUI.class.st
@@ -212,9 +212,10 @@ SpChooseMethodUI >> packageList [
 SpChooseMethodUI >> packageListAction [
 	packageList
 		transmitTo: classList
-		transform: [ :selectedPacakge | 
-			selectedPacakge
-				ifNotNil: [ selectedPacakge classes asOrderedCollection ] ]
+		transform: [ :selectedPackage | 
+			selectedPackage
+				ifNil: [ #() ]
+				ifNotNil: [ selectedPackage classes asOrderedCollection ] ]
 		postTransmission: [ classList selectIndex: 1 ]
 ]
 

--- a/src/Spec2-Transmission-Tests/SpListTransmissionTest.class.st
+++ b/src/Spec2-Transmission-Tests/SpListTransmissionTest.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #SpListTransmissionTest,
+	#superclass : #TestCase,
+	#category : #'Spec2-Transmission-Tests'
+}
+
+{ #category : #tests }
+SpListTransmissionTest >> testSelectionIsNilAfterItemsAssignment [
+	| presenter |
+	presenter := SpTransmissionTestPresenter new.
+	presenter selectIndex: 2.
+
+	presenter items: #(5 6).
+
+	self assert: presenter label equals: 'nil'
+]
+
+{ #category : #tests }
+SpListTransmissionTest >> testTransmissionIsDoneWhenSelectingAnItem [
+	| presenter |
+	presenter := SpTransmissionTestPresenter new.
+
+	presenter selectIndex: 2.
+
+	self assert: presenter label equals: '2'
+]
+
+{ #category : #tests }
+SpListTransmissionTest >> testTransmitNilWhenUnselecteAllItems [
+	| presenter |
+	presenter := SpTransmissionTestPresenter new.
+	presenter selectIndex: 2.
+
+	presenter unselectAll.
+
+	self assert: presenter label equals: 'nil'
+]

--- a/src/Spec2-Transmission-Tests/SpTransmissionTestPresenter.class.st
+++ b/src/Spec2-Transmission-Tests/SpTransmissionTestPresenter.class.st
@@ -1,0 +1,66 @@
+"
+A presenter with a list and a label used to test Spec transmission.
+Selected element in the list is transmitted to the label using #asString to transform it.
+"
+Class {
+	#name : #SpTransmissionTestPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'list',
+		'label'
+	],
+	#category : #'Spec2-Transmission-Tests'
+}
+
+{ #category : #specs }
+SpTransmissionTestPresenter class >> defaultSpec [
+	^ SpBoxLayout newVertical
+		add: #list;
+		add: #label expand: false;
+		yourself
+]
+
+{ #category : #specs }
+SpTransmissionTestPresenter class >> example [
+	^ self new 
+		openWithSpec;
+		yourself
+]
+
+{ #category : #initialization }
+SpTransmissionTestPresenter >> connectPresenters [
+	list transmitTo: label transform: [ :item | item asString ]
+]
+
+{ #category : #initialization }
+SpTransmissionTestPresenter >> initializePresenters [
+	list := SpTablePresenter new
+		items: (1 to: 5) asOrderedCollection;
+		yourself.
+	label := SpLabelPresenter new.
+]
+
+{ #category : #accessing }
+SpTransmissionTestPresenter >> items: aCollection [
+	list items: aCollection
+]
+
+{ #category : #accessing }
+SpTransmissionTestPresenter >> label [
+	^ label label
+]
+
+{ #category : #selecting }
+SpTransmissionTestPresenter >> selectIndex: anIndex [
+	list selectIndex: anIndex
+]
+
+{ #category : #selecting }
+SpTransmissionTestPresenter >> selection [
+	^ list selection
+]
+
+{ #category : #selecting }
+SpTransmissionTestPresenter >> unselectAll [
+	list unselectAll
+]

--- a/src/Spec2-Transmission-Tests/package.st
+++ b/src/Spec2-Transmission-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Spec2-Transmission-Tests' }


### PR DESCRIPTION
Add tests for Spec transmissions