### PR TITLE
Reverse sense of #allowingContextMenu

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -143,7 +143,7 @@ SpCodePresenter >> allowingContextMenu [
 	 When allowing the code context menu, visible operations will be collected from  `SpPresenter>>#rootCommandsGroup` and `SpTextPresenter>>#editionCommandsGroup`, and what user 
 	 define on `SpAbstractTextPresenter>>contextMenu:` will be appended between those groups."
 	
-	self overrideContextMenu: true
+	self overrideContextMenu: false
 ]
 
 { #category : #private }


### PR DESCRIPTION
It looks like #allowingContextMenu, introduced as part of the fix for issue #933, had its sense accidentally backward.