### PR TITLE
Renaming SpStyleVariableEnvironment to SpStyleEnvironmentVariable

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpStyleEnvironmentVariable.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleEnvironmentVariable.class.st
@@ -1,0 +1,81 @@
+"
+A base for environment variables (values that point to values in the environment).
+"
+Class {
+	#name : #SpStyleEnvironmentVariable,
+	#superclass : #SpStyleAbstractVariable,
+	#instVars : [
+		'name'
+	],
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #documentation }
+SpStyleEnvironmentVariable class >> addDocumentExample: aBuilder [
+
+	aBuilder newLine.
+	aBuilder header: [ :builder | builder text: 'Example' ] withLevel: 2.
+	aBuilder newLine.
+	aBuilder monospace: self documentExampleCode
+]
+
+{ #category : #documentation }
+SpStyleEnvironmentVariable class >> addDocumentValidValues: aBuilder [	
+
+	aBuilder newLine.
+	aBuilder header: [ :builder | builder text: 'Valid values' ] withLevel: 2.
+	aBuilder newLine.
+	aBuilder unorderedListDuring: [  
+		(self documentValidValues sorted) do: [ :each |
+			aBuilder item: [
+				aBuilder monospace: '#', each asString ] ] ]	
+]
+
+{ #category : #documentation }
+SpStyleEnvironmentVariable class >> buildMicroDownUsing: aBuilder withComment: aString [
+	
+	super buildMicroDownUsing: aBuilder withComment: aString.
+	self addDocumentExample: aBuilder.
+	self addDocumentValidValues: aBuilder	
+
+]
+
+{ #category : #documentation }
+SpStyleEnvironmentVariable class >> documentExampleCode [
+
+	^ '(none)'
+]
+
+{ #category : #documentation }
+SpStyleEnvironmentVariable class >> documentValidValues [
+	
+	^ #()
+]
+
+{ #category : #'ston-core' }
+SpStyleEnvironmentVariable class >> stonName [
+
+	^ 'Environment'
+]
+
+{ #category : #'instance creation' }
+SpStyleEnvironmentVariable >> fromSton: stonReader [
+
+	self name: stonReader parseContainedValue
+]
+
+{ #category : #testing }
+SpStyleEnvironmentVariable >> isEnvironmentVariable [
+
+	^ true
+]
+
+{ #category : #accessing }
+SpStyleEnvironmentVariable >> name [
+	^ name
+]
+
+{ #category : #accessing }
+SpStyleEnvironmentVariable >> name: anObject [
+	name := anObject
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironment.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironment.class.st
@@ -3,79 +3,11 @@ A base for environment variables (values that point to values in the environment
 "
 Class {
 	#name : #SpStyleVariableEnvironment,
-	#superclass : #SpStyleAbstractVariable,
-	#instVars : [
-		'name'
-	],
+	#superclass : #SpStyleEnvironmentVariable,
 	#category : #'Spec2-Adapters-Morphic-StyleSheet'
 }
 
-{ #category : #documentation }
-SpStyleVariableEnvironment class >> addDocumentExample: aBuilder [
-
-	aBuilder newLine.
-	aBuilder header: [ :builder | builder text: 'Example' ] withLevel: 2.
-	aBuilder newLine.
-	aBuilder monospace: self documentExampleCode
-]
-
-{ #category : #documentation }
-SpStyleVariableEnvironment class >> addDocumentValidValues: aBuilder [	
-
-	aBuilder newLine.
-	aBuilder header: [ :builder | builder text: 'Valid values' ] withLevel: 2.
-	aBuilder newLine.
-	aBuilder unorderedListDuring: [  
-		(self documentValidValues sorted) do: [ :each |
-			aBuilder item: [
-				aBuilder monospace: '#', each asString ] ] ]	
-]
-
-{ #category : #documentation }
-SpStyleVariableEnvironment class >> buildMicroDownUsing: aBuilder withComment: aString [
-	
-	super buildMicroDownUsing: aBuilder withComment: aString.
-	self addDocumentExample: aBuilder.
-	self addDocumentValidValues: aBuilder	
-
-]
-
-{ #category : #documentation }
-SpStyleVariableEnvironment class >> documentExampleCode [
-
-	^ '(none)'
-]
-
-{ #category : #documentation }
-SpStyleVariableEnvironment class >> documentValidValues [
-	
-	^ #()
-]
-
-{ #category : #'ston-core' }
-SpStyleVariableEnvironment class >> stonName [
-
-	^ 'Environment'
-]
-
-{ #category : #'instance creation' }
-SpStyleVariableEnvironment >> fromSton: stonReader [
-
-	self name: stonReader parseContainedValue
-]
-
 { #category : #testing }
-SpStyleVariableEnvironment >> isEnvironmentVariable [
-
+SpStyleVariableEnvironment class >> isDeprecated [ 
 	^ true
-]
-
-{ #category : #accessing }
-SpStyleVariableEnvironment >> name [
-	^ name
-]
-
-{ #category : #accessing }
-SpStyleVariableEnvironment >> name: anObject [
-	name := anObject
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentColor.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentColor.class.st
@@ -3,7 +3,7 @@ A variable to access environment colors (defined in `UITheme` and subclasses)
 "
 Class {
 	#name : #SpStyleVariableEnvironmentColor,
-	#superclass : #SpStyleVariableEnvironment,
+	#superclass : #SpStyleEnvironmentVariable,
 	#category : #'Spec2-Adapters-Morphic-StyleSheet'
 }
 

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentFont.class.st
@@ -4,7 +4,7 @@ This variable must be used to assign the attribute `name` of a `SpStyleFont` pro
 "
 Class {
 	#name : #SpStyleVariableEnvironmentFont,
-	#superclass : #SpStyleVariableEnvironment,
+	#superclass : #SpStyleEnvironmentVariable,
 	#category : #'Spec2-Adapters-Morphic-StyleSheet'
 }
 


### PR DESCRIPTION
Since it is a base for environment variables, it is better to rentame it to SpStyleEnvironmentVariable.