### PR TITLE
 Do not modify model collection when sorting but use a copy of it. 

### DIFF
--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -92,7 +92,7 @@ SpCollectionListModel >> items [
 { #category : #refreshing }
 SpCollectionListModel >> refreshList [
 
-	self sortingBlock ifNotNil: [ :aSortFunction | collection sort: aSortFunction ]
+	self sortingBlock ifNotNil: [ :aSortFunction | collection := collection sorted: aSortFunction ]
 ]
 
 { #category : #collection }


### PR DESCRIPTION
Fixes  pharo-project/pharo#7359