### PR TITLE
lineAtCursorPosition-empty

### DIFF
--- a/src/Spec2-Adapters-Morphic/RubTextEditor.extension.st
+++ b/src/Spec2-Adapters-Morphic/RubTextEditor.extension.st
@@ -5,7 +5,7 @@ RubTextEditor >> lineAtCursorPosition [
 	| string lastEnd index lastStart |
 	
 	index := self pointIndex.
-	string := self text asString.
+	string := self text asString ifEmpty: [^''].
 	string lineIndicesDo: [ :start :endWithoutDelimiters :end | 
 		index <= end ifTrue: [ 
 			^ string copyFrom: start to: endWithoutDelimiters ].

--- a/src/Spec2-Backend-Tests/SpTextAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpTextAdapterTest.class.st
@@ -44,7 +44,13 @@ three'.
 	self assert: presenter lineAtCursorPosition equals: 'two'.	
 	
 	presenter cursorPositionIndex: 14.
-	self assert: presenter lineAtCursorPosition equals: 'three'
+	self assert: presenter lineAtCursorPosition equals: 'three'.
+	
+	presenter text: ''.
+	presenter cursorPositionIndex: 1.
+	self assert: presenter lineAtCursorPosition equals: ''.
+	
+	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
this PR fixes https://github.com/pharo-project/pharo/issues/9391 by adding an empty check.

testLineAtCursorPosition is improved to test for the empty case.

