### PR TITLE
Rename SpToolbarDisplayMode hierarchy

### DIFF
--- a/src/Spec2-Core/SpIconAndLabelToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpIconAndLabelToolbarDisplayMode.class.st
@@ -1,0 +1,27 @@
+"
+Display the toolbar with icons and label only
+"
+Class {
+	#name : #SpIconAndLabelToolbarDisplayMode,
+	#superclass : #SpToolbarDisplayMode,
+	#category : #'Spec2-Core-Widgets'
+}
+
+{ #category : #configuring }
+SpIconAndLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
+	"ask for icon and label"
+	aButton getLabelSelector: #label.
+	aButton getIconSelector: #icon.
+	aButton badgeSelector: #badge.
+]
+
+{ #category : #accessing }
+SpIconAndLabelToolbarDisplayMode >> extent [
+	^ 45@45
+]
+
+{ #category : #accessing }
+SpIconAndLabelToolbarDisplayMode >> styleName [ 
+
+	^ 'toolBar.iconsAndLabel'
+]

--- a/src/Spec2-Core/SpIconToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpIconToolbarDisplayMode.class.st
@@ -1,0 +1,27 @@
+"
+Display the toolbar with icons only
+"
+Class {
+	#name : #SpIconToolbarDisplayMode,
+	#superclass : #SpToolbarDisplayMode,
+	#category : #'Spec2-Core-Widgets'
+}
+
+{ #category : #configuring }
+SpIconToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
+	"ask for icon (no label)"
+	aButton getIconSelector: #icon.
+	aButton badgeSelector: #badge.
+]
+
+{ #category : #accessing }
+SpIconToolbarDisplayMode >> extent [
+
+	^ 30@30
+]
+
+{ #category : #accessing }
+SpIconToolbarDisplayMode >> styleName [ 
+
+	^ 'toolBar.icons'
+]

--- a/src/Spec2-Core/SpLabelToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpLabelToolbarDisplayMode.class.st
@@ -1,0 +1,26 @@
+"
+Display the toolbar with labels only
+"
+Class {
+	#name : #SpLabelToolbarDisplayMode,
+	#superclass : #SpToolbarDisplayMode,
+	#category : #'Spec2-Core-Widgets'
+}
+
+{ #category : #configuring }
+SpLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
+	"ask for label (no icon)"
+	aButton getLabelSelector: #label.
+	aButton badgeSelector: #badge.
+]
+
+{ #category : #accessing }
+SpLabelToolbarDisplayMode >> extent [
+	^ 45@25
+]
+
+{ #category : #accessing }
+SpLabelToolbarDisplayMode >> styleName [
+
+	^ 'toolBar.label'
+]

--- a/src/Spec2-Core/SpToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpToolbarDisplayMode.class.st
@@ -17,17 +17,17 @@ SpToolbarDisplayMode class >> default [
 
 { #category : #accessing }
 SpToolbarDisplayMode class >> modeIcon [
-	^ SpToolbarDisplayModeIcon uniqueInstance
+	^ SpIconToolbarDisplayMode uniqueInstance
 ]
 
 { #category : #accessing }
 SpToolbarDisplayMode class >> modeIconAndLabel [
-	^ SpToolbarDisplayModeIconAndLabel uniqueInstance
+	^ SpIconAndLabelToolbarDisplayMode uniqueInstance
 ]
 
 { #category : #accessing }
 SpToolbarDisplayMode class >> modeLabel [
-	^ SpToolbarDisplayModeLabel uniqueInstance
+	^ SpLabelToolbarDisplayMode uniqueInstance
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Core/SpToolbarDisplayModeIcon.class.st
+++ b/src/Spec2-Core/SpToolbarDisplayModeIcon.class.st
@@ -3,25 +3,11 @@ Display the toolbar with icons only
 "
 Class {
 	#name : #SpToolbarDisplayModeIcon,
-	#superclass : #SpToolbarDisplayMode,
+	#superclass : #SpIconToolbarDisplayMode,
 	#category : #'Spec2-Core-Widgets'
 }
 
-{ #category : #configuring }
-SpToolbarDisplayModeIcon >> configureButton: aButton item: aToolbarItem [
-	"ask for icon (no label)"
-	aButton getIconSelector: #icon.
-	aButton badgeSelector: #badge.
-]
-
-{ #category : #accessing }
-SpToolbarDisplayModeIcon >> extent [
-
-	^ 30@30
-]
-
-{ #category : #accessing }
-SpToolbarDisplayModeIcon >> styleName [ 
-
-	^ 'toolBar.icons'
+{ #category : #testing }
+SpToolbarDisplayModeIcon class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Spec2-Core/SpToolbarDisplayModeIconAndLabel.class.st
+++ b/src/Spec2-Core/SpToolbarDisplayModeIconAndLabel.class.st
@@ -3,25 +3,11 @@ Display the toolbar with icons and label only
 "
 Class {
 	#name : #SpToolbarDisplayModeIconAndLabel,
-	#superclass : #SpToolbarDisplayMode,
+	#superclass : #SpIconAndLabelToolbarDisplayMode,
 	#category : #'Spec2-Core-Widgets'
 }
 
-{ #category : #configuring }
-SpToolbarDisplayModeIconAndLabel >> configureButton: aButton item: aToolbarItem [
-	"ask for icon and label"
-	aButton getLabelSelector: #label.
-	aButton getIconSelector: #icon.
-	aButton badgeSelector: #badge.
-]
-
-{ #category : #accessing }
-SpToolbarDisplayModeIconAndLabel >> extent [
-	^ 45@45
-]
-
-{ #category : #accessing }
-SpToolbarDisplayModeIconAndLabel >> styleName [ 
-
-	^ 'toolBar.iconsAndLabel'
+{ #category : #testing }
+SpToolbarDisplayModeIconAndLabel class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Spec2-Core/SpToolbarDisplayModeLabel.class.st
+++ b/src/Spec2-Core/SpToolbarDisplayModeLabel.class.st
@@ -3,24 +3,11 @@ Display the toolbar with labels only
 "
 Class {
 	#name : #SpToolbarDisplayModeLabel,
-	#superclass : #SpToolbarDisplayMode,
+	#superclass : #SpLabelToolbarDisplayMode,
 	#category : #'Spec2-Core-Widgets'
 }
 
-{ #category : #configuring }
-SpToolbarDisplayModeLabel >> configureButton: aButton item: aToolbarItem [
-	"ask for label (no icon)"
-	aButton getLabelSelector: #label.
-	aButton badgeSelector: #badge.
-]
-
-{ #category : #accessing }
-SpToolbarDisplayModeLabel >> extent [
-	^ 45@25
-]
-
-{ #category : #accessing }
-SpToolbarDisplayModeLabel >> styleName [
-
-	^ 'toolBar.label'
+{ #category : #testing }
+SpToolbarDisplayModeLabel class >> isDeprecated [ 
+	^ true
 ]


### PR DESCRIPTION
Adding the 'ToolbarDisplayMode' at the end is better :) 
Subclasses of SpToolbarDisplayMode represent modes