### PR TITLE
1013-Changing-a-Toolbar-should-affect-the-window

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
@@ -4,6 +4,9 @@ I am the adapter used to bridge window presenters and windows or worlds
 Class {
 	#name : #SpAbstractMorphicWindowAdapter,
 	#superclass : #SpAbstractMorphicAdapter,
+	#instVars : [
+		'toolbarMorph'
+	],
 	#category : #'Spec2-Adapters-Morphic-Base'
 }
 
@@ -30,7 +33,11 @@ SpAbstractMorphicWindowAdapter >> addContent: aMorph toWindow: aSpecWindow [
 
 	"add all decorations (menu, toolbar and statusbar)"
 	self model hasMenu ifTrue: [ self addMenuTo: containerMorph ].
-	self model hasToolbar ifTrue: [ self addToolbarTo: containerMorph ].
+	self model hasToolbar ifTrue: [ self setToolbarTo: containerMorph ].
+
+	"Register for changes in the toolbar"
+	self model whenToolbarChangedDo: [ self setToolbarTo: containerMorph ].
+
 	containerMorph addMorphBack: aMorph.
 	aMorph
 		hResizing: #spaceFill;
@@ -63,17 +70,6 @@ SpAbstractMorphicWindowAdapter >> addStatusBarTo: aMorph [
 ]
 
 { #category : #private }
-SpAbstractMorphicWindowAdapter >> addToolbarTo: aMorph [
-
-	| toolbarMorph |
-	toolbarMorph := self presenter toolbar buildWithSpec.
-	aMorph addMorphBack: toolbarMorph.
-	toolbarMorph
-		hResizing: #spaceFill;
-		vResizing: #rigid
-]
-
-{ #category : #private }
 SpAbstractMorphicWindowAdapter >> newContainerMorph [
 
 	^ PanelMorph new
@@ -82,4 +78,22 @@ SpAbstractMorphicWindowAdapter >> newContainerMorph [
 		  vResizing: #spaceFill;
 		  listDirection: #topToBottom;
 		  yourself
+]
+
+{ #category : #private }
+SpAbstractMorphicWindowAdapter >> setToolbarTo: aMorph [
+
+	| newToolbarMorph |
+	newToolbarMorph := self presenter toolbar buildWithSpec.
+	newToolbarMorph
+		hResizing: #spaceFill;
+		vResizing: #rigid.
+	
+	"If we have a toolbar morph, we replace with the new one"
+	toolbarMorph 
+		ifNil: [	aMorph addMorphBack: newToolbarMorph ]
+		ifNotNil: [ aMorph replaceSubmorph: toolbarMorph by: newToolbarMorph ].
+		
+	toolbarMorph := newToolbarMorph
+
 ]

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
@@ -100,7 +100,7 @@ SpAbstractMorphicWindowAdapter >> setToolbarTo: aMorph [
 	
 	"If we have a toolbar morph, we replace with the new one"
 	toolbarMorph 
-		ifNil: [	aMorph addMorphBack: newToolbarMorph ]
+		ifNil: [	aMorph addMorph: newToolbarMorph ]
 		ifNotNil: [ aMorph replaceSubmorph: toolbarMorph by: newToolbarMorph ].
 		
 	toolbarMorph := newToolbarMorph

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
@@ -33,7 +33,8 @@ SpAbstractMorphicWindowAdapter >> addContent: aMorph toWindow: aSpecWindow [
 
 	"add all decorations (menu, toolbar and statusbar)"
 	self model hasMenu ifTrue: [ self addMenuTo: containerMorph ].
-	self model hasToolbar ifTrue: [ self setToolbarTo: containerMorph ].
+
+	self setToolbarTo: containerMorph.
 
 	"Register for changes in the toolbar"
 	self model whenToolbarChangedDo: [ self setToolbarTo: containerMorph ].
@@ -84,6 +85,14 @@ SpAbstractMorphicWindowAdapter >> newContainerMorph [
 SpAbstractMorphicWindowAdapter >> setToolbarTo: aMorph [
 
 	| newToolbarMorph |
+	
+	self model hasToolbar 
+		ifFalse: [ 
+			toolbarMorph ifNotNil: [ 
+				aMorph removeMorph: toolbarMorph.
+				toolbarMorph := nil.  ].
+			^ self. ].
+	
 	newToolbarMorph := self presenter toolbar buildWithSpec.
 	newToolbarMorph
 		hResizing: #spaceFill;

--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -629,6 +629,17 @@ SpWindowPresenter >> whenResizingDo: aBlock [
 ]
 
 { #category : #'api-events' }
+SpWindowPresenter >> whenToolbarChangedDo: aBlock [
+	"Inform when the toolbar has been changed.
+	
+	 `aBlock` receives two optional arguments 
+	 - new toolbar
+	 - old toolbar"
+	
+	self property: #toolbar whenChangedDo: aBlock
+]
+
+{ #category : #'api-events' }
 SpWindowPresenter >> whenWillCloseDo: aBlock [
 	"Inform when window will close, allowing process before the close happen. 
 	 Note that user cannot cancel the close operation using this event. 


### PR DESCRIPTION
Adding to the MorphicWindowAdapter the responsibility to handle the change of the toolbar in the presenter.
When a new toolbar is set, we need to replace the old one.

Fix #1013 
Fix https://github.com/pharo-vcs/iceberg/issues/1416
Fix https://github.com/pharo-vcs/iceberg/issues/1407