### PR TITLE
This fixes a non-categrorize method in SpIndeterminatedProgressBarState

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpIndeterminatedProgressBarState.extension.st
+++ b/src/Spec2-Adapters-Morphic/SpIndeterminatedProgressBarState.extension.st
@@ -6,6 +6,12 @@ SpIndeterminatedProgressBarState >> customizeMorphicBar: aProgressBarMorph [
 ]
 
 { #category : #'*Spec2-Adapters-Morphic' }
+SpIndeterminatedProgressBarState >> customizeMorphicLabel: aLabelMorph [
+
+	aLabelMorph contents: 'Processing...'
+]
+
+{ #category : #'*Spec2-Adapters-Morphic' }
 SpIndeterminatedProgressBarState >> progressBarMorph [
 	^ SpIndeterminatedProgressBarMorph
 ]

--- a/src/Spec2-Core/SpIndeterminatedProgressBarState.class.st
+++ b/src/Spec2-Core/SpIndeterminatedProgressBarState.class.st
@@ -15,12 +15,6 @@ Class {
 	#category : #'Spec2-Core-Utils'
 }
 
-{ #category : #'as yet unclassified' }
-SpIndeterminatedProgressBarState >> customizeMorphicLabel: aLabelMorph [
-
-	aLabelMorph contents: 'Processing...'
-]
-
 { #category : #'api - events' }
 SpIndeterminatedProgressBarState >> whenValueChangedDo: aBlock [
 	"Value cannot change in indeterminate state"


### PR DESCRIPTION
all the other implementors are in Spec2-Adapters-Morphic, so I moved this one there, too.

last step (I hope) for https://github.com/pharo-project/pharo/issues/9705