### PR TITLE
Move `#reset` class side methods over to `class initialization` protocol

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyle.class.st
@@ -127,7 +127,7 @@ SpStyle class >> newApplication [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : #'class initialization' }
 SpStyle class >> reset [ 
 	<script>
 

--- a/src/Spec2-Core/SpNullApplication.class.st
+++ b/src/Spec2-Core/SpNullApplication.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Spec2-Core-Base'
 }
 
-{ #category : #initialization }
+{ #category : #'class initialization' }
 SpNullApplication class >> reset [
 	<script>
 	

--- a/src/Spec2-Morphic-Tests/SpTestWorldPresenter.class.st
+++ b/src/Spec2-Morphic-Tests/SpTestWorldPresenter.class.st
@@ -27,7 +27,7 @@ SpTestWorldPresenter class >> newWorld [
 		yourself
 ]
 
-{ #category : #'ui requests' }
+{ #category : #'class initialization' }
 SpTestWorldPresenter class >> reset [
 	TestWorld := nil
 ]


### PR DESCRIPTION
Hi 👋 . This moves a few class side `#reset` methods over to the `initialization` protocol. It's to help move the following issue forward: https://github.com/pharo-project/pharo/issues/2607

Hope it's all OK!