### PR TITLE
Renaming SpMorphicAdapterTestCase to SpMorphicAdapterTest

### DIFF
--- a/src/Spec2-Morphic-Backend-Tests/SpMorphicAdapterTest.class.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpMorphicAdapterTest.class.st
@@ -1,0 +1,82 @@
+Class {
+	#name : #SpMorphicAdapterTest,
+	#superclass : #ParametrizedTestCase,
+	#instVars : [
+		'presenter',
+		'specInitializationStrategy',
+		'window'
+	],
+	#category : #'Spec2-Morphic-Backend-Tests'
+}
+
+{ #category : #testing }
+SpMorphicAdapterTest class >> isAbstract [ 
+	^ self == SpMorphicAdapterTest
+]
+
+{ #category : #testing }
+SpMorphicAdapterTest class >> testParameters [ 
+
+	^ ParametrizedTestMatrix new
+		forSelector: #specInitializationStrategy
+		addOptions: { [ SpInitializationStrategy beforeTest ]. [ SpInitializationStrategy afterTest ] }
+]
+
+{ #category : #running }
+SpMorphicAdapterTest >> adapter [
+
+	^ presenter adapter
+]
+
+{ #category : #running }
+SpMorphicAdapterTest >> initializeTestedInstance [
+]
+
+{ #category : #running }
+SpMorphicAdapterTest >> openInstance [
+
+	window ifNil: [ window := presenter openWithSpec ].
+	MorphicRenderLoop new doOneCycle.
+]
+
+{ #category : #private }
+SpMorphicAdapterTest >> performTest [
+	
+	specInitializationStrategy beforeTest: self.
+	super performTest.
+]
+
+{ #category : #accessing }
+SpMorphicAdapterTest >> presenter [
+	^ presenter
+]
+
+{ #category : #running }
+SpMorphicAdapterTest >> setUp [
+	super setUp.
+	presenter := self classToTest new.
+	self initializeTestedInstance
+]
+
+{ #category : #accessing }
+SpMorphicAdapterTest >> specInitializationStrategy: aStrategy [
+	
+	specInitializationStrategy := aStrategy
+]
+
+{ #category : #running }
+SpMorphicAdapterTest >> tearDown [
+	window ifNotNil: [ window delete ].
+	super tearDown
+]
+
+{ #category : #running }
+SpMorphicAdapterTest >> widget [
+
+	"Force opening the spec instance here.
+	The action should have been correctly configured before
+	depending on the spec initialization strategy"
+	self openInstance.
+	MorphicRenderLoop new doOneCycle.
+	^ self adapter widget
+]

--- a/src/Spec2-Morphic-Backend-Tests/SpMorphicAdapterTestCase.class.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpMorphicAdapterTestCase.class.st
@@ -1,82 +1,10 @@
 Class {
 	#name : #SpMorphicAdapterTestCase,
-	#superclass : #ParametrizedTestCase,
-	#instVars : [
-		'presenter',
-		'specInitializationStrategy',
-		'window'
-	],
+	#superclass : #SpMorphicAdapterTest,
 	#category : #'Spec2-Morphic-Backend-Tests'
 }
 
 { #category : #testing }
-SpMorphicAdapterTestCase class >> isAbstract [ 
-	^ self == SpMorphicAdapterTestCase
-]
-
-{ #category : #testing }
-SpMorphicAdapterTestCase class >> testParameters [ 
-
-	^ ParametrizedTestMatrix new
-		forSelector: #specInitializationStrategy
-		addOptions: { [ SpInitializationStrategy beforeTest ]. [ SpInitializationStrategy afterTest ] }
-]
-
-{ #category : #running }
-SpMorphicAdapterTestCase >> adapter [
-
-	^ presenter adapter
-]
-
-{ #category : #running }
-SpMorphicAdapterTestCase >> initializeTestedInstance [
-]
-
-{ #category : #running }
-SpMorphicAdapterTestCase >> openInstance [
-
-	window ifNil: [ window := presenter openWithSpec ].
-	MorphicRenderLoop new doOneCycle.
-]
-
-{ #category : #private }
-SpMorphicAdapterTestCase >> performTest [
-	
-	specInitializationStrategy beforeTest: self.
-	super performTest.
-]
-
-{ #category : #accessing }
-SpMorphicAdapterTestCase >> presenter [
-	^ presenter
-]
-
-{ #category : #running }
-SpMorphicAdapterTestCase >> setUp [
-	super setUp.
-	presenter := self classToTest new.
-	self initializeTestedInstance
-]
-
-{ #category : #accessing }
-SpMorphicAdapterTestCase >> specInitializationStrategy: aStrategy [
-	
-	specInitializationStrategy := aStrategy
-]
-
-{ #category : #running }
-SpMorphicAdapterTestCase >> tearDown [
-	window ifNotNil: [ window delete ].
-	super tearDown
-]
-
-{ #category : #running }
-SpMorphicAdapterTestCase >> widget [
-
-	"Force opening the spec instance here.
-	The action should have been correctly configured before
-	depending on the spec initialization strategy"
-	self openInstance.
-	MorphicRenderLoop new doOneCycle.
-	^ self adapter widget
+SpMorphicAdapterTestCase class >> isDeprecated [ 
+	^ true
 ]


### PR DESCRIPTION
This is the only test class which ends with the case suffix. It would be more consistent to end all test classes with the same Test suffix.