### PR TITLE
Fix: Evaluating code in the inspector incorrectly uses binding of on the receiver

### DIFF
--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -55,10 +55,10 @@ SpCodeInteractionModel >> doItReceiver [
 	^ nil
 ]
 
-{ #category : #testing }
+{ #category : #binding }
 SpCodeInteractionModel >> hasBindingOf: aString [
 
-	^ self subclassResponsibility
+	^ false
 ]
 
 { #category : #testing }

--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -32,7 +32,7 @@ SpCodeInteractionModel >> behavior [
 { #category : #binding }
 SpCodeInteractionModel >> bindingOf: aString [
 
-	^ self subclassResponsibility
+	^ nil
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Code/SpCodeNullInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeNullInteractionModel.class.st
@@ -3,15 +3,3 @@ Class {
 	#superclass : #SpCodeInteractionModel,
 	#category : #'Spec2-Code-Base'
 }
-
-{ #category : #binding }
-SpCodeNullInteractionModel >> bindingOf: aString [
-
-	^ nil
-]
-
-{ #category : #testing }
-SpCodeNullInteractionModel >> hasBindingOf: aString [
-
-	^ false
-]

--- a/src/Spec2-Code/SpCodeObjectInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeObjectInteractionModel.class.st
@@ -19,22 +19,10 @@ SpCodeObjectInteractionModel >> behavior [
 	^ self object class
 ]
 
-{ #category : #binding }
-SpCodeObjectInteractionModel >> bindingOf: aString [
-
-	^ self doItReceiver bindingOf: aString
-]
-
 { #category : #accessing }
 SpCodeObjectInteractionModel >> doItReceiver [
 
 	^ self object
-]
-
-{ #category : #testing }
-SpCodeObjectInteractionModel >> hasBindingOf: aString [
-
-	^ self doItReceiver hasBindingOf: aString
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- move bindingOf: method from SpCodeNullInteractionModel to the super class
-  SpCodeObjectInteractionModel can use those

This is tested via SpCodeInteractionModelTest and subclasses

fixes https://github.com/pharo-spec/NewTools/issues/312


