### PR TITLE
Fix visibility of workspace variables in debugIt expressions

### DIFF
--- a/src/Spec2-Code-Commands/SpCodeDebugItCommand.class.st
+++ b/src/Spec2-Code-Commands/SpCodeDebugItCommand.class.st
@@ -35,7 +35,7 @@ SpCodeDebugItCommand >> compile: aStream for: anObject in: evalContext [
 		source: aStream;
 		class: methodClass;
 		context: evalContext;
-		requestor: nil;
+		requestor: context; "it should enable a visibility of current tool variables in new debugger"
 		noPattern: true;
 		failBlock: [ ^ nil ];
 		compile

--- a/src/Spec2-Code-Commands/SpCodeDebugItCommand.class.st
+++ b/src/Spec2-Code-Commands/SpCodeDebugItCommand.class.st
@@ -67,9 +67,9 @@ SpCodeDebugItCommand >> debug: aCompiledMethod receiver: anObject in: evalContex
 	process := [ 
 		aCompiledMethod
 			valueWithReceiver: anObject
-			arguments: (evalContext 
-				ifNotNil: [ { evalContext } ] 
-				ifNil: [ #() ] ) ]
+			arguments: (aCompiledMethod numArgs = 0 
+				ifTrue: [ #() ] 
+				ifFalse: [ { evalContext } ] ) ]
 			newProcess.
 	suspendedContext := process suspendedContext.
 	

--- a/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
@@ -197,14 +197,18 @@ SpMorphicCodeAdapter >> setEditingModeFor: textArea [
 
 { #category : #private }
 SpMorphicCodeAdapter >> setEditingModeFor: textArea withBehavior: aBehavior forScripting: aBoolean [
-
 	textArea model: self.
 	(aBoolean or: [ aBehavior isNil ]) 
 		ifTrue: [ 
 			textArea beForSmalltalkScripting.
 			textArea editingMode classOrMetaClass: aBehavior ]
 		ifFalse: [
-			textArea beForSmalltalkCodeInClass: aBehavior ]
+			textArea beForSmalltalkCodeInClass: aBehavior ].
+	"Following code should bring correct requestor (a code presenter) with a proper code interaction model into styler to enable a visibility of external variables (like workspace variables)"
+	textArea shoutStyler styler 
+		isForWorkspace: aBoolean;
+		workspace: self presenter.
+	textArea shoutStyler refreshStyling
 ]
 
 { #category : #'widget API' }


### PR DESCRIPTION
Fixes integration between SpCodePresenter and morphic widget to properly setup a requestor for related compilation operations:
- debugIt command
- code highlighting

It fixes the visibility of workspace variables in debugIt expressions and allows further improvement to have transparent temps.

The fix requires extra PR for NewTools to have an effect: https://github.com/pharo-spec/NewTools/pull/122.