### PR TITLE
Rename SpPopoverPosition hierarchy.

### DIFF
--- a/src/Spec2-Core/SpPopoverBottomPosition.class.st
+++ b/src/Spec2-Core/SpPopoverBottomPosition.class.st
@@ -1,0 +1,14 @@
+"
+I define a popover needs to be shown at the bottom of its owner.
+"
+Class {
+	#name : #SpPopoverBottomPosition,
+	#superclass : #SpPopoverPosition,
+	#category : #'Spec2-Core-Support'
+}
+
+{ #category : #operations }
+SpPopoverBottomPosition >> applyTo: aWidget [
+
+	aWidget bePositionBottom
+]

--- a/src/Spec2-Core/SpPopoverLeftPosition.class.st
+++ b/src/Spec2-Core/SpPopoverLeftPosition.class.st
@@ -1,0 +1,14 @@
+"
+I define a popover needs to be shown at the left of its owner.
+"
+Class {
+	#name : #SpPopoverLeftPosition,
+	#superclass : #SpPopoverPosition,
+	#category : #'Spec2-Core-Support'
+}
+
+{ #category : #operations }
+SpPopoverLeftPosition >> applyTo: aWidget [
+
+	aWidget bePositionLeft
+]

--- a/src/Spec2-Core/SpPopoverPosition.class.st
+++ b/src/Spec2-Core/SpPopoverPosition.class.st
@@ -14,13 +14,13 @@ Class {
 { #category : #accessing }
 SpPopoverPosition class >> bottom [
 
-	^ SpPopoverPositionBottom uniqueInstance
+	^ SpPopoverBottomPosition uniqueInstance
 ]
 
 { #category : #accessing }
 SpPopoverPosition class >> left [
 
-	^ SpPopoverPositionLeft uniqueInstance
+	^ SpPopoverLeftPosition uniqueInstance
 ]
 
 { #category : #'instance creation' }
@@ -32,13 +32,13 @@ SpPopoverPosition class >> new [
 { #category : #accessing }
 SpPopoverPosition class >> right [
 
-	^ SpPopoverPositionRight uniqueInstance
+	^ SpPopoverRightPosition uniqueInstance
 ]
 
 { #category : #accessing }
 SpPopoverPosition class >> top [
 
-	^ SpPopoverPositionTop uniqueInstance
+	^ SpPopoverTopPosition uniqueInstance
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Core/SpPopoverPositionBottom.class.st
+++ b/src/Spec2-Core/SpPopoverPositionBottom.class.st
@@ -3,12 +3,12 @@ I define a popover needs to be shown at the bottom of its owner.
 "
 Class {
 	#name : #SpPopoverPositionBottom,
-	#superclass : #SpPopoverPosition,
+	#superclass : #SpPopoverBottomPosition,
 	#category : #'Spec2-Core-Support'
 }
 
-{ #category : #operations }
-SpPopoverPositionBottom >> applyTo: aWidget [
+{ #category : #testing }
+SpPopoverPositionBottom class >> isDeprecated [ 
 
-	aWidget bePositionBottom
+	^ true
 ]

--- a/src/Spec2-Core/SpPopoverPositionLeft.class.st
+++ b/src/Spec2-Core/SpPopoverPositionLeft.class.st
@@ -3,12 +3,11 @@ I define a popover needs to be shown at the left of its owner.
 "
 Class {
 	#name : #SpPopoverPositionLeft,
-	#superclass : #SpPopoverPosition,
+	#superclass : #SpPopoverLeftPosition,
 	#category : #'Spec2-Core-Support'
 }
 
-{ #category : #operations }
-SpPopoverPositionLeft >> applyTo: aWidget [
-
-	aWidget bePositionLeft
+{ #category : #testing }
+SpPopoverPositionLeft class >> isDeprecated [  
+	^ true
 ]

--- a/src/Spec2-Core/SpPopoverPositionRight.class.st
+++ b/src/Spec2-Core/SpPopoverPositionRight.class.st
@@ -3,12 +3,11 @@ I define a popover needs to be shown at the right of its owner.
 "
 Class {
 	#name : #SpPopoverPositionRight,
-	#superclass : #SpPopoverPosition,
+	#superclass : #SpPopoverRightPosition,
 	#category : #'Spec2-Core-Support'
 }
 
-{ #category : #operations }
-SpPopoverPositionRight >> applyTo: aWidget [
-
-	aWidget bePositionRight
+{ #category : #testing }
+SpPopoverPositionRight class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Spec2-Core/SpPopoverPositionTop.class.st
+++ b/src/Spec2-Core/SpPopoverPositionTop.class.st
@@ -3,12 +3,12 @@ I define a popover needs to be shown at the top of its owner.
 "
 Class {
 	#name : #SpPopoverPositionTop,
-	#superclass : #SpPopoverPosition,
+	#superclass : #SpPopoverTopPosition,
 	#category : #'Spec2-Core-Support'
 }
 
-{ #category : #operations }
-SpPopoverPositionTop >> applyTo: aWidget [
-
-	aWidget bePositionTop
+{ #category : #testing }
+SpPopoverPositionTop class >> isDeprecated [
+	
+	^ true
 ]

--- a/src/Spec2-Core/SpPopoverRightPosition.class.st
+++ b/src/Spec2-Core/SpPopoverRightPosition.class.st
@@ -1,0 +1,14 @@
+"
+I define a popover needs to be shown at the right of its owner.
+"
+Class {
+	#name : #SpPopoverRightPosition,
+	#superclass : #SpPopoverPosition,
+	#category : #'Spec2-Core-Support'
+}
+
+{ #category : #operations }
+SpPopoverRightPosition >> applyTo: aWidget [
+
+	aWidget bePositionRight
+]

--- a/src/Spec2-Core/SpPopoverTopPosition.class.st
+++ b/src/Spec2-Core/SpPopoverTopPosition.class.st
@@ -1,0 +1,14 @@
+"
+I define a popover needs to be shown at the top of its owner.
+"
+Class {
+	#name : #SpPopoverTopPosition,
+	#superclass : #SpPopoverPosition,
+	#category : #'Spec2-Core-Support'
+}
+
+{ #category : #operations }
+SpPopoverTopPosition >> applyTo: aWidget [
+
+	aWidget bePositionTop
+]


### PR DESCRIPTION
The hierarchy becomes consistent if the 'Position' suffix is placed at the end of all subclasses + class names make more sens.
Example: SpPopoverBottomPosition makes more sens than SpPopoverPositionBottom 