### PR TITLE
Renaming SpInteractionCancelled to SpCancelledInteractionError

### DIFF
--- a/src/Spec2-Commander2/SpCancelledInteractionError.extension.st
+++ b/src/Spec2-Commander2/SpCancelledInteractionError.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #SpInteractionCancelled }
+Extension { #name : #SpCancelledInteractionError }
 
 { #category : #'*Spec2-Commander2' }
-SpInteractionCancelled >> actForSpec [
+SpCancelledInteractionError >> actForSpec [
 	"Does nothing on purpose."
 	self flag: #TODO. "In the best world, we should delegate the behaviour to the Spec presenter which originated the error."
 ]

--- a/src/Spec2-Interactions/SpCancelledInteractionError.class.st
+++ b/src/Spec2-Interactions/SpCancelledInteractionError.class.st
@@ -1,0 +1,8 @@
+"
+I am the error raised when the user cancelled a request.
+"
+Class {
+	#name : #SpCancelledInteractionError,
+	#superclass : #SpInteractionError,
+	#category : #'Spec2-Interactions'
+}

--- a/src/Spec2-Interactions/SpInteractionCancelled.class.st
+++ b/src/Spec2-Interactions/SpInteractionCancelled.class.st
@@ -3,6 +3,11 @@ I am the error raised when the user cancelled a request.
 "
 Class {
 	#name : #SpInteractionCancelled,
-	#superclass : #SpInteractionError,
+	#superclass : #SpCancelledInteractionError,
 	#category : #'Spec2-Interactions'
 }
+
+{ #category : #testing }
+SpInteractionCancelled class >> isDeprecated [ 
+	^ true
+]

--- a/src/Spec2-Interactions/SpPresenter.extension.st
+++ b/src/Spec2-Interactions/SpPresenter.extension.st
@@ -15,7 +15,7 @@ SpPresenter >> request: request initialAnswer: initialAnwser title: title [
 					title: title.
 					
 	answer "If this is nil, it means that user cancelled the UI."
-		ifNil: [ SpInteractionCancelled signal ].
+		ifNil: [ SpCancelledInteractionError signal ].
 	
 	^ answer
 ]


### PR DESCRIPTION
SpCancelledInteractionError is closer in meaning to an error raised when an interaction is cancelled + consistent with the hierarchy