### PR TITLE
use "accessing - ui" category instead of "accessing ui" to align with all the other "accessing - ..." categories

### DIFF
--- a/src/Spec2-Examples/SpInitializeWindowExample.class.st
+++ b/src/Spec2-Examples/SpInitializeWindowExample.class.st
@@ -133,7 +133,7 @@ SpInitializeWindowExample >> pushMessage [
 	statusBar pushMessage: ('StatusBar message {1}...' format: { count })
 ]
 
-{ #category : #'accessing ui' }
+{ #category : #'accessing - ui' }
 SpInitializeWindowExample >> text [ 
 
 	^ text


### PR DESCRIPTION
… 