### PR TITLE
fixing-moving-buttons-in-toolbar

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpToolbarButtonMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpToolbarButtonMorph.class.st
@@ -130,3 +130,10 @@ SpToolbarButtonMorph >> normalFillStyle [
 
 	^ Color transparent
 ]
+
+{ #category : #style }
+SpToolbarButtonMorph >> pressedBorderStyle [
+	"Return the pressed borderStyle of the receiver."
+
+	^ self normalBorderStyle
+]

--- a/src/Spec2-Adapters-Morphic/SpToolbarMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpToolbarMorph.class.st
@@ -140,8 +140,8 @@ SpToolbarMorph >> initialize [
 	self
 		changeTableLayout;
 		listDirection: #leftToRight;
-		hResizing: #shrinkWrap;
-		vResizing: #shrinkWrap;
+		hResizing: #spaceFill;
+		vResizing: #rigid;
 		wrapCentering: #center; 
 		color: self defaultColor;
 		extent: 0@0.

--- a/src/Spec2-Core/SpToolbarDisplayModeIconAndLabel.class.st
+++ b/src/Spec2-Core/SpToolbarDisplayModeIconAndLabel.class.st
@@ -17,7 +17,7 @@ SpToolbarDisplayModeIconAndLabel >> configureButton: aButton item: aToolbarItem 
 
 { #category : #accessing }
 SpToolbarDisplayModeIconAndLabel >> extent [
-	^ 45@40
+	^ 45@45
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The border style of the toolbar button should not have style different than the one when it is in normal state.

Having additional border makes it bigger and it moves, producing a flick.
The SpToolbarMorph should be rigid vertically and spaceFill horizontally to honor the values set has height by the SpToolbarDisplayMode
The extent when the SpToolbarDisplayModeIconAndLabel should be square.

Fix https://github.com/pharo-vcs/iceberg/issues/1431