### PR TITLE
Rename SpLayoutDirection hierarchy

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpHorizontalLayoutDirection.extension.st
+++ b/src/Spec2-Adapters-Morphic/SpHorizontalLayoutDirection.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #SpLayoutDirectionHorizontal }
+Extension { #name : #SpHorizontalLayoutDirection }
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionHorizontal >> addHomogeneousToMorph: aMorph into: anAdapter [
+SpHorizontalLayoutDirection >> addHomogeneousToMorph: aMorph into: anAdapter [
 	
 	^ anAdapter addHorizontalHomogeneousToMorph: aMorph
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionHorizontal >> addPadding: aNumber toMorph: aMorph into: anAdapter [
+SpHorizontalLayoutDirection >> addPadding: aNumber toMorph: aMorph into: anAdapter [
 
 	^ anAdapter 
 		addHorizontalPadding: aNumber 
@@ -15,19 +15,19 @@ SpLayoutDirectionHorizontal >> addPadding: aNumber toMorph: aMorph into: anAdapt
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionHorizontal >> newSplitter [
+SpHorizontalLayoutDirection >> newSplitter [
 
 	^ SpPanedResizerMorph newHorizontal
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionHorizontal >> recalculatePages: anAdaptor [
+SpHorizontalLayoutDirection >> recalculatePages: anAdaptor [
 
 	^ anAdaptor recalculatePageWidths
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionHorizontal >> setRigidityOfNonExpandedMorph: aMorph [
+SpHorizontalLayoutDirection >> setRigidityOfNonExpandedMorph: aMorph [
 
 	aMorph 
 		vResizing: #spaceFill; 

--- a/src/Spec2-Adapters-Morphic/SpVerticalLayoutDirection.extension.st
+++ b/src/Spec2-Adapters-Morphic/SpVerticalLayoutDirection.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #SpLayoutDirectionVertical }
+Extension { #name : #SpVerticalLayoutDirection }
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionVertical >> addHomogeneousToMorph: aMorph into: anAdapter [
+SpVerticalLayoutDirection >> addHomogeneousToMorph: aMorph into: anAdapter [
 	
 	^ anAdapter addVerticalHomogeneousToMorph: aMorph
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionVertical >> addPadding: aNumber toMorph: aMorph into: anAdapter [
+SpVerticalLayoutDirection >> addPadding: aNumber toMorph: aMorph into: anAdapter [
 
 	^ anAdapter 
 		addVerticalPadding: aNumber 
@@ -15,18 +15,18 @@ SpLayoutDirectionVertical >> addPadding: aNumber toMorph: aMorph into: anAdapter
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionVertical >> newSplitter [
+SpVerticalLayoutDirection >> newSplitter [
 	^ SpPanedResizerMorph newVertical
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionVertical >> recalculatePages: anAdaptor [
+SpVerticalLayoutDirection >> recalculatePages: anAdaptor [
 
 	^ anAdaptor recalculatePageHeights
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
-SpLayoutDirectionVertical >> setRigidityOfNonExpandedMorph: aMorph [
+SpVerticalLayoutDirection >> setRigidityOfNonExpandedMorph: aMorph [
 
 	aMorph 
 		hResizing: #spaceFill; 

--- a/src/Spec2-Layout/SpHorizontalLayoutDirection.class.st
+++ b/src/Spec2-Layout/SpHorizontalLayoutDirection.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #SpHorizontalLayoutDirection,
+	#superclass : #SpLayoutDirection,
+	#category : #'Spec2-Layout-Base'
+}
+
+{ #category : #testing }
+SpHorizontalLayoutDirection >> isHorizontal [
+
+	^ true
+]
+
+{ #category : #factory }
+SpHorizontalLayoutDirection >> newWidgetOn: anAdapter [
+
+	^ anAdapter newHorizontal
+]

--- a/src/Spec2-Layout/SpLayoutDirection.class.st
+++ b/src/Spec2-Layout/SpLayoutDirection.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #accessing }
 SpLayoutDirection class >> horizontal [
 
-	^ SpLayoutDirectionHorizontal uniqueInstance
+	^ SpHorizontalLayoutDirection uniqueInstance
 ]
 
 { #category : #accessing }
@@ -24,7 +24,7 @@ SpLayoutDirection class >> uniqueInstance [
 { #category : #accessing }
 SpLayoutDirection class >> vertical [
 
-	^ SpLayoutDirectionVertical uniqueInstance
+	^ SpVerticalLayoutDirection uniqueInstance
 ]
 
 { #category : #testing }

--- a/src/Spec2-Layout/SpLayoutDirectionHorizontal.class.st
+++ b/src/Spec2-Layout/SpLayoutDirectionHorizontal.class.st
@@ -1,17 +1,10 @@
 Class {
 	#name : #SpLayoutDirectionHorizontal,
-	#superclass : #SpLayoutDirection,
+	#superclass : #SpHorizontalLayoutDirection,
 	#category : #'Spec2-Layout-Base'
 }
 
 { #category : #testing }
-SpLayoutDirectionHorizontal >> isHorizontal [
-
+SpLayoutDirectionHorizontal class >> isDeprecated [ 
 	^ true
-]
-
-{ #category : #factory }
-SpLayoutDirectionHorizontal >> newWidgetOn: anAdapter [
-
-	^ anAdapter newHorizontal
 ]

--- a/src/Spec2-Layout/SpLayoutDirectionVertical.class.st
+++ b/src/Spec2-Layout/SpLayoutDirectionVertical.class.st
@@ -1,17 +1,10 @@
 Class {
 	#name : #SpLayoutDirectionVertical,
-	#superclass : #SpLayoutDirection,
+	#superclass : #SpVerticalLayoutDirection,
 	#category : #'Spec2-Layout-Base'
 }
 
 { #category : #testing }
-SpLayoutDirectionVertical >> isVertical [
-
+SpLayoutDirectionVertical class >> isDeprecated [ 
 	^ true
-]
-
-{ #category : #factory }
-SpLayoutDirectionVertical >> newWidgetOn: anAdapter [
-
-	^ anAdapter newVertical
 ]

--- a/src/Spec2-Layout/SpVerticalLayoutDirection.class.st
+++ b/src/Spec2-Layout/SpVerticalLayoutDirection.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #SpVerticalLayoutDirection,
+	#superclass : #SpLayoutDirection,
+	#category : #'Spec2-Layout-Base'
+}
+
+{ #category : #testing }
+SpVerticalLayoutDirection >> isVertical [
+
+	^ true
+]
+
+{ #category : #factory }
+SpVerticalLayoutDirection >> newWidgetOn: anAdapter [
+
+	^ anAdapter newVertical
+]


### PR DESCRIPTION
Renaming the SpLayoutDirection to end with the 'LayoutDirection' is better for consistency reasons of course 