### PR TITLE
Disable the list in form example

### DIFF
--- a/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
@@ -64,8 +64,6 @@ SpDemoStandaloneFormPresenter class >> defaultSpec [
 						add: #femaleButton;
 						yourself)
 					at: 2 @ 9;
-				add: 'Items:' at: 1 @ 10;
-				add: #itemsInput at: 2 @ 10;
 				yourself);
 		add: (SpBoxLayout newLeftToRight
 				add: #submitButton;


### PR DESCRIPTION
Disable the list inside the grid layout as there is a layout problem that invalidates the layout all the time.
It produces infinites (and expensive) redraws