### PR TITLE
SpDemo: add Presenters to focusOrder, not Layout

### DIFF
--- a/src/Spec2-Examples/SpDemo.class.st
+++ b/src/Spec2-Examples/SpDemo.class.st
@@ -139,7 +139,7 @@ SpDemo >> initializePresenters [
 
 	self focusOrder
 		add: list;
-		add: page
+		addAll: page presenters 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #1124 

This change assumes that Layouts shouldn't be added to `focusOrder`, only Presenters.