### PR TITLE
Fix for PoolVars References/Senders and Implementors from debugger

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -197,18 +197,16 @@ SpCodePresenter >> bindingOf: aString [
 ]
 
 { #category : #'private - commands' }
-SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonGlobalBlock [
+SpCodePresenter >> browseReferencesToPoolVar [
 
-	| variableOrClassName env astNode |
-	variableOrClassName := self selectedSelector.
-	variableOrClassName ifNil: [ ^ nil ].
+	"If the selected text is a pool var, list all references and return true. Return false otherwise."
 
-
-	"Fix for showing Pool Vars references"
-	(interactionModel hasBindingOf: variableOrClassName) ifTrue: [ 
-		astNode := interactionModel context method ast variableNodes
-			           detect: [ :node | 
-							 "this way also works without selecting the variable, setting the cursor inside is enogugh"
+	| astNode selectedText |
+	selectedText := self selectedSelector.
+	selectedText ifNil: [ ^ false ].
+	(interactionModel hasBindingOf: selectedText) ifTrue: [ 
+		astNode := interactionModel ast variableNodes
+			           detect: [ :node | "this way also works without selecting the variable, setting the cursor inside is enogugh"
 				           node start <= self selectionInterval first and: [ 
 					           self selectionInterval last <= node stop ] ]
 			           ifNone: [ nil ] ].
@@ -217,9 +215,16 @@ SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonG
 		self systemNavigation
 			openBrowserFor: astNode binding
 			withMethods: astNode binding usingMethods.
-		^ self ].
-	"End of: Fix for showing Pool Vars references"
+		^ true ].
+	^ false
+]
 
+{ #category : #'private - commands' }
+SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonGlobalBlock [
+
+	| variableOrClassName env |
+	variableOrClassName := self selectedSelector.
+	variableOrClassName ifNil: [ ^ nil ].
 
 	env := self environment.
 
@@ -374,15 +379,17 @@ SpCodePresenter >> doBrowseMethodsMatchingStringSensitive [
 
 { #category : #commands }
 SpCodePresenter >> doBrowseSenders [
-	| result |
 
-	result := self
-		browseSelectedSelectorIfGlobal: [ :global | 
-			self systemNavigation browseAllSendersOf: global ]
-		ifNotGlobal:  [ :selector |
-			self systemNavigation browseAllReferencesTo: selector ].
-	result ifNil: [ 
-		self application inform: 'No selectors found.' ]	
+	| result selectionIsPoolVar |
+	selectionIsPoolVar := self browseReferencesToPoolVar.
+
+	selectionIsPoolVar ifFalse: [ 
+		result := self
+			          browseSelectedSelectorIfGlobal: [ :global | 
+			          self systemNavigation browseAllSendersOf: global ]
+			          ifNotGlobal: [ :selector | 
+			          self systemNavigation browseAllReferencesTo: selector ].
+		result ifNil: [ self application inform: 'No selectors found.' ] ]
 ]
 
 { #category : #'private - bindings' }

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -197,6 +197,27 @@ SpCodePresenter >> bindingOf: aString [
 ]
 
 { #category : #'private - commands' }
+SpCodePresenter >> browseImplementorOfPoolVar [
+
+	"If the selected text is a pool var, list all references and return true. Return false otherwise."
+
+	| astNode selectedText |
+	selectedText := self selectedSelector.
+	selectedText ifNil: [ ^ false ].
+	(interactionModel hasBindingOf: selectedText) ifTrue: [ 
+		astNode := interactionModel ast variableNodes
+			           detect: [ :node | "this way also works without selecting the variable, setting the cursor inside is enogugh"
+				           node start <= self selectionInterval first and: [ 
+					           self selectionInterval last <= node stop ] ]
+			           ifNone: [ nil ] ].
+
+	(astNode isNotNil and: [ astNode binding isPoolVariable ]) ifTrue: [ 
+		self systemNavigation browseHierarchy: astNode binding owningClass.
+		^ true ].
+	^ false
+]
+
+{ #category : #'private - commands' }
 SpCodePresenter >> browseReferencesToPoolVar [
 
 	"If the selected text is a pool var, list all references and return true. Return false otherwise."
@@ -337,14 +358,17 @@ SpCodePresenter >> doBrowseHierarchy [
 
 { #category : #commands }
 SpCodePresenter >> doBrowseImplementors [
-	| result |
-	
-	result := self
-		browseSelectedSelectorIfGlobal: [ :global | global browse ]
-		ifNotGlobal:  [ :selector | 
-			self systemNavigation browseAllImplementorsOf: selector ].
-	result ifNil: [ 
-		self application inform: 'No selectors found.' ]
+
+	| result selectionIsPoolVar |
+	selectionIsPoolVar := self browseImplementorOfPoolVar.
+
+	selectionIsPoolVar ifFalse: [ 
+		result := self
+			          browseSelectedSelectorIfGlobal: [ :global | 
+			          global browse ]
+			          ifNotGlobal: [ :selector | 
+			          self systemNavigation browseAllImplementorsOf: selector ].
+		result ifNil: [ self application inform: 'No selectors found.' ] ]
 ]
 
 { #category : #commands }

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -198,22 +198,38 @@ SpCodePresenter >> bindingOf: aString [
 
 { #category : #'private - commands' }
 SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonGlobalBlock [
-	| variableOrClassName env |
 
+	| variableOrClassName env position astNode |
 	variableOrClassName := self selectedSelector.
 	variableOrClassName ifNil: [ ^ nil ].
-	
+
+
+  "Fix for showing Pool Vars references"
+	position := self selectionInterval first.
+	astNode:= interactionModel context method ast variableNodes
+		detect: [ :node | node start = position ]
+		ifNone: [ nil ].
+
+	(astNode isNotNil and: [ astNode binding isPoolVariable ]) ifTrue: [ 
+		self systemNavigation openBrowserFor:  astNode binding withMethods: astNode  binding usingMethods.
+		^self
+	].
+	"End of: Fix for showing Pool Vars references"
+
+
 	env := self environment.
-	
+
 	self flag: #bug.
 	"If we are looking for implementors of a class variable, this does not work right..."
-	env isBehavior ifTrue: [
-		(env hasSlotNamed: variableOrClassName) ifTrue: [
-		 ^ self systemNavigation browseAllAccessesTo: variableOrClassName from: env ] ].
+	env isBehavior ifTrue: [ 
+		(env hasSlotNamed: variableOrClassName) ifTrue: [ 
+			^ self systemNavigation
+				  browseAllAccessesTo: variableOrClassName
+				  from: env ] ].
 
-	(env bindingOf: variableOrClassName) 
-		ifNotNil: [ :ref | ^ globalBlock value: ref ].
-	
+	(env bindingOf: variableOrClassName) ifNotNil: [ :ref | 
+		^ globalBlock value: ref ].
+
 	nonGlobalBlock value: variableOrClassName
 ]
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -199,21 +199,25 @@ SpCodePresenter >> bindingOf: aString [
 { #category : #'private - commands' }
 SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonGlobalBlock [
 
-	| variableOrClassName env position astNode |
+	| variableOrClassName env astNode |
 	variableOrClassName := self selectedSelector.
 	variableOrClassName ifNil: [ ^ nil ].
 
 
-  "Fix for showing Pool Vars references"
-	position := self selectionInterval first.
-	(interactionModel hasBindingOf:variableOrClassName) ifTrue:[ astNode:= interactionModel context method ast variableNodes
-		detect: [ :node | node start = position ]
-		ifNone: [ nil ]].
- 
+	"Fix for showing Pool Vars references"
+	(interactionModel hasBindingOf: variableOrClassName) ifTrue: [ 
+		astNode := interactionModel context method ast variableNodes
+			           detect: [ :node | 
+							 "this way also works without selecting the variable, setting the cursor inside is enogugh"
+				           node start <= self selectionInterval first and: [ 
+					           self selectionInterval last <= node stop ] ]
+			           ifNone: [ nil ] ].
+
 	(astNode isNotNil and: [ astNode binding isPoolVariable ]) ifTrue: [ 
-		self systemNavigation openBrowserFor:  astNode binding withMethods: astNode  binding usingMethods.
-		^self
-	].
+		self systemNavigation
+			openBrowserFor: astNode binding
+			withMethods: astNode binding usingMethods.
+		^ self ].
 	"End of: Fix for showing Pool Vars references"
 
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -201,6 +201,15 @@ SpCodePresenter >> browseImplementorOfPoolVar [
 
 	"If the selected text is a pool var, list all references and return true. Return false otherwise."
 
+	^ self browsePoolVarNode: [ :astNode | 
+		  self systemNavigation browseHierarchy: astNode binding owningClass ]
+]
+
+{ #category : #'private - commands' }
+SpCodePresenter >> browsePoolVarNode: aBlock [
+
+	"If the selected text is a pool var, list all references  using the block and return true. Return afalse otherwise."
+
 	| astNode selectedText |
 	selectedText := self selectedSelector.
 	selectedText ifNil: [ ^ false ].
@@ -212,7 +221,7 @@ SpCodePresenter >> browseImplementorOfPoolVar [
 			           ifNone: [ nil ] ].
 
 	(astNode isNotNil and: [ astNode binding isPoolVariable ]) ifTrue: [ 
-		self systemNavigation browseHierarchy: astNode binding owningClass.
+		aBlock value: astNode.
 		^ true ].
 	^ false
 ]
@@ -222,22 +231,10 @@ SpCodePresenter >> browseReferencesToPoolVar [
 
 	"If the selected text is a pool var, list all references and return true. Return false otherwise."
 
-	| astNode selectedText |
-	selectedText := self selectedSelector.
-	selectedText ifNil: [ ^ false ].
-	(interactionModel hasBindingOf: selectedText) ifTrue: [ 
-		astNode := interactionModel ast variableNodes
-			           detect: [ :node | "this way also works without selecting the variable, setting the cursor inside is enogugh"
-				           node start <= self selectionInterval first and: [ 
-					           self selectionInterval last <= node stop ] ]
-			           ifNone: [ nil ] ].
-
-	(astNode isNotNil and: [ astNode binding isPoolVariable ]) ifTrue: [ 
-		self systemNavigation
-			openBrowserFor: astNode binding
-			withMethods: astNode binding usingMethods.
-		^ true ].
-	^ false
+	^ self browsePoolVarNode: [ :astNode | 
+		  self systemNavigation
+			  openBrowserFor: astNode binding
+			  withMethods: astNode binding usingMethods ]
 ]
 
 { #category : #'private - commands' }

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -206,10 +206,10 @@ SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonG
 
   "Fix for showing Pool Vars references"
 	position := self selectionInterval first.
-	astNode:= interactionModel context method ast variableNodes
+	(interactionModel hasBindingOf:variableOrClassName) ifTrue:[ astNode:= interactionModel context method ast variableNodes
 		detect: [ :node | node start = position ]
-		ifNone: [ nil ].
-
+		ifNone: [ nil ]].
+ 
 	(astNode isNotNil and: [ astNode binding isPoolVariable ]) ifTrue: [ 
 		self systemNavigation openBrowserFor:  astNode binding withMethods: astNode  binding usingMethods.
 		^self


### PR DESCRIPTION
I have tried to modify as less a possible the existing code. Now the pool var case is treated first, if the 
selected text (or the token where the cursor is located) is a poolvar the implementor / senders will be shown.
If not, the computation will continue as it was before. I believe it is necessary more refactoring on the existing, for example, several  method names assume that the token is a selector, but in the code it can be seen that it could be also a class or a variable.