### PR TITLE
Fixed bug in SpFilteringListPresenter

### DIFF
--- a/src/Spec2-Core/SpFilteringListPresenter.class.st
+++ b/src/Spec2-Core/SpFilteringListPresenter.class.st
@@ -13,10 +13,10 @@ Class {
 	#name : #SpFilteringListPresenter,
 	#superclass : #SpPresenter,
 	#instVars : [
-		'itemFilter',
 		'unfilteredItems',
 		'listPresenter',
-		'filterInputPresenter'
+		'filterInputPresenter',
+		'itemFilterBlock'
 	],
 	#category : #'Spec2-Core-Widgets-Advanced'
 }
@@ -83,18 +83,20 @@ SpFilteringListPresenter >> filterInputPresenter [
 
 { #category : #private }
 SpFilteringListPresenter >> filterListItems: pattern [
-	| filteredItems |
 
+	| filteredItems |
 	unfilteredItems ifNil: [ unfilteredItems := self items ].
+	(unfilteredItems includesAll: self items) ifFalse: [ 
+		unfilteredItems := self items ].
 	pattern ifEmpty: [ 
 		self items: unfilteredItems.
 		^ self ].
-	
-	filteredItems := unfilteredItems select: [ :item |
-		itemFilter 
-			value: (self display value: item)
-			value: pattern ].
-	
+
+	filteredItems := unfilteredItems select: [ :item | 
+		                 itemFilterBlock
+			                 value: (self display value: item)
+			                 value: pattern ].
+
 	self items: filteredItems
 ]
 
@@ -107,7 +109,9 @@ SpFilteringListPresenter >> filterText [
 { #category : #initialization }
 SpFilteringListPresenter >> initializePresenters [
 
-	filterInputPresenter := self newTextInput placeholder: 'Filter...'; yourself.
+	filterInputPresenter := self newTextInput
+		                        placeholder: 'Filter...';
+		                        yourself.
 	listPresenter := self newListToFilter.
 	self matchSubstring
 ]
@@ -115,13 +119,13 @@ SpFilteringListPresenter >> initializePresenters [
 { #category : #private }
 SpFilteringListPresenter >> itemFilter [
 
-	^ itemFilter
+	^ itemFilterBlock
 ]
 
 { #category : #api }
 SpFilteringListPresenter >> itemFilter: aBlock [
 
-	itemFilter := aBlock
+	itemFilterBlock := aBlock
 ]
 
 { #category : #api }
@@ -144,17 +148,15 @@ SpFilteringListPresenter >> listPresenter [
 { #category : #initialization }
 SpFilteringListPresenter >> matchBeginOfString [
 
-	itemFilter := [ :each :pattern | 
+	itemFilterBlock := [ :each :pattern | 
 	              each asLowercase beginsWith: pattern asLowercase ]
 ]
 
 { #category : #initialization }
 SpFilteringListPresenter >> matchSubstring [
 
-	itemFilter := [ :each :pattern | 
-		each 
-			includesSubstring: pattern asLowercase 
-			caseSensitive: false ]
+	itemFilterBlock := [ :each :pattern | 
+	              each asLowercase includesSubstring: pattern asLowercase ]
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Tests/SpFilteringListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpFilteringListPresenterTest.class.st
@@ -82,17 +82,37 @@ SpFilteringListPresenterTest >> testFilterListItems [
 		             Set.
 		             Dictionary }.
 	listWithFilter items: listItems.
-	listWithFilter applyFilter: 'collection'.
+	listWithFilter filterListItems: 'collection'.
 	self assertCollection: listWithFilter items hasSameElements: { 
 			OrderedCollection.
 			SequenceableCollection }.
-	listWithFilter applyFilter: 'xyz'.
+	listWithFilter filterListItems: 'xyz'.
 	self assertEmpty: listWithFilter items.
-	listWithFilter applyFilter: 'array'.
+	listWithFilter filterListItems: 'array'.
 	self
 		assertCollection: listWithFilter items
 		hasSameElements: { Array }.
-	listWithFilter applyFilter: ''.
+	listWithFilter filterListItems: ''.
+	self
+		assertCollection: listWithFilter items
+		hasSameElements: listItems.
+	listItems := 1 to: 10.
+	listWithFilter items: listItems.
+	listWithFilter filterListItems: 'collection'.
+	self assertEmpty: listWithFilter items.
+	listWithFilter filterListItems: '5'.
+	self assertCollection: listWithFilter items hasSameElements: #( 5 ).
+	listWithFilter filterListItems: ''.
+	self
+		assertCollection: listWithFilter items
+		hasSameElements: listItems.
+	listItems := #( 'a' 'e' 'i' 'o' 'u' ).
+	listWithFilter listPresenter items: listItems.
+	listWithFilter filterListItems: '5'.
+	self assertEmpty: listWithFilter items.
+	listWithFilter filterListItems: 'a'.
+	self assertCollection: listWithFilter items hasSameElements: #( 'a' ).
+	listWithFilter filterListItems: ''.
 	self
 		assertCollection: listWithFilter items
 		hasSameElements: listItems


### PR DESCRIPTION
It was a bug: When changing the items of a spFilteringList that already had items, the filter functionality stops working.
For example, if you do `SpFilteringListPresenter new items: anItems`. Typing something in the filter box and then setting the new items `filteringList items: newItems`. The filter functionality stops working. The bug was fixed.

Also, the instance variable name of filterInput was changed to filterInputBlock.

And finally, the test for the filterListItems; method now is more detailed.