### PR TITLE
Fix CMD-shift-n (Variable References) work in the debugger.

### DIFF
--- a/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
@@ -172,15 +172,17 @@ SpCodePresenterTest >> testDoBrowseMethodReferences [
 	
 	navigation := SpCodeSystemNavigationMock new.
 	presenter systemNavigation: navigation.
+	presenter environment add: SpCodePresenterTest binding.
+	presenter environment add: SpCodeSystemNavigationMock binding.
 	self openInstance.
 	
-	presenter text: 'testDoBrowseMethodReferencesX'.
+	presenter text: 'Object'.
 	presenter doBrowseMethodReferences.
 	
-	self assert: navigation messageList isEmpty.
+	self assert: navigation messageList isNil.
 	
 	navigation reset.
-	presenter text: 'doBrowseMethodReferences'.
+	presenter text: 'SpCodeSystemNavigationMock'.
 	presenter doBrowseMethodReferences.
 	
 	self assert: navigation messageList notEmpty.

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -198,14 +198,9 @@ SpCodePresenter >> bindingOf: aString [
 { #category : #'private - commands' }
 SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonGlobalBlock [
 	| variableOrClassName variable |
-	variableOrClassName := self selectedSelector.
-	variableOrClassName ifNil: [ ^ nil ].
+	variableOrClassName := self selectedSelector ifNil: [ ^ nil ].
 
-	variable := ((interactionModel doItContext
-		ifNil: [ interactionModel behavior ])
-			ifNil: [ environment
-				ifNil: [ self class environment ] ])
-					lookupVar: variableOrClassName.
+	variable := self lookupEnvironment lookupVar: variableOrClassName.
 
 	variable ifNil: [^nonGlobalBlock value: variableOrClassName ].
 	variable isLiteralVariable ifFalse: [^nonGlobalBlock value: variable name  ].
@@ -318,8 +313,17 @@ SpCodePresenter >> doBrowseImplementors [
 
 { #category : #commands }
 SpCodePresenter >> doBrowseMethodReferences [
+	"Browse references to Variables (Cmd-shift-n)"
+	| variableOrClassName variable usingMethods |
+	variableOrClassName := self selectedSelector ifNil: [ ^ nil ].
 
-	self doBrowseSenders
+	variable := self lookupEnvironment lookupVar: variableOrClassName.
+	variable ifNil: [ ^ nil ].
+	usingMethods := variable usingMethods ifEmpty: [ ^ application inform: 'No users found.'].
+
+	"the dialog sadly hard-codes 'senders'"
+	^ self systemNavigation openBrowserFor: variable name withMethods: usingMethods
+
 ]
 
 { #category : #commands }
@@ -579,6 +583,15 @@ SpCodePresenter >> isForScripting [
 SpCodePresenter >> lineNumbers: aBoolean [
 
 	lineNumbers := aBoolean
+]
+
+{ #category : #'command support' }
+SpCodePresenter >> lookupEnvironment [
+	"when searching for variables, start here"
+	^((interactionModel doItContext
+		ifNil: [ interactionModel behavior ])
+			ifNil: [ environment
+				ifNil: [ self class environment ] ])
 ]
 
 { #category : #private }


### PR DESCRIPTION
- add SpCodePresenter>>#lookupEnvironment
- simplify browseSelectedSelectorIfGlobal:ifNotGlobal: to use it
- implement #doBrowseMethodReferences
- test the corrent thing in testDoBrowseMethodReferences

Fixes https://github.com/pharo-project/pharo/issues/10942