### PR TITLE
fix-user-canBeGlobalVarInitial 

### DIFF
--- a/src/Spec2-Examples/SpTextInputFieldPresenter.extension.st
+++ b/src/Spec2-Examples/SpTextInputFieldPresenter.extension.st
@@ -15,13 +15,7 @@ SpTextInputFieldPresenter class >> example [
 SpTextInputFieldPresenter class >> exampleEntryCompletion [
 	| applicants entryCompletion |
 
-	applicants := (Array
-		streamContents: [ :strm | 
-			Symbol allSymbolTablesDo: [ :each | 
-				(each notEmpty 
-					and: [ each isValidGlobalName 
-					and: [ Smalltalk globals includesKey: each ] ])
-					ifTrue: [ strm nextPut: each ] ] ]) sort.
+	applicants := Smalltalk globals classNames sorted.
 	
 	entryCompletion := EntryCompletion new
 		dataSourceBlock: [ :currText | applicants ];

--- a/src/Spec2-Examples/SpTextInputFieldPresenter.extension.st
+++ b/src/Spec2-Examples/SpTextInputFieldPresenter.extension.st
@@ -19,7 +19,7 @@ SpTextInputFieldPresenter class >> exampleEntryCompletion [
 		streamContents: [ :strm | 
 			Symbol allSymbolTablesDo: [ :each | 
 				(each notEmpty 
-					and: [ each first canBeGlobalVarInitial 
+					and: [ each isValidGlobalName 
 					and: [ Smalltalk globals includesKey: each ] ])
 					ifTrue: [ strm nextPut: each ] ] ]) sort.
 	


### PR DESCRIPTION
Character>>#leadingChar is deprecated but used by #canBeGlobalVarInitial (see https://github.com/pharo-project/pharo/issues/10238).

This PR replaces  the users by calling #isValidGlobalName on the string, which does do the check if the fist character is uppercase (and works corrrecty in case of Unicode, too).

This is one step for https://github.com/pharo-project/pharo/issues/10238

