### PR TITLE
Fix #889.

### DIFF
--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -123,16 +123,22 @@ SpAbstractListPresenter >> isMultipleSelection [
 ]
 
 { #category : #accessing }
-SpAbstractListPresenter >> itemAt: anInteger [ 
-	
-	^ self model at: anInteger
+SpAbstractListPresenter >> itemAt: index [ 
+	"If there is an adapter the widget items indexes can be different thant the model items indexes, 
+	e.g. when the sort by a column is activated. In this case, ask the adapter to get the element displayed at index."
+
+	^ self adapter 
+			ifNotNil: [ :anAdapter | anAdapter elementAt: index ]
+			ifNil: [ self model at: index ].
+				
+	"^ self model at: index"
 ]
 
 { #category : #private }
 SpAbstractListPresenter >> itemAtPath: anArray [
 	"This is to provide polymorphism with SpTreeTablePresentrer"
 
-	^ self listElementAt: anArray first
+	^ self itemAt: anArray first
 ]
 
 { #category : #TOREMOVE }
@@ -164,17 +170,8 @@ SpAbstractListPresenter >> items: aCollection [
 ]
 
 { #category : #private }
-SpAbstractListPresenter >> listElementAt: anIndex [
-	"Return the item at index _anIndex_"
-
-	^ self model at: anIndex ifAbsent: [ nil ]
-]
-
-{ #category : #private }
-SpAbstractListPresenter >> listElementAt: anIndex ifAbsent: aBlock [	
-	"Return the item at index _anIndex_"
-	
-	^ self listItems at: anIndex ifAbsent: aBlock
+SpAbstractListPresenter >> itemsAt: aCollectionOfIndex [
+	^ aCollectionOfIndex collect: [ :anIndex | self itemAt: anIndex ]
 ]
 
 { #category : #api }
@@ -267,19 +264,14 @@ SpAbstractListPresenter >> selectItems: aCollection [
 SpAbstractListPresenter >> selectedItems [
 	"Return all the selected items in the case of a multiple selection list"
 
-	^ self selectedItemsAtIndexes: self selection selectedIndexes
-]
-
-{ #category : #private }
-SpAbstractListPresenter >> selectedItemsAtIndexes: aCollectionOfIndex [
-	^ aCollectionOfIndex collect: [ :anIndex | self listElementAt: anIndex ]
+	^ self selection selectedItems
 ]
 
 { #category : #api }
 SpAbstractListPresenter >> selectedItemsSorted [
 	"return all the selected items sorted by their index"
 
-	^ self selectedItemsAtIndexes: self selection selectedIndexes sort
+	^ self itemsAt: self selection selectedIndexes sort
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Core/SpAbstractSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractSelectionMode.class.st
@@ -152,6 +152,7 @@ SpAbstractSelectionMode >> whenChangedDo: aBlock [
 
 { #category : #accessing }
 SpAbstractSelectionMode >> widget [
+	"Returns the presenter"
 	^ widget
 ]
 

--- a/src/Spec2-Core/SpMultipleSelectionMode.class.st
+++ b/src/Spec2-Core/SpMultipleSelectionMode.class.st
@@ -68,14 +68,16 @@ SpMultipleSelectionMode >> selectAll [
 { #category : #selecting }
 SpMultipleSelectionMode >> selectIndexes: aCollection [
 	| indexes |
-	indexes := (aCollection collect: [ :each | self withinRangeIndex: each ]) asSet.
-	"If all elements are out of range, just ignore the event like for single selection."
-	(indexes isNotEmpty and: [ indexes allSatisfy: [ :each | each = 0 ] ]) ifTrue: [ ^ self ].
+	indexes := aCollection 
+		collect: [ :each | self withinRangeIndex: each ]
+		thenReject: [ :each | each = 0 ]. "0 index means out of range"
+	(aCollection isNotEmpty and: [ indexes isEmpty ]) "all indexes are out of range"
+		ifTrue: [ ^ #() ].
 
-	indexes := indexes reject: [ :each | each = 0 ].
-	indexes = self selectedIndexes asSet ifTrue: [ ^ self ].
+	indexes := indexes asOrderedCollection removeDuplicates.
+	indexes = self selectedIndexes ifTrue: [ ^ self ].
 
-	^ selectedIndexes := indexes asOrderedCollection
+	^ selectedIndexes := indexes
 ]
 
 { #category : #selecting }
@@ -91,10 +93,13 @@ SpMultipleSelectionMode >> selectedIndexes [
 { #category : #selecting }
 SpMultipleSelectionMode >> selectedItems [
 
-	^ self selectedIndexes collect: [ :index | 
-		self widget adapter 
-			ifNotNil: [ :anAdapter | anAdapter elementAt: index ]
-			ifNil: [ self model at: index ] ]
+	^ self widget itemsAt: self selectedIndexes
+]
+
+{ #category : #selecting }
+SpMultipleSelectionMode >> selectedItemsSortedByIndex [
+
+	^ self widget itemsAt: self selectedIndexes sort
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Tests/SpAbstractListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractListPresenterTest.class.st
@@ -131,6 +131,21 @@ SpAbstractListPresenterTest >> testSelectAll [
 		equals: #(10 20 30)
 ]
 
+{ #category : #tests }
+SpAbstractListPresenterTest >> testSelectedItemsSortedByIndex [
+
+	presenter beMultipleSelection.
+	presenter 
+		selectIndex: 3;
+		selectIndex: 1.
+	self 
+		assert: presenter selection selectedItems asArray
+		equals: #(30 10). 
+	self 
+		assert: presenter selection selectedItemsSortedByIndex asArray
+		equals: #(10 30)
+]
+
 { #category : #'tests-smoke' }
 SpAbstractListPresenterTest >> testSetSortingBlockBeforeItems [
 	| count |

--- a/src/Spec2-Tests/SpComponentListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpComponentListPresenterTest.class.st
@@ -120,6 +120,21 @@ SpComponentListPresenterTest >> testSelectAll [
 		equals: #('10' '20' '30')
 ]
 
+{ #category : #tests }
+SpComponentListPresenterTest >> testSelectedItemsSortedByIndex [
+
+	presenter beMultipleSelection.
+	presenter 
+		selectIndex: 3;
+		selectIndex: 1.
+	self 
+		assert: (presenter selection selectedItems collect: #label as: Array)
+		equals: #('30' '10'). 
+	self 
+		assert: (presenter selection selectedItemsSortedByIndex collect: #label as: Array)
+		equals: #('10' '30')
+]
+
 { #category : #'tests-smoke' }
 SpComponentListPresenterTest >> testSetSortingBlockBeforeItems [
 	| count |

--- a/src/Spec2-Tests/SpTablePresenterTest.class.st
+++ b/src/Spec2-Tests/SpTablePresenterTest.class.st
@@ -72,6 +72,23 @@ SpTablePresenterTest >> testHideColumnHeadersRaisesOneEventOnly [
 	self assert: count equals: 1
 ]
 
+{ #category : #tests }
+SpTablePresenterTest >> testSelectedItemsReturnsRightElementAfterSortingOfElementsChanged [
+	[ presenter
+		addColumn: (SpStringTableColumn title: ' i ' evaluated: #value);
+		addColumn: (SpStringTableColumn title: ' 1 / i ' evaluated: [ :item | (1 / item) value ]);
+		openWithSpec;
+		selectIndex: 1. "10"
+		
+	"sort by 1/i ascending"
+	presenter clickOnColumnHeaderAt: 2.
+
+	presenter selectIndex: 1.
+	
+	self assert: presenter selectedItems first equals: 30 "items are still sorted by 1/i ascending value" ]
+		ensure: [ presenter delete ]
+]
+
 { #category : #'tests-activation' }
 SpTablePresenterTest >> testShowColumnHeadersRaisesOneEventOnly [
 


### PR DESCRIPTION
Selection delegates item fetching from index to the presenter. 
More uniform selectors for item fetching.
Keep selection order in mutlitple selection.
