### PR TITLE
Fix for Pressing cmd+m tries to access the senderes instead of the implementations in Pharo 10 #10671

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -206,7 +206,7 @@ SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonG
 		ifNil: [ interactionModel behavior ])
 			ifNil: [ environment
 				ifNil: [ self class environment ] ])
-					lookupVar: variableOrClassName.
+					lookupVar: variableOrClassName declare: false.
 
 	variable ifNil: [ ^ nonGlobalBlock value: variableOrClassName ].
 	self systemNavigation openBrowserFor: variableOrClassName withMethods: variable usingMethods


### PR DESCRIPTION
lookup variable without decaring a new one in case this cose is run with a playground scope as the parent scope

Fixes https://github.com/pharo-project/pharo/issues/10671