### PR TITLE
Rename SpNotificationType hierarchy.

### DIFF
--- a/src/Spec2-Core/SpErrorNotificationType.class.st
+++ b/src/Spec2-Core/SpErrorNotificationType.class.st
@@ -1,0 +1,14 @@
+"
+I'm a notification type error
+"
+Class {
+	#name : #SpErrorNotificationType,
+	#superclass : #SpNotificationType,
+	#category : #'Spec2-Core-Base'
+}
+
+{ #category : #dispatching }
+SpErrorNotificationType >> notify: aSpecNotification on: aNotificationAware [
+	
+	aNotificationAware notifyError: aSpecNotification
+]

--- a/src/Spec2-Core/SpInfoNotificationType.class.st
+++ b/src/Spec2-Core/SpInfoNotificationType.class.st
@@ -1,0 +1,14 @@
+"
+I'm a notification type information
+"
+Class {
+	#name : #SpInfoNotificationType,
+	#superclass : #SpNotificationType,
+	#category : #'Spec2-Core-Base'
+}
+
+{ #category : #dispatching }
+SpInfoNotificationType >> notify: aSpecNotification on: aNotificationAware [
+	
+	aNotificationAware notifyInfo: aSpecNotification
+]

--- a/src/Spec2-Core/SpNotificationType.class.st
+++ b/src/Spec2-Core/SpNotificationType.class.st
@@ -13,13 +13,13 @@ Class {
 { #category : #accessing }
 SpNotificationType class >> error [
 
-	^ SpNotificationTypeError uniqueInstance
+	^ SpErrorNotificationType uniqueInstance
 ]
 
 { #category : #accessing }
 SpNotificationType class >> info [
 
-	^ SpNotificationTypeInfo uniqueInstance
+	^ SpInfoNotificationType uniqueInstance
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Core/SpNotificationTypeError.class.st
+++ b/src/Spec2-Core/SpNotificationTypeError.class.st
@@ -3,12 +3,11 @@ I'm a notification type error
 "
 Class {
 	#name : #SpNotificationTypeError,
-	#superclass : #SpNotificationType,
+	#superclass : #SpErrorNotificationType,
 	#category : #'Spec2-Core-Base'
 }
 
-{ #category : #dispatching }
-SpNotificationTypeError >> notify: aSpecNotification on: aNotificationAware [
-	
-	aNotificationAware notifyError: aSpecNotification
+{ #category : #testing }
+SpNotificationTypeError class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Spec2-Core/SpNotificationTypeInfo.class.st
+++ b/src/Spec2-Core/SpNotificationTypeInfo.class.st
@@ -3,12 +3,11 @@ I'm a notification type information
 "
 Class {
 	#name : #SpNotificationTypeInfo,
-	#superclass : #SpNotificationType,
+	#superclass : #SpInfoNotificationType,
 	#category : #'Spec2-Core-Base'
 }
 
-{ #category : #dispatching }
-SpNotificationTypeInfo >> notify: aSpecNotification on: aNotificationAware [
-	
-	aNotificationAware notifyInfo: aSpecNotification
+{ #category : #testing }
+SpNotificationTypeInfo class >> isDeprecated [ 
+	^ true
 ]


### PR DESCRIPTION
SpNotificationTypeError is not an error itself but a notification of type error.
SpNotificationTypeInfo is not an information either but a notification of type information.