### PR TITLE
Renaming SpToolbarItemPosition hierarchy.

### DIFF
--- a/src/Spec2-Core/SpToolbarItemLeftPosition.class.st
+++ b/src/Spec2-Core/SpToolbarItemLeftPosition.class.st
@@ -1,0 +1,17 @@
+"
+This class has a single instance representing a left item position.
+
+Do not use the class directly, instead use:
+
+	ITItemPosition left
+"
+Class {
+	#name : #SpToolbarItemLeftPosition,
+	#superclass : #SpToolbarItemPosition,
+	#category : #'Spec2-Core-Widgets'
+}
+
+{ #category : #accessing }
+SpToolbarItemLeftPosition >> addItem: anObject into: aToolbar [
+	aToolbar addItemLeft: anObject
+]

--- a/src/Spec2-Core/SpToolbarItemPosition.class.st
+++ b/src/Spec2-Core/SpToolbarItemPosition.class.st
@@ -23,7 +23,7 @@ SpToolbarItemPosition class >> default [
 
 { #category : #accessing }
 SpToolbarItemPosition class >> left [
-	^ SpToolbarItemPositionLeft uniqueInstance
+	^ SpToolbarItemLeftPosition uniqueInstance
 	
 ]
 
@@ -34,7 +34,7 @@ SpToolbarItemPosition class >> new [
 
 { #category : #accessing }
 SpToolbarItemPosition class >> right [
-	^ SpToolbarItemPositionRight uniqueInstance
+	^ SpToolbarItemRightPosition uniqueInstance
 	
 ]
 

--- a/src/Spec2-Core/SpToolbarItemPositionLeft.class.st
+++ b/src/Spec2-Core/SpToolbarItemPositionLeft.class.st
@@ -7,11 +7,11 @@ Do not use the class directly, instead use:
 "
 Class {
 	#name : #SpToolbarItemPositionLeft,
-	#superclass : #SpToolbarItemPosition,
+	#superclass : #SpToolbarItemLeftPosition,
 	#category : #'Spec2-Core-Widgets'
 }
 
-{ #category : #accessing }
-SpToolbarItemPositionLeft >> addItem: anObject into: aToolbar [
-	aToolbar addItemLeft: anObject
+{ #category : #testing }
+SpToolbarItemPositionLeft class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Spec2-Core/SpToolbarItemPositionRight.class.st
+++ b/src/Spec2-Core/SpToolbarItemPositionRight.class.st
@@ -7,11 +7,11 @@ Do not use the class directly, instead use:
 "
 Class {
 	#name : #SpToolbarItemPositionRight,
-	#superclass : #SpToolbarItemPosition,
+	#superclass : #SpToolbarItemRightPosition,
 	#category : #'Spec2-Core-Widgets'
 }
 
-{ #category : #accessing }
-SpToolbarItemPositionRight >> addItem: anObject into: aToolbar [
-	aToolbar addItemRight: anObject
+{ #category : #testing }
+SpToolbarItemPositionRight class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Spec2-Core/SpToolbarItemRightPosition.class.st
+++ b/src/Spec2-Core/SpToolbarItemRightPosition.class.st
@@ -1,0 +1,17 @@
+"
+This class has a single instance representing a right item position.
+
+Do not use the class directly, instead use:
+
+	ITItemPosition right
+"
+Class {
+	#name : #SpToolbarItemRightPosition,
+	#superclass : #SpToolbarItemPosition,
+	#category : #'Spec2-Core-Widgets'
+}
+
+{ #category : #accessing }
+SpToolbarItemRightPosition >> addItem: anObject into: aToolbar [
+	aToolbar addItemRight: anObject
+]


### PR DESCRIPTION
SpToolbarItemRightPosition and SpToolbarItemLeftPosition make more sens than SpToolbarItemPositionRight and SpToolbarItemPositionLeft respectively + coherent .