### PR TITLE
parentLayoutOf

### DIFF
--- a/src/Spec2-Layout/SpExecutableLayout.class.st
+++ b/src/Spec2-Layout/SpExecutableLayout.class.st
@@ -147,6 +147,23 @@ SpExecutableLayout >> isSpLayout [
 ]
 
 { #category : #accessing }
+SpExecutableLayout >> parentLayoutOf: aKey [ 
+
+	"Find a child layout that contains a presenter of given key. Useful if you need to find a parent layout of a presenter that you need to replace."
+
+    (self children anySatisfy: [ :each | each = aKey ])
+        ifTrue: [ ^ self ].
+    
+    self children do: [ :each | 
+        each isSpLayout ifTrue: [ 
+            | found | 
+            found := each parentLayoutOf: aKey.
+            found ifNotNil: [ ^ found ] ] ].
+        
+    ^ nil 
+]
+
+{ #category : #accessing }
 SpExecutableLayout >> presenter [
 
 	^ adapter ifNotNil: [ adapter presenter ]


### PR DESCRIPTION
Find a child layout that contains a presenter of given key. Useful if you need to find a parent layout of a presenter that you need to replace.