### PR TITLE
Rename SpInvalidUserInput

### DIFF
--- a/src/Spec2-Commander2/SpInvalidUserInputError.extension.st
+++ b/src/Spec2-Commander2/SpInvalidUserInputError.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #SpInvalidUserInput }
+Extension { #name : #SpInvalidUserInputError }
 
 { #category : #'*Spec2-Commander2' }
-SpInvalidUserInput >> actForSpec [
+SpInvalidUserInputError >> actForSpec [
 	"Does nothing on purpose."
 	UIManager default
 		inform: self messageText.

--- a/src/Spec2-Interactions/SpInvalidUserInput.class.st
+++ b/src/Spec2-Interactions/SpInvalidUserInput.class.st
@@ -3,6 +3,11 @@ I am the error raised when a user entered bad input during interaction.
 "
 Class {
 	#name : #SpInvalidUserInput,
-	#superclass : #SpInteractionError,
+	#superclass : #SpInvalidUserInputError,
 	#category : #'Spec2-Interactions'
 }
+
+{ #category : #testing }
+SpInvalidUserInput class >> isDeprecated [ 
+	^ true
+]

--- a/src/Spec2-Interactions/SpInvalidUserInputError.class.st
+++ b/src/Spec2-Interactions/SpInvalidUserInputError.class.st
@@ -1,0 +1,8 @@
+"
+I am the error raised when a user entered bad input during interaction.
+"
+Class {
+	#name : #SpInvalidUserInputError,
+	#superclass : #SpInteractionError,
+	#category : #'Spec2-Interactions'
+}


### PR DESCRIPTION
SpInvalidUserInputError name makes it easier and quicker to understand that the class is an Error raised in case the user enters an invalid input 