### PR TITLE
1012-SpTestPresenterWithToolbar-has-class-var-that-is-not-referenced

### DIFF
--- a/src/Spec2-Tests/SpTestPresenterWithToolbar.class.st
+++ b/src/Spec2-Tests/SpTestPresenterWithToolbar.class.st
@@ -7,9 +7,6 @@ Class {
 	#instVars : [
 		'button'
 	],
-	#classVars : [
-		'TestWorld'
-	],
 	#category : #'Spec2-Tests-Core-Support'
 }
 


### PR DESCRIPTION
remove the unused class var from SpTestPresenterWithToolbar
fixes #1012

