### PR TITLE
Refactoring the Spec in-image examples 

### DIFF
--- a/src/Spec2-Examples/SpApplicationWithToolbar.class.st
+++ b/src/Spec2-Examples/SpApplicationWithToolbar.class.st
@@ -38,7 +38,7 @@ SpApplicationWithToolbar >> addItemTo: aGroup [
 SpApplicationWithToolbar >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: menu withConstraints: [ :constraints | constraints height: self class toolbarHeight ];
+		add: menu expand: false;
 		add: text;
 		yourself
 ]

--- a/src/Spec2-Examples/SpApplicationWithToolbar.class.st
+++ b/src/Spec2-Examples/SpApplicationWithToolbar.class.st
@@ -13,14 +13,6 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpApplicationWithToolbar class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #menu withConstraints: [ :constraints | constraints height: self toolbarHeight ];
-		add: #text;
-		yourself
-]
-
 { #category : #examples }
 SpApplicationWithToolbar class >> example [
 
@@ -40,6 +32,15 @@ SpApplicationWithToolbar >> addItemTo: aGroup [
 					self build ] ].
 	self needRebuild: false.
 	self build
+]
+
+{ #category : #layout }
+SpApplicationWithToolbar >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: menu withConstraints: [ :constraints | constraints height: self class toolbarHeight ];
+		add: text;
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpBoxLayoutAlignmentExample.class.st
+++ b/src/Spec2-Examples/SpBoxLayoutAlignmentExample.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SpBoxLayoutAlignmentExample,
 	#superclass : #SpPresenter,
-	#category : #'Spec2-Examples-Layouts'
+	#category : #'Spec2-Examples-Demo-Layouts'
 }
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpBoxLayoutReplacePresenterExample.class.st
+++ b/src/Spec2-Examples/SpBoxLayoutReplacePresenterExample.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SpBoxLayoutReplacePresenterExample,
 	#superclass : #SpPresenter,
-	#category : #'Spec2-Examples-Layouts'
+	#category : #'Spec2-Examples-Demo-Layouts'
 }
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpCheckBoxExample.class.st
+++ b/src/Spec2-Examples/SpCheckBoxExample.class.st
@@ -15,20 +15,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Checkboxes'
 }
 
-{ #category : #layout }
-SpCheckBoxExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #button1;
-				add: #button2;
-				add: #button3;
-				yourself)
-			withConstraints: [ :c | c height: self toolbarHeight ];
-		add: #label withConstraints: [ :c | c height: self labelHeight ];
-		yourself
-]
-
 { #category : #examples }
 SpCheckBoxExample class >> example [
 
@@ -50,6 +36,20 @@ SpCheckBoxExample >> connectPresenters [
 	button2 whenChangedDo: [ self updateLabel ].
 
 	button3 whenChangedDo: [ self updateLabel ]
+]
+
+{ #category : #layout }
+SpCheckBoxExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: (SpBoxLayout newLeftToRight
+			add: button1;
+			add: button2;
+			add: button3;
+			yourself)
+		withConstraints: [ :c | c height: self class toolbarHeight ];
+		add: label withConstraints: [ :c | c height: self class labelHeight ];
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpCheckBoxExample.class.st
+++ b/src/Spec2-Examples/SpCheckBoxExample.class.st
@@ -42,14 +42,14 @@ SpCheckBoxExample >> connectPresenters [
 SpCheckBoxExample >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: (SpBoxLayout newLeftToRight
-			add: button1;
-			add: button2;
-			add: button3;
-			yourself)
-		withConstraints: [ :c | c height: self class toolbarHeight ];
-		add: label withConstraints: [ :c | c height: self class labelHeight ];
-		yourself
+		  add: (SpBoxLayout newLeftToRight
+				   add: button1;
+				   add: button2;
+				   add: button3;
+				   yourself)
+		  expand: false;
+		  add: label expand: false;
+		  yourself
 ]
 
 { #category : #initialization }
@@ -78,15 +78,12 @@ SpCheckBoxExample >> setFocus [
 
 { #category : #updating }
 SpCheckBoxExample >> updateLabel [
-	label
-		label:
-			(String
-				streamContents: [ :s | 
-					{button1 . button2 . button3}
-						do: [ :button | 
-							s
-								<< button label;
-								<< ' : ';
-								<< (button state ifTrue: [ 'V' ] ifFalse: [ 'X' ]) ]
-						separatedBy: [ s << ' - ' ] ])
+
+	label label: (String streamContents: [ :s | 
+		{button1 . button2 . button3}
+		do: [ :button | 
+			s  << button label;
+				<< ' : ';
+				<< (button state ifTrue: [ 'V' ] ifFalse: [ 'X' ]) ]
+		separatedBy: [ s << ' - ' ] ])
 ]

--- a/src/Spec2-Examples/SpClassMethodBrowser.class.st
+++ b/src/Spec2-Examples/SpClassMethodBrowser.class.st
@@ -14,18 +14,6 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpClassMethodBrowser class >> defaultLayout [
-	^ SpPanedLayout newTopToBottom
-		add:
-			(SpPanedLayout newLeftToRight
-				add: #classListPresenter;
-				add: #methodListPresenter;
-				yourself);
-		add: #textPresenter;
-		yourself
-]
-
 { #category : #examples }
 SpClassMethodBrowser class >> example [
 
@@ -65,6 +53,18 @@ SpClassMethodBrowser >> connectPresenters [
 		transform: [ :method | method ifNil: [ '' ] ifNotNil: #sourceCode ]
 		postTransmission: [ :destination :origin :transmited | 
 			transmited ifNotNil: [ destination beForMethod: transmited ] ]
+]
+
+{ #category : #layout }
+SpClassMethodBrowser >> defaultLayout [
+
+	^ SpPanedLayout newTopToBottom
+		add: (SpPanedLayout newLeftToRight
+			add: classListPresenter;
+			add: methodListPresenter;
+			yourself);
+		add: textPresenter;
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemo.class.st
+++ b/src/Spec2-Examples/SpDemo.class.st
@@ -82,6 +82,19 @@ SpDemo >> connectPresenters [
 				list setSelectedItem: self selectedPage ] ]
 ]
 
+{ #category : #layout }
+SpDemo >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: menu expand: false;
+		  add: (SpPanedLayout newLeftToRight
+				   positionOfSlider: 200;
+				   add: list;
+				   add: page;
+				   yourself);
+		  yourself
+]
+
 { #category : #accessing }
 SpDemo >> defaultPage [
 
@@ -102,39 +115,29 @@ SpDemo >> initialExtent [
 { #category : #initialization }
 SpDemo >> initializePresenters [
 
-	menu := self mainMenu.
-	list := self newList.
 	page := SpBoxLayout newTopToBottom 
 		add: (self instantiate: (selectedPage := self availablePages first));
 		yourself.
-
-	self layout: (SpBoxLayout newTopToBottom
-		add: menu expand: false;
-		add: (SpPanedLayout newLeftToRight
-			positionOfSlider: 200;
-			add: list;
-			add: page;
-			yourself);
-		yourself).
-
+	
+	menu := self mainMenu.
 	menu addKeybindingsTo: self.
-
+	
+	list := self newList.
 	list
 		items: self availablePages;
 		display: [ :item | item pageName ];
-		contextMenu:
-			(self newMenu
-				addItem: [ :item | 
-					item
-						name: 'Browse';
-						icon: (self iconNamed: #smallHelp);
-						action: [ list selectedItem browse ] ];
-				addItem: [ :item | 
-					item
-						name: 'Browse presenter';
-						icon: (self iconNamed: #smallHelp);
-						action: [ list selectedItem new pageClass browse ] ];
-				yourself).
+		contextMenu: (self newMenu
+			addItem: [ :item | 
+				item
+					name: 'Browse';
+					icon: (self iconNamed: #smallHelp);
+					action: [ list selectedItem browse ] ];
+			addItem: [ :item | 
+				item
+					name: 'Browse presenter';
+					icon: (self iconNamed: #smallHelp);
+					action: [ list selectedItem new pageClass browse ] ];
+			yourself).
 
 	self focusOrder
 		add: list;

--- a/src/Spec2-Examples/SpDemoAbstractModalPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoAbstractModalPresenter.class.st
@@ -13,16 +13,17 @@ Class {
 	#category : #'Spec2-Examples-Demo-Modals'
 }
 
-{ #category : #layout }
-SpDemoAbstractModalPresenter class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #explanation;
-		yourself
-]
-
 { #category : #accessing }
 SpDemoAbstractModalPresenter >> content [
 	^ self subclassResponsibility
+]
+
+{ #category : #layout }
+SpDemoAbstractModalPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: explanation;
+		  yourself
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpDemoActionBarPage.class.st
+++ b/src/Spec2-Examples/SpDemoActionBarPage.class.st
@@ -13,9 +13,10 @@ SpDemoActionBarPage class >> pageName [
 	^ 'ActionBar'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoActionBarPage class >> priority [
-	^ 13
+
+	^ 800
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoActionBarPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoActionBarPresenter.class.st
@@ -15,9 +15,9 @@ Class {
 SpDemoActionBarPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: text;
-		addLast: actionBar expand: false fill: false padding: 0;
-		yourself
+		  add: text;
+		  addLast: actionBar expand: false;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoActionBarPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoActionBarPresenter.class.st
@@ -12,11 +12,11 @@ Class {
 }
 
 { #category : #layout }
-SpDemoActionBarPresenter class >> defaultLayout [
+SpDemoActionBarPresenter >> defaultLayout [
 
-	^ SpBoxLayout newTopToBottom 
-		add: #text;
-		addLast: #actionBar expand: false fill: false padding: 0;
+	^ SpBoxLayout newTopToBottom
+		add: text;
+		addLast: actionBar expand: false fill: false padding: 0;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoButtonsPage.class.st
+++ b/src/Spec2-Examples/SpDemoButtonsPage.class.st
@@ -13,10 +13,10 @@ SpDemoButtonsPage class >> pageName [
 	^ 'Buttons'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoButtonsPage class >> priority [
 
-	^ 20
+	^ 600
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoButtonsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoButtonsPresenter.class.st
@@ -19,107 +19,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Buttons'
 }
 
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonDisabled [
-	^ buttonDisabled
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonDisabled: anObject [
-	buttonDisabled := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonHighlighted [
-	^ buttonHighlighted
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonHighlighted: anObject [
-	buttonHighlighted := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonNormal [
-	^ buttonNormal
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonNormal: anObject [
-	buttonNormal := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithColor [
-	^ buttonWithColor
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithColor: anObject [
-	buttonWithColor := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithDifferentFont [
-	^ buttonWithDifferentFont
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithDifferentFont: anObject [
-	buttonWithDifferentFont := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithHelp [
-	^ buttonWithHelp
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithHelp: anObject [
-
-	buttonWithHelp := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithIcon [
-	^ buttonWithIcon
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithIcon: anObject [
-	buttonWithIcon := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithIconOnly [
-	^ buttonWithIconOnly
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithIconOnly: anObject [
-	buttonWithIconOnly := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithMenu [
-	^ buttonWithMenu
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithMenu: anObject [
-	buttonWithMenu := anObject
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithShortcut [
-	^ buttonWithShortcut
-]
-
-{ #category : #accessing }
-SpDemoButtonsPresenter >> buttonWithShortcut: anObject [
-	buttonWithShortcut := anObject
-]
-
 { #category : #initialization }
 SpDemoButtonsPresenter >> connectPresenters [
 
@@ -129,19 +28,24 @@ SpDemoButtonsPresenter >> connectPresenters [
 { #category : #layout }
 SpDemoButtonsPresenter >> defaultLayout [
 
-	^ SpGridLayout new
-		  beColumnHomogeneous;
-		  borderWidth: 0;
-		  add: buttonNormal at: 1 @ 1;
-		  add: buttonDisabled at: 2 @ 1;
-		  add: buttonWithIcon at: 3 @ 1;
-		  add: buttonWithIconOnly at: 4 @ 1;
-		  add: buttonHighlighted at: 5 @ 1;
-		  add: buttonWithColor at: 1 @ 2;
-		  add: buttonWithMenu at: 2 @ 2;
-		  add: buttonWithShortcut at: 3 @ 2;
-		  add: buttonWithHelp at: 4 @ 2;
-		  add: buttonWithDifferentFont at: 5 @ 2
+	^ SpGridLayout build: [ :builder | 
+		builder
+			beColumnHomogeneous;
+			beRowHomogeneous;
+			borderWidth: 0;
+			add: buttonNormal;
+			add: buttonDisabled;
+			add: buttonWithIcon;
+			nextRow;
+			add: buttonWithIconOnly;
+			add: buttonHighlighted;
+			add: buttonWithColor;
+			nextRow;
+			add: buttonWithMenu;
+			add: buttonWithShortcut;
+			add: buttonWithHelp;
+			nextRow;
+			add: buttonWithDifferentFont ]
 ]
 
 { #category : #initialization }
@@ -185,6 +89,7 @@ a multiline help';
 		label: 'different font';
 		font: StandardFonts codeFont;
 		yourself.
+	
 	self focusOrder
 		add: buttonNormal;
 		add: buttonDisabled;

--- a/src/Spec2-Examples/SpDemoButtonsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoButtonsPresenter.class.st
@@ -19,23 +19,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Buttons'
 }
 
-{ #category : #specs }
-SpDemoButtonsPresenter class >> defaultLayout [
-	^ SpGridLayout new
-		beColumnHomogeneous;
-		borderWidth: 0;
-		add: #buttonNormal at: 1 @ 1;
-		add: #buttonDisabled at: 2 @ 1;
-		add: #buttonWithIcon at: 3 @ 1;
-		add: #buttonWithIconOnly at: 4 @ 1;
-		add: #buttonHighlighted at: 5 @ 1;
-		add: #buttonWithColor at: 1 @ 2;
-		add: #buttonWithMenu at: 2 @ 2;
-		add: #buttonWithShortcut at: 3 @ 2;
-		add: #buttonWithHelp at: 4 @ 2;
-		add: #buttonWithDifferentFont at: 5 @ 2
-]
-
 { #category : #accessing }
 SpDemoButtonsPresenter >> buttonDisabled [
 	^ buttonDisabled
@@ -141,6 +124,24 @@ SpDemoButtonsPresenter >> buttonWithShortcut: anObject [
 SpDemoButtonsPresenter >> connectPresenters [
 
 	buttonWithShortcut action: [ self inform: 'button with shortcut pressed' ]																																														
+]
+
+{ #category : #layout }
+SpDemoButtonsPresenter >> defaultLayout [
+
+	^ SpGridLayout new
+		  beColumnHomogeneous;
+		  borderWidth: 0;
+		  add: buttonNormal at: 1 @ 1;
+		  add: buttonDisabled at: 2 @ 1;
+		  add: buttonWithIcon at: 3 @ 1;
+		  add: buttonWithIconOnly at: 4 @ 1;
+		  add: buttonHighlighted at: 5 @ 1;
+		  add: buttonWithColor at: 1 @ 2;
+		  add: buttonWithMenu at: 2 @ 2;
+		  add: buttonWithShortcut at: 3 @ 2;
+		  add: buttonWithHelp at: 4 @ 2;
+		  add: buttonWithDifferentFont at: 5 @ 2
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoCheckboxesPage.class.st
+++ b/src/Spec2-Examples/SpDemoCheckboxesPage.class.st
@@ -13,10 +13,10 @@ SpDemoCheckboxesPage class >> pageName [
 	^ 'Checkboxes'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoCheckboxesPage class >> priority [
 
-	^ 30
+	^ 1000
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
@@ -14,57 +14,15 @@ Class {
 	#category : #'Spec2-Examples-Demo-Checkboxes'
 }
 
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxDisabled [
-	^ checkboxDisabled
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxDisabled: anObject [
-	checkboxDisabled := anObject
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxNormal [
-	^ checkboxNormal
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxNormal: anObject [
-	checkboxNormal := anObject
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxWithHelp [
-	^ checkboxWithHelp
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxWithHelp: anObject [
-	checkboxWithHelp := anObject
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxWithLabelOnLeft [
-	^ checkboxWithLabelOnLeft
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxWithLabelOnLeft: anObject [
-	checkboxWithLabelOnLeft := anObject
-]
-
 { #category : #layout }
 SpDemoCheckboxesPresenter >> defaultLayout [
 
-	^ SpBoxLayout newLeftToRight
-		add: (SpBoxLayout newTopToBottom
-			add: checkboxNormal;
-			add: checkboxDisabled;
-			add: checkboxWithHelp;
-			yourself);
-		add: checkboxExample;
-		yourself
+	^ SpBoxLayout newTopToBottom
+		  add: checkboxExample expand: false;
+		  add: checkboxNormal;
+		  add: checkboxDisabled;
+		  add: checkboxWithHelp;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
@@ -8,7 +8,6 @@ Class {
 		'checkboxNormal',
 		'checkboxDisabled',
 		'checkboxWithHelp',
-		'checkboxWithLabelOnLeft',
 		'checkboxExample'
 	],
 	#category : #'Spec2-Examples-Demo-Checkboxes'

--- a/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
@@ -18,11 +18,11 @@ Class {
 SpDemoCheckboxesPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		  add: checkboxExample expand: false;
-		  add: checkboxNormal;
-		  add: checkboxDisabled;
-		  add: checkboxWithHelp;
-		  yourself
+		add: checkboxExample expand: false;
+		add: checkboxNormal;
+		add: checkboxDisabled;
+		add: checkboxWithHelp;
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoCheckboxesPresenter.class.st
@@ -7,27 +7,12 @@ Class {
 	#instVars : [
 		'checkboxNormal',
 		'checkboxDisabled',
-		'checkboxWithColor',
 		'checkboxWithHelp',
 		'checkboxWithLabelOnLeft',
 		'checkboxExample'
 	],
 	#category : #'Spec2-Examples-Demo-Checkboxes'
 }
-
-{ #category : #layout }
-SpDemoCheckboxesPresenter class >> defaultLayout [
-	^ SpBoxLayout newLeftToRight
-		add:
-			(SpBoxLayout newTopToBottom
-				add: #checkboxNormal;
-				add: #checkboxDisabled;
-				add: #checkboxWithColor;
-				add: #checkboxWithHelp;
-				yourself);
-		add: #checkboxExample;
-		yourself
-]
 
 { #category : #accessing }
 SpDemoCheckboxesPresenter >> checkboxDisabled [
@@ -50,16 +35,6 @@ SpDemoCheckboxesPresenter >> checkboxNormal: anObject [
 ]
 
 { #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxWithColor [
-	^ checkboxWithColor
-]
-
-{ #category : #accessing }
-SpDemoCheckboxesPresenter >> checkboxWithColor: anObject [
-	checkboxWithColor := anObject
-]
-
-{ #category : #accessing }
 SpDemoCheckboxesPresenter >> checkboxWithHelp [
 	^ checkboxWithHelp
 ]
@@ -79,6 +54,19 @@ SpDemoCheckboxesPresenter >> checkboxWithLabelOnLeft: anObject [
 	checkboxWithLabelOnLeft := anObject
 ]
 
+{ #category : #layout }
+SpDemoCheckboxesPresenter >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		add: (SpBoxLayout newTopToBottom
+			add: checkboxNormal;
+			add: checkboxDisabled;
+			add: checkboxWithHelp;
+			yourself);
+		add: checkboxExample;
+		yourself
+]
+
 { #category : #initialization }
 SpDemoCheckboxesPresenter >> initializePresenters [
 
@@ -87,10 +75,6 @@ SpDemoCheckboxesPresenter >> initializePresenters [
 	checkboxDisabled := self newCheckBox 
 		label: 'disabled';
 		disable;
-		yourself.
-	checkboxWithColor := self newCheckBox 
-		label: 'red';
-		color: Color red;
 		yourself.
 	checkboxWithHelp := self newCheckBox 
 		label: 'with help';

--- a/src/Spec2-Examples/SpDemoFilteringListsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoFilteringListsPresenter.class.st
@@ -56,27 +56,3 @@ SpDemoFilteringListsPresenter >> initializePresenters [
 	selectableList listPresenter
 		sortingBlock: [ :a :b | a name > b name ]
 ]
-
-{ #category : #accessing }
-SpDemoFilteringListsPresenter >> listWithMethodsAlreadyFiltered [
-
-	^ listWithMethodsAlreadyFiltered
-]
-
-{ #category : #accessing }
-SpDemoFilteringListsPresenter >> listWithMethodsAlreadyFiltered: anObject [
-
-	listWithMethodsAlreadyFiltered := anObject
-]
-
-{ #category : #accessing }
-SpDemoFilteringListsPresenter >> listWithPackages [
-
-	^ listWithPackages
-]
-
-{ #category : #accessing }
-SpDemoFilteringListsPresenter >> listWithPackages: anObject [
-
-	listWithPackages := anObject
-]

--- a/src/Spec2-Examples/SpDemoFilteringListsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoFilteringListsPresenter.class.st
@@ -1,0 +1,82 @@
+"
+I am a demo showing filtering lists examples
+"
+Class {
+	#name : #SpDemoFilteringListsPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'listWithPackages',
+		'listWithMethodsAlreadyFiltered',
+		'selectableList'
+	],
+	#category : #'Spec2-Examples-Demo-Lists'
+}
+
+{ #category : #layout }
+SpDemoFilteringListsPresenter >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		add: (SpBoxLayout newTopToBottom
+			add: 'Filtering List' expand: false;
+			add: listWithPackages;
+			yourself);
+		add: (SpBoxLayout newTopToBottom
+			add: 'Filtering List with Filter Text' expand: false;
+			add: listWithMethodsAlreadyFiltered;
+			yourself);
+		add: (SpBoxLayout newTopToBottom
+			add: 'Selectable Filtering List' expand: false;
+			add: selectableList;
+			yourself);
+		yourself
+]
+
+{ #category : #initialization }
+SpDemoFilteringListsPresenter >> initializePresenters [
+
+	listWithPackages := self newFilteringList.
+	listWithPackages items: self class environment allClasses.
+	listWithPackages listPresenter
+		display: [ :class | class name ];
+		sortingBlock: [ :a : b | a name < b name ];
+		displayIcon: [ :aClass | aClass systemIcon ].
+	
+	listWithMethodsAlreadyFiltered := self newFilteringList.
+	listWithMethodsAlreadyFiltered
+		items: self class environment allClasses;
+		applyFilter: 'SpDemo'.
+	
+	listWithMethodsAlreadyFiltered listPresenter
+		display: [ :class | class name ];
+		sortingBlock: [ :a :b | a name < b name ];
+		displayIcon: [ :aClass | aClass systemIcon ].
+	
+	selectableList :=  self instantiate: SpFilteringSelectableListPresenter.
+	selectableList items: self class environment allClasses.
+	selectableList listPresenter
+		sortingBlock: [ :a :b | a name > b name ]
+]
+
+{ #category : #accessing }
+SpDemoFilteringListsPresenter >> listWithMethodsAlreadyFiltered [
+
+	^ listWithMethodsAlreadyFiltered
+]
+
+{ #category : #accessing }
+SpDemoFilteringListsPresenter >> listWithMethodsAlreadyFiltered: anObject [
+
+	listWithMethodsAlreadyFiltered := anObject
+]
+
+{ #category : #accessing }
+SpDemoFilteringListsPresenter >> listWithPackages [
+
+	^ listWithPackages
+]
+
+{ #category : #accessing }
+SpDemoFilteringListsPresenter >> listWithPackages: anObject [
+
+	listWithPackages := anObject
+]

--- a/src/Spec2-Examples/SpDemoFormPage.class.st
+++ b/src/Spec2-Examples/SpDemoFormPage.class.st
@@ -4,19 +4,13 @@ Demo page for SpecDemoFormPresenter
 Class {
 	#name : #SpDemoFormPage,
 	#superclass : #SpDemoPage,
-	#category : #'Spec2-Morphic-Examples-Demo-Forms'
+	#category : #'Spec2-Examples-Demo-Forms'
 }
 
-{ #category : #specs }
-SpDemoFormPage class >> pageName [
-
-	^ 'Forms'
-]
-
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoFormPage class >> priority [
 
-	^ 10
+	^ 100
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoFormPage.class.st
+++ b/src/Spec2-Examples/SpDemoFormPage.class.st
@@ -8,6 +8,12 @@ Class {
 }
 
 { #category : #initialization }
+SpDemoFormPage class >> pageName [
+
+	^ 'Forms'
+]
+
+{ #category : #initialization }
 SpDemoFormPage class >> priority [
 
 	^ 100

--- a/src/Spec2-Examples/SpDemoFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoFormPresenter.class.st
@@ -76,6 +76,11 @@ SpDemoFormPresenter >> initializePresenters [
 		beResizable
 ]
 
+{ #category : #initialization }
+SpDemoFormPresenter >> modelChanged [
+	table items: self model elements
+]
+
 { #category : #'option list presenter' }
 SpDemoFormPresenter >> optionIcon [
 	

--- a/src/Spec2-Examples/SpDemoFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoFormPresenter.class.st
@@ -28,22 +28,13 @@ Class {
 }
 
 { #category : #layout }
-SpDemoFormPresenter class >> defaultLayout [
+SpDemoFormPresenter >> defaultLayout [
+
 	^ SpPanedLayout newLeftToRight
-		positionOfSlider: (StandardFonts defaultFont widthOfString: 'M') * 35;
-		add: #form;
-		add: #resultPane;
-		yourself
-]
-
-{ #category : #accessing }
-SpDemoFormPresenter >> form [
-	^ form
-]
-
-{ #category : #accessing }
-SpDemoFormPresenter >> form: anObject [
-	form := anObject
+		  positionOfSlider: (StandardFonts defaultFont widthOfString: 'M') * 35;
+		  add: form;
+		  add: resultPane;
+		  yourself
 ]
 
 { #category : #initialization }
@@ -78,6 +69,7 @@ SpDemoFormPresenter >> initializePresenters [
 
 { #category : #initialization }
 SpDemoFormPresenter >> modelChanged [
+
 	table items: self model elements
 ]
 
@@ -89,17 +81,8 @@ SpDemoFormPresenter >> optionIcon [
 
 { #category : #'option list presenter' }
 SpDemoFormPresenter >> optionTitle [
+
 	^ 'Form Presenter'
-]
-
-{ #category : #accessing }
-SpDemoFormPresenter >> resultPane [
-	^ resultPane
-]
-
-{ #category : #accessing }
-SpDemoFormPresenter >> resultPane: anObject [
-	resultPane := anObject
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpDemoFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoFormPresenter.class.st
@@ -24,7 +24,7 @@ Class {
 		'resultPane',
 		'table'
 	],
-	#category : #'Spec2-Morphic-Examples-Demo-Forms'
+	#category : #'Spec2-Examples-Demo-Forms'
 }
 
 { #category : #layout }
@@ -74,11 +74,6 @@ SpDemoFormPresenter >> initializePresenters [
 		addColumn: (SpStringTableColumn title: 'Value' evaluated: #value);
 		items: self model elements;
 		beResizable
-]
-
-{ #category : #accessing }
-SpDemoFormPresenter >> modelChanged [
-	table items: self model elements
 ]
 
 { #category : #'option list presenter' }

--- a/src/Spec2-Examples/SpDemoImagePage.class.st
+++ b/src/Spec2-Examples/SpDemoImagePage.class.st
@@ -19,7 +19,7 @@ SpDemoImagePage class >> pageName [
 { #category : #initialization }
 SpDemoImagePage class >> priority [
 
-	^ 16
+	^ 1600
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoImagePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoImagePresenter.class.st
@@ -40,23 +40,14 @@ SpDemoImagePresenter >> defaultLayout [
 		yourself
 ]
 
-{ #category : #accessing }
-SpDemoImagePresenter >> image1 [
-	^ image1
-]
-
-{ #category : #accessing }
-SpDemoImagePresenter >> image2 [
-	^ image2
-]
-
 { #category : #initialization }
 SpDemoImagePresenter >> initializePresenters [
+
 	image1 := self newImage.
 	image2 := self newImage.
 
 	image1 image: (self iconNamed: #pharo).
-	image2 image: self currentWorld submorphs last form.
+	image2 image: self currentWorld submorphs last form
 ]
 
 { #category : #'option list presenter' }

--- a/src/Spec2-Examples/SpDemoImagePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoImagePresenter.class.st
@@ -14,29 +14,30 @@ Class {
 	#category : #'Spec2-Examples-Demo-Other'
 }
 
+{ #category : #'instance creation' }
+SpDemoImagePresenter class >> open [
+	<script>
+	self new open
+]
+
 { #category : #layout }
-SpDemoImagePresenter class >> defaultLayout [
+SpDemoImagePresenter >> defaultLayout [
+
 	^ SpBoxLayout newTopToBottom
 		add: (SpBoxLayout newLeftToRight
 			add: 'Image added through an ImagePresenter:';
-			add: #image1;
+			add: image1;
 			yourself)
 		height: 50;
 		add: (SpBoxLayout newLeftToRight
 			add: 'Image added through an ImagePresenter:';
-			add: #image2;
+			add: image2;
 			yourself);
 		add: (SpBoxLayout newLeftToRight
 			add: 'Image added directly from the layout definition:';
 			add: (self iconNamed: #pharoBig);
 			yourself);
 		yourself
-]
-
-{ #category : #'instance creation' }
-SpDemoImagePresenter class >> open [
-	<script>
-	self new open
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpDemoLabeledPage.class.st
+++ b/src/Spec2-Examples/SpDemoLabeledPage.class.st
@@ -7,13 +7,19 @@ I am a page for a labelled presenter demo
 Class {
 	#name : #SpDemoLabeledPage,
 	#superclass : #SpDemoPage,
-	#category : #'Spec2-Examples-Demo-Forms'
+	#category : #'Spec2-Examples-Demo-Labeled'
 }
 
 { #category : #initialization }
 SpDemoLabeledPage class >> pageName [
 
 	^ 'Labeled presenter'
+]
+
+{ #category : #initialization }
+SpDemoLabeledPage class >> priority [
+
+	^ 1300
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoLabeledPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoLabeledPresenter.class.st
@@ -23,11 +23,6 @@ SpDemoLabeledPresenter >> defaultLayout [
 		yourself
 ]
 
-{ #category : #accessing }
-SpDemoLabeledPresenter >> email [
-	^ email
-]
-
 { #category : #initialization }
 SpDemoLabeledPresenter >> initializePresenters [
 	| passwordInput |
@@ -44,9 +39,4 @@ SpDemoLabeledPresenter >> initializePresenters [
 		label: 'Password' 
 		input: passwordInput 
 		description: 'Password of the email account used.')
-]
-
-{ #category : #accessing }
-SpDemoLabeledPresenter >> password [
-	^ password
 ]

--- a/src/Spec2-Examples/SpDemoLabeledPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoLabeledPresenter.class.st
@@ -11,15 +11,15 @@ Class {
 		'email',
 		'password'
 	],
-	#category : #'Spec2-Examples-Demo-Forms'
+	#category : #'Spec2-Examples-Demo-Labeled'
 }
 
 { #category : #layout }
-SpDemoLabeledPresenter class >> defaultLayout [
+SpDemoLabeledPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: #email expand: false;
-		add: #password expand: false;
+		add: email expand: false;
+		add: password expand: false;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoLinksPage.class.st
+++ b/src/Spec2-Examples/SpDemoLinksPage.class.st
@@ -16,10 +16,10 @@ SpDemoLinksPage class >> pageName [
 	^ 'Links'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoLinksPage class >> priority [
 
-	^ 15
+	^ 1500
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoLinksPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoLinksPresenter.class.st
@@ -16,20 +16,21 @@ Class {
 	#category : #'Spec2-Examples-Demo-Other'
 }
 
-{ #category : #layout }
-SpDemoLinksPresenter class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #link1;
-		add: #link2;
-		add: #link3;
-		add: #link4;
-		yourself
-]
-
 { #category : #'instance creation' }
 SpDemoLinksPresenter class >> open [
 	<script>
 	self new open
+]
+
+{ #category : #layout }
+SpDemoLinksPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: link1;
+		  add: link2;
+		  add: link3;
+		  add: link4;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoListsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoListsPresenter.class.st
@@ -47,21 +47,15 @@ SpDemoListsPresenter >> defaultLayout [
 	^ SpBoxLayout newTopToBottom
 		  add: (SpBoxLayout newLeftToRight
 				   add: (SpBoxLayout newTopToBottom
-						    add: 'Menu'
-						    withConstraints: [ :constraints | 
-							    constraints height: self class labelHeight ];
+						    add: 'Menu' expand: false;
 						    add: list1;
 						    yourself);
 				   add: (SpBoxLayout newTopToBottom
-						    add: 'Multi selection/Sorting'
-						    withConstraints: [ :constraints | 
-							    constraints height: self class labelHeight ];
+						    add: 'Multi selection/Sorting' expand: false;
 						    add: list2;
 						    yourself);
 				   add: (SpBoxLayout newTopToBottom
-						    add: 'Icons/Filter'
-						    withConstraints: [ :constraints | 
-							    constraints height: self class labelHeight ];
+						    add: 'Icons/Filter' expand: false;
 						    add: list3;
 						    yourself);
 				   yourself);
@@ -69,8 +63,7 @@ SpDemoListsPresenter >> defaultLayout [
 				   add: multiLabel;
 				   add: label;
 				   yourself)
-		  withConstraints: [ :constraints | 
-		  constraints height: self class labelHeight ];
+		  expand: false;
 		  yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoListsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoListsPresenter.class.st
@@ -17,66 +17,61 @@ Class {
 	#category : #'Spec2-Examples-Demo-Lists'
 }
 
-{ #category : #layout }
-SpDemoListsPresenter class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add:
-			(SpBoxLayout newLeftToRight
-				add:
-					(SpBoxLayout newTopToBottom
-						add: 'Menu' withConstraints: [ :constraints | constraints height: self labelHeight ];
-						add: #list1;
-						yourself);
-				add:
-					(SpBoxLayout newTopToBottom
-						add: 'Multi selection/Sorting' withConstraints: [ :constraints | constraints height: self labelHeight ];
-						add: #list2;
-						yourself);
-				add:
-					(SpBoxLayout newTopToBottom
-						add: 'Icons/Filter' withConstraints: [ :constraints | constraints height: self labelHeight ];
-						add: #list3;
-						yourself);
-				yourself);
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #multiLabel;
-				add: #label;
-				yourself)
-			withConstraints: [ :constraints | constraints height: self labelHeight ];
-		yourself
-]
-
 { #category : #initialization }
 SpDemoListsPresenter >> connectPresenters [
-	list1
-		whenSelectionChangedDo: [ :selection | 
-			[ :elem | 
-			label
-				label:
-					(elem
-						ifNil: [ 'Deselection from list 1' ]
-						ifNotNil: [ 'Selection from list 1: ' , elem asString ]) ]
-				cull: selection selectedItem ].
 
-	list2
-		whenSelectionChangedDo: [ :selection | 
-			[ :elems | 
-			multiLabel
-				label:
-					(elems
-						ifEmpty: [ 'Not multi selection (from list 2 only)' ]
-						ifNotEmpty: [ 'Multi-selection from list 2: ' , elems asString ]) ]
-				cull: selection selectedItems ].
-	list3
-		whenSelectionChangedDo: [ :selection | 
-			[ :elem | 
-			label
-				label:
-					(elem
-						ifNil: [ 'Deselection from list 3' ]
-						ifNotNil: [ 'Selection from list 3: ' , elem asString ]) ]
-				cull: selection selectedItem ]
+	list1 whenSelectionChangedDo: [ :selection | 
+		[ :elem | 
+		label label: (elem
+				 ifNil: [ 'Deselection from list 1' ]
+				 ifNotNil: [ 'Selection from list 1: ' , elem asString ]) ] cull:
+			selection selectedItem ].
+
+	list2 whenSelectionChangedDo: [ :selection | 
+		[ :elems | 
+		multiLabel label: (elems
+				 ifEmpty: [ 'Not multi selection (from list 2 only)' ]
+				 ifNotEmpty: [ 'Multi-selection from list 2: ' , elems asString ]) ] 
+			cull: selection selectedItems ].
+	list3 whenSelectionChangedDo: [ :selection | 
+		[ :elem | 
+		label label: (elem
+				 ifNil: [ 'Deselection from list 3' ]
+				 ifNotNil: [ 'Selection from list 3: ' , elem asString ]) ] cull:
+			selection selectedItem ]
+]
+
+{ #category : #layout }
+SpDemoListsPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: (SpBoxLayout newLeftToRight
+				   add: (SpBoxLayout newTopToBottom
+						    add: 'Menu'
+						    withConstraints: [ :constraints | 
+							    constraints height: self class labelHeight ];
+						    add: list1;
+						    yourself);
+				   add: (SpBoxLayout newTopToBottom
+						    add: 'Multi selection/Sorting'
+						    withConstraints: [ :constraints | 
+							    constraints height: self class labelHeight ];
+						    add: list2;
+						    yourself);
+				   add: (SpBoxLayout newTopToBottom
+						    add: 'Icons/Filter'
+						    withConstraints: [ :constraints | 
+							    constraints height: self class labelHeight ];
+						    add: list3;
+						    yourself);
+				   yourself);
+		  add: (SpBoxLayout newLeftToRight
+				   add: multiLabel;
+				   add: label;
+				   yourself)
+		  withConstraints: [ :constraints | 
+		  constraints height: self class labelHeight ];
+		  yourself
 ]
 
 { #category : #defaults }

--- a/src/Spec2-Examples/SpDemoMenuButtonPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoMenuButtonPresenter.class.st
@@ -9,24 +9,24 @@ Class {
 	#category : #'Spec2-Examples-Demo-Buttons'
 }
 
-{ #category : #specs }
-SpDemoMenuButtonPresenter class >> defaultLayout [
+{ #category : #layout }
+SpDemoMenuButtonPresenter >> defaultLayout [
 
-	^ SpBoxLayout newTopToBottom 
+	^ SpBoxLayout newTopToBottom
 		add: (SpBoxLayout newLeftToRight
-			add: #button;
-			add: #menu expand: false fill: false padding: 0;
-			yourself) 
-			expand: false 
-			fill: false 
-			padding: 0;
-		add: #text;
-		yourself
+			add: button;
+			add: menu expand: false fill: false padding: 0;
+			yourself)
+		 expand: false
+		 fill: false
+		 padding: 0;
+		 add: text;
+		 yourself
 ]
 
 { #category : #initialization }
 SpDemoMenuButtonPresenter >> initializePresenters [
-	<script: 'self new openWithSpec'>
+	<script: 'self new open'>
 
 	(button := self newButton)
 		label: 'Choice';

--- a/src/Spec2-Examples/SpDemoMenuButtonPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoMenuButtonPresenter.class.st
@@ -13,15 +13,13 @@ Class {
 SpDemoMenuButtonPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: (SpBoxLayout newLeftToRight
-			add: button;
-			add: menu expand: false fill: false padding: 0;
-			yourself)
-		 expand: false
-		 fill: false
-		 padding: 0;
-		 add: text;
-		 yourself
+		  add: (SpBoxLayout newLeftToRight
+				   add: button;
+				   add: menu expand: false;
+				   yourself)
+		  expand: false;
+		  add: text;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoModalPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoModalPresenter.class.st
@@ -14,18 +14,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Modals'
 }
 
-{ #category : #layout }
-SpDemoModalPresenter class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #button1;
-				add: #button2;
-				yourself)
-			withConstraints: [ :constraints | constraints height: self buttonHeight ];
-		yourself
-]
-
 { #category : #'instance creation' }
 SpDemoModalPresenter class >> open [
 	<script>
@@ -45,6 +33,18 @@ SpDemoModalPresenter >> button1 [
 { #category : #accessing }
 SpDemoModalPresenter >> button2 [
 	^ button2
+]
+
+{ #category : #layout }
+SpDemoModalPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: (SpBoxLayout newLeftToRight
+			add: button1;
+			add: button2;
+			yourself)
+		withConstraints: [ :constraints | constraints height: self class buttonHeight ];
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoModalPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoModalPresenter.class.st
@@ -43,7 +43,7 @@ SpDemoModalPresenter >> defaultLayout [
 			add: button1;
 			add: button2;
 			yourself)
-		withConstraints: [ :constraints | constraints height: self class buttonHeight ];
+		expand: false;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoModalsPage.class.st
+++ b/src/Spec2-Examples/SpDemoModalsPage.class.st
@@ -16,10 +16,10 @@ SpDemoModalsPage class >> pageName [
 	^ 'Modals'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoModalsPage class >> priority [
 
-	^ 30
+	^ 1700
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoNotebookPage.class.st
+++ b/src/Spec2-Examples/SpDemoNotebookPage.class.st
@@ -15,9 +15,10 @@ SpDemoNotebookPage class >> pageName [
 	^ 'Notebook'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoNotebookPage class >> priority [
-	^ 13
+
+	^ 1100
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoNotebookPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoNotebookPresenter.class.st
@@ -15,15 +15,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Notebook'
 }
 
-{ #category : #layout }
-SpDemoNotebookPresenter class >> defaultLayout [
-
-	^ SpBoxLayout newTopToBottom
-		add: #notebook;
-		add: #checkbox expand: false;
-		yourself
-]
-
 { #category : #examples }
 SpDemoNotebookPresenter class >> example [
 	^ self new open
@@ -52,6 +43,15 @@ SpDemoNotebookPresenter >> connectPresenters [
 				ifNotNil: [ :page | 
 					notebook removePage: page.
 					dynamicPage := nil ] ]
+]
+
+{ #category : #layout }
+SpDemoNotebookPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: notebook;
+		  add: checkbox expand: false;
+		  yourself
 ]
 
 { #category : #pages }

--- a/src/Spec2-Examples/SpDemoPage.class.st
+++ b/src/Spec2-Examples/SpDemoPage.class.st
@@ -15,13 +15,6 @@ SpDemoPage class >> availablePages [
 	^ self allSubclasses sort: #priority ascending
 ]
 
-{ #category : #layout }
-SpDemoPage class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #tabManager;
-		yourself
-]
-
 { #category : #initialization }
 SpDemoPage class >> pageName [
 
@@ -48,6 +41,14 @@ SpDemoPage >> codeTab [
 		provider: [ self newText
 				text: (self codeFor: self pageClass);
 				yourself ]
+]
+
+{ #category : #layout }
+SpDemoPage >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: tabManager;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoRadioButtonsPage.class.st
+++ b/src/Spec2-Examples/SpDemoRadioButtonsPage.class.st
@@ -4,7 +4,7 @@ Demo page for SpecDemoRadioButtonsPresenter.
 Class {
 	#name : #SpDemoRadioButtonsPage,
 	#superclass : #SpDemoPage,
-	#category : #'Spec2-Examples-Demo-Checkboxes'
+	#category : #'Spec2-Examples-Demo-Buttons'
 }
 
 { #category : #initialization }
@@ -14,7 +14,8 @@ SpDemoRadioButtonsPage class >> pageName [
 
 { #category : #initialization }
 SpDemoRadioButtonsPage class >> priority [
-	^ 32
+
+	^ 900
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoRadioButtonsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoRadioButtonsPresenter.class.st
@@ -7,14 +7,15 @@ Class {
 	#instVars : [
 		'radioButtonExample'
 	],
-	#category : #'Spec2-Examples-Demo-Checkboxes'
+	#category : #'Spec2-Examples-Demo-Buttons'
 }
 
 { #category : #layout }
-SpDemoRadioButtonsPresenter class >> defaultLayout [
+SpDemoRadioButtonsPresenter >> defaultLayout [
+
 	^ SpBoxLayout newLeftToRight
-		add: #radioButtonExample;
-		yourself
+		  add: radioButtonExample;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
@@ -34,52 +34,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Forms'
 }
 
-{ #category : #layout }
-SpDemoStandaloneFormPresenter class >> defaultLayout [
-	
-	^ SpBoxLayout newTopToBottom
-		add:
-			(SpGridLayout build: [ :builder |
-				builder
-					add: 'Name:';
-					add: #nameTextInput;
-					nextRow;
-					add: 'Surname:';
-					add: #surnameTextInput;
-					nextRow;
-					add: 'Number 1:';
-					add: #number1Input;
-					nextRow;
-					add: 'Number 2:';
-					add: #number2Input;
-					nextRow;
-					add: 'Scale:';
-					add: #scaleInput;
-					nextRow;
-					add: 'Password:';
-					add: #passwordInput;
-					nextRow;
-					add: 'Remember me:';
-					add: #checkboxInput;
-					nextRow;
-					"SpDatePresenter is exclusive from Morphic backend for the moment"
-					"add: 'Date:';
-					add: #dateInput;
-					nextRow;"
-					add: 'Gender:';
-					add:
-						(SpBoxLayout newLeftToRight
-							add: #maleButton;
-							add: #femaleButton;
-							yourself) ]);
-		add: (SpBoxLayout newLeftToRight
-				add: #submitButton;
-				add: #restoreButton;
-				yourself)
-			expand: false;
-		yourself
-]
-
 { #category : #'instance creation' }
 SpDemoStandaloneFormPresenter class >> open [
 	<example>
@@ -130,6 +84,50 @@ SpDemoStandaloneFormPresenter >> dateLabel [
 { #category : #accessing }
 SpDemoStandaloneFormPresenter >> dateLabel: anObject [
 	dateLabel := anObject
+]
+
+{ #category : #layout }
+SpDemoStandaloneFormPresenter >> defaultLayout [
+	
+	^ SpBoxLayout newTopToBottom
+		add: (SpGridLayout build: [ :builder |
+			builder
+				add: 'Name:';
+				add: nameTextInput;
+				nextRow;
+				add: 'Surname:';
+				add: surnameTextInput;
+				nextRow;
+				add: 'Number 1:';
+				add: number1Input;
+				nextRow;
+				add: 'Number 2:';
+				add: number2Input;
+				nextRow;
+				add: 'Scale:';
+				add: scaleInput;
+				nextRow;
+				add: 'Password:';
+				add: passwordInput;
+				nextRow;
+				add: 'Remember me:';
+				add: checkboxInput;
+				nextRow;
+				"SpDatePresenter is exclusive from Morphic backend for the moment"
+				"add: 'Date:';
+				add: #dateInput;
+				nextRow;"
+				add: 'Gender:';
+				add: (SpBoxLayout newLeftToRight
+					add: maleButton;
+					add: femaleButton;
+					yourself) ]);
+		add: (SpBoxLayout newLeftToRight
+			add: submitButton;
+			add: restoreButton;
+			yourself)
+		expand: false;
+		yourself
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpDemoTablePage.class.st
+++ b/src/Spec2-Examples/SpDemoTablePage.class.st
@@ -16,6 +16,12 @@ SpDemoTablePage class >> pageName [
 ]
 
 { #category : #initialization }
+SpDemoTablePage class >> priority [
+
+	^ 200
+]
+
+{ #category : #initialization }
 SpDemoTablePage >> pageClass [
 	^ SpDemoTablePresenter
 ]

--- a/src/Spec2-Examples/SpDemoTablePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoTablePresenter.class.st
@@ -16,10 +16,11 @@ Class {
 }
 
 { #category : #layout }
-SpDemoTablePresenter class >> defaultLayout [
+SpDemoTablePresenter >> defaultLayout [
+
 	^ SpBoxLayout newTopToBottom
-		add: #table1;
-		add: #label withConstraints: [ :c | c height: self labelHeight ];
+		add: table1;
+		add: label withConstraints: [ :c | c height: self class labelHeight ];
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoTablePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoTablePresenter.class.st
@@ -20,7 +20,7 @@ SpDemoTablePresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
 		add: table1;
-		add: label withConstraints: [ :c | c height: self class labelHeight ];
+		add: label expand: false;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoTextInputPage.class.st
+++ b/src/Spec2-Examples/SpDemoTextInputPage.class.st
@@ -13,10 +13,10 @@ SpDemoTextInputPage class >> pageName [
 	^ 'Text input'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoTextInputPage class >> priority [
 
-	^ 20
+	^ 1200
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoTextInputPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoTextInputPresenter.class.st
@@ -20,21 +20,18 @@ SpDemoTextInputPresenter class >> example [
 
 { #category : #layout }
 SpDemoTextInputPresenter >> defaultLayout [
-	^ (SpGridLayout build: [ :builder |
-		builder 
-			add: 'Normal:';
-			add: fieldNormal;
-			nextRow;
-			add: 'Disabled:';
-			add: fieldDisabled;
-			nextRow;
-			add: 'Placeholder:';
-			add: fieldPlaceholderText;
-			nextRow;
-			add: 'Password:';
-			add: fieldEncrypted ])
-		beColumnNotHomogeneous;
-		yourself
+
+	^ SpGridLayout new
+		  add: 'Normal:' at: 1 @ 1;
+		  add: fieldNormal at: 2 @ 1 span: 2 @ 1;
+		  add: 'Disabled:' at: 1 @ 2;
+		  add: fieldDisabled at: 2 @ 2 span: 2 @ 1;
+		  add: 'Placeholder:' at: 1 @ 3;
+		  add: fieldPlaceholderText at: 2 @ 3 span: 2 @ 1;
+		  add: 'Password:' at: 1 @ 4;
+		  add: fieldEncrypted at: 2 @ 4 span: 2 @ 1;
+		  beColumnNotHomogeneous;
+		  yourself
 ]
 
 { #category : #accessing }
@@ -79,13 +76,19 @@ SpDemoTextInputPresenter >> fieldPlaceholderText: anObject [
 
 { #category : #initialization }
 SpDemoTextInputPresenter >> initializePresenters [
+
 	fieldNormal := self newTextInput.
-	
-	fieldDisabled := self newTextInput enabled: false.
-	
-	fieldPlaceholderText := self newTextInput placeholder: 'Placeholder text'.
-	
+
+	fieldDisabled := self newTextInput
+		editable: false;
+		yourself.
+
+	fieldPlaceholderText := self newTextInput
+		placeholder: 'Placeholder text';
+		yourself.
+
 	fieldEncrypted := self newTextInput
 		text: 'Password';
-		bePassword
+		bePassword;
+		yourself
 ]

--- a/src/Spec2-Examples/SpDemoToolbarPage.class.st
+++ b/src/Spec2-Examples/SpDemoToolbarPage.class.st
@@ -13,9 +13,10 @@ SpDemoToolbarPage class >> pageName [
 	^ 'Toolbar'
 ]
 
-{ #category : #specs }
+{ #category : #initialization }
 SpDemoToolbarPage class >> priority [
-	^ 12
+
+	^ 700
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDemoToolbarPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoToolbarPresenter.class.st
@@ -12,11 +12,11 @@ Class {
 }
 
 { #category : #layout }
-SpDemoToolbarPresenter class >> defaultLayout [
+SpDemoToolbarPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom 
-		add: #toolBar expand: false;
-		add: #text;
+		add: toolBar expand: false;
+		add: text;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoTransmissionPage.class.st
+++ b/src/Spec2-Examples/SpDemoTransmissionPage.class.st
@@ -1,0 +1,26 @@
+"
+I am a page for displaying the transmission example in the Spec demo presenter
+"
+Class {
+	#name : #SpDemoTransmissionPage,
+	#superclass : #SpDemoPage,
+	#category : #'Spec2-Examples-Demo-Transmission'
+}
+
+{ #category : #initialization }
+SpDemoTransmissionPage class >> pageName [
+
+	^ 'Transmissions'
+]
+
+{ #category : #initialization }
+SpDemoTransmissionPage class >> priority [
+
+	^ 1110
+]
+
+{ #category : #initialization }
+SpDemoTransmissionPage >> pageClass [
+
+	^ SpTransmissionExample
+]

--- a/src/Spec2-Examples/SpDemoTreeTablePage.class.st
+++ b/src/Spec2-Examples/SpDemoTreeTablePage.class.st
@@ -16,6 +16,12 @@ SpDemoTreeTablePage class >> pageName [
 ]
 
 { #category : #initialization }
+SpDemoTreeTablePage class >> priority [
+
+	^ 300
+]
+
+{ #category : #initialization }
 SpDemoTreeTablePage >> pageClass [
 	^ SpDemoTreeTablePresenter
 ]

--- a/src/Spec2-Examples/SpDemoTreeTablePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoTreeTablePresenter.class.st
@@ -14,13 +14,11 @@ Class {
 }
 
 { #category : #layout }
-SpDemoTreeTablePresenter class >> defaultLayout [
+SpDemoTreeTablePresenter >> defaultLayout [
+
 	^ SpBoxLayout newTopToBottom
-		add: #table1;
-		add: 'Double click to browse.'
-			expand: false
-			fill: false
-			padding: 0;
+		add: table1;
+		add: 'Double click to browse.' expand: false fill: false padding: 0;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDemoTreeTablePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoTreeTablePresenter.class.st
@@ -18,7 +18,7 @@ SpDemoTreeTablePresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
 		add: table1;
-		add: 'Double click to browse.' expand: false fill: false padding: 0;
+		add: 'Double click to browse.' expand: false;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpDynamicLayoutExamplePage.class.st
+++ b/src/Spec2-Examples/SpDynamicLayoutExamplePage.class.st
@@ -1,0 +1,26 @@
+"
+I am an example page for the dynamic layouts
+"
+Class {
+	#name : #SpDynamicLayoutExamplePage,
+	#superclass : #SpDemoPage,
+	#category : #'Spec2-Examples-Demo-Layouts'
+}
+
+{ #category : #initialization }
+SpDynamicLayoutExamplePage class >> pageName [
+
+	^ 'Dynamic Layouts'
+]
+
+{ #category : #initialization }
+SpDynamicLayoutExamplePage class >> priority [
+
+	^ 2200
+]
+
+{ #category : #initialization }
+SpDynamicLayoutExamplePage >> pageClass [
+
+	^ SpDynamicLayoutExamplePresenter
+]

--- a/src/Spec2-Examples/SpDynamicLayoutExamplePresenter.class.st
+++ b/src/Spec2-Examples/SpDynamicLayoutExamplePresenter.class.st
@@ -1,0 +1,86 @@
+"
+I am a dynamic layout example
+"
+Class {
+	#name : #SpDynamicLayoutExamplePresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'addPresenterButton',
+		'removePreseterButton',
+		'textPresenter',
+		'canRemovePresenter'
+	],
+	#category : #'Spec2-Examples-Demo-Layouts'
+}
+
+{ #category : #actions }
+SpDynamicLayoutExamplePresenter >> addToLayout [
+
+	canRemovePresenter := true.
+	removePreseterButton enable.
+	
+	self layout add: self createButton expand: false
+]
+
+{ #category : #actions }
+SpDynamicLayoutExamplePresenter >> createButton [
+
+	| randomButtonName newButton |
+	randomButtonName := 'Random number: ', (Random new nextBetween: 100 and: 1000) asInteger asString.
+
+	newButton := self newButton.
+	newButton
+		label: randomButtonName;
+		icon: (self iconNamed: #smallObjects).
+	^ newButton
+]
+
+{ #category : #layout }
+SpDynamicLayoutExamplePresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: addPresenterButton expand: false;
+		add: removePreseterButton expand: false;
+		add: textPresenter;
+		yourself 
+		
+]
+
+{ #category : #initialization }
+SpDynamicLayoutExamplePresenter >> initialize [
+
+	super initialize.
+	canRemovePresenter := false
+]
+
+{ #category : #initialization }
+SpDynamicLayoutExamplePresenter >> initializePresenters [
+
+	addPresenterButton := self newButton.
+	addPresenterButton
+		action: [ self addToLayout ];
+		label: 'Add a presenter to the layout';
+		icon: (self iconNamed: #smallAdd).
+		
+	removePreseterButton := self newButton.
+	removePreseterButton
+		action: [ self removeFromLayout ];
+		label: 'Remove a presenter from the layout';
+		icon: (self iconNamed: #smallDelete);
+		disable.
+		
+	textPresenter := self newText.
+	textPresenter
+		text: 'I am a text presenter.
+		I will not be removed';
+		beNotEditable
+]
+
+{ #category : #actions }
+SpDynamicLayoutExamplePresenter >> removeFromLayout [
+
+	self layout remove: self layout presenters last.
+
+	self layout presenters last = textPresenter
+		ifTrue: [ removePreseterButton disable ]
+]

--- a/src/Spec2-Examples/SpDynamicLayoutExamplePresenter.class.st
+++ b/src/Spec2-Examples/SpDynamicLayoutExamplePresenter.class.st
@@ -42,8 +42,7 @@ SpDynamicLayoutExamplePresenter >> defaultLayout [
 		add: addPresenterButton expand: false;
 		add: removePreseterButton expand: false;
 		add: textPresenter;
-		yourself 
-		
+		yourself		
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpDynamicWidgetChange.class.st
+++ b/src/Spec2-Examples/SpDynamicWidgetChange.class.st
@@ -71,7 +71,7 @@ SpDynamicWidgetChange >> changeToList [
 SpDynamicWidgetChange >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: button withConstraints: [ :constraints | constraints height: 25 ];
+		add: button expand: false;
 		add: bottom;
 		yourself
 ]

--- a/src/Spec2-Examples/SpDynamicWidgetChange.class.st
+++ b/src/Spec2-Examples/SpDynamicWidgetChange.class.st
@@ -14,14 +14,6 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpDynamicWidgetChange class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #button withConstraints: [ :constraints | constraints height: 25 ];
-		add: #bottom;
-		yourself
-]
-
 { #category : #examples }
 SpDynamicWidgetChange class >> example [
 
@@ -73,6 +65,15 @@ SpDynamicWidgetChange >> changeToList [
 	button font: (LogicalFont familyName: 'Source Sans Pro' pointSize: 10).
 		
 	bottom items: (1 to: 100) asOrderedCollection.
+]
+
+{ #category : #layout }
+SpDynamicWidgetChange >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: button withConstraints: [ :constraints | constraints height: 25 ];
+		add: bottom;
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpFilteringListsDemoPage.class.st
+++ b/src/Spec2-Examples/SpFilteringListsDemoPage.class.st
@@ -1,0 +1,27 @@
+"
+I am a demo page to show how to use spec filtering lists.
+"
+Class {
+	#name : #SpFilteringListsDemoPage,
+	#superclass : #SpDemoPage,
+	#category : #'Spec2-Examples-Demo-Lists'
+}
+
+{ #category : #initialization }
+SpFilteringListsDemoPage class >> pageName [
+
+	^ 'Filtering Lists'
+
+]
+
+{ #category : #initialization }
+SpFilteringListsDemoPage class >> priority [
+
+	^ 500
+]
+
+{ #category : #initialization }
+SpFilteringListsDemoPage >> pageClass [
+
+	^ SpDemoFilteringListsPresenter
+]

--- a/src/Spec2-Examples/SpInitializeWindowExample.class.st
+++ b/src/Spec2-Examples/SpInitializeWindowExample.class.st
@@ -18,13 +18,6 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpInitializeWindowExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #text;
-		yourself
-]
-
 { #category : #showing }
 SpInitializeWindowExample class >> show [
 	<script>
@@ -85,6 +78,14 @@ SpInitializeWindowExample >> buildToolbar [
 		addItem: self buildPopMessageToolBarItem;
 		addItem: self buildPopMessageToolBarItem position: SpToolbarItemPosition right;
 		yourself
+]
+
+{ #category : #layout }
+SpInitializeWindowExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: text;
+		  yourself
 ]
 
 { #category : #api }

--- a/src/Spec2-Examples/SpListSelectionPresenter.class.st
+++ b/src/Spec2-Examples/SpListSelectionPresenter.class.st
@@ -15,18 +15,6 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpListSelectionPresenter class >> defaultLayout [
-	^ SpPanedLayout newTopToBottom
-		add: #listModel;
-		add:
-			(SpPanedLayout newLeftToRight
-				add: #textModel1;
-				add: #textModel2;
-				yourself);
-		yourself
-]
-
 { #category : #examples }
 SpListSelectionPresenter class >> example [
 
@@ -37,6 +25,18 @@ SpListSelectionPresenter class >> example [
 { #category : #initialization }
 SpListSelectionPresenter >> connectPresenters [
 	listModel whenSelectionChangedDo: [ self updateText ]
+]
+
+{ #category : #layout }
+SpListSelectionPresenter >> defaultLayout [
+
+	^ SpPanedLayout newTopToBottom
+		  add: listModel;
+		  add: (SpPanedLayout newLeftToRight
+				   add: textModel1;
+				   add: textModel2;
+				   yourself);
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpListsDemoPage.class.st
+++ b/src/Spec2-Examples/SpListsDemoPage.class.st
@@ -16,6 +16,12 @@ SpListsDemoPage class >> pageName [
 ]
 
 { #category : #initialization }
+SpListsDemoPage class >> priority [
+
+	^ 400
+]
+
+{ #category : #initialization }
 SpListsDemoPage >> pageClass [
 	^ SpDemoListsPresenter
 ]

--- a/src/Spec2-Examples/SpOpenOnIntExample.class.st
+++ b/src/Spec2-Examples/SpOpenOnIntExample.class.st
@@ -14,19 +14,6 @@ Class {
 	#category : #'Spec2-Examples-Wrapper'
 }
 
-{ #category : #layout }
-SpOpenOnIntExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #text withConstraints: [ :constraints | constraints height: 25 ];
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #minus;
-				add: #plus;
-				yourself)
-			withConstraints: [ :constraints | constraints height: 25 ];
-		yourself
-]
-
 { #category : #examples }
 SpOpenOnIntExample class >> example [
 
@@ -52,6 +39,19 @@ SpOpenOnIntExample >> connectPresenters [
 		action: [ | currentValue |
 			currentValue := text label asInteger.
 			text label: (currentValue + 1) asString ]
+]
+
+{ #category : #layout }
+SpOpenOnIntExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: text withConstraints: [ :constraints | constraints height: 25 ];
+		add: (SpBoxLayout newLeftToRight
+			add: minus;
+			add: plus;
+			yourself)
+		withConstraints: [ :constraints | constraints height: 25 ];
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpOpenOnIntExample.class.st
+++ b/src/Spec2-Examples/SpOpenOnIntExample.class.st
@@ -45,12 +45,12 @@ SpOpenOnIntExample >> connectPresenters [
 SpOpenOnIntExample >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		add: text withConstraints: [ :constraints | constraints height: 25 ];
+		add: text expand: false;
 		add: (SpBoxLayout newLeftToRight
 			add: minus;
 			add: plus;
 			yourself)
-		withConstraints: [ :constraints | constraints height: 25 ];
+		expand: false;
 		yourself
 ]
 

--- a/src/Spec2-Examples/SpOpenOnNilExample.class.st
+++ b/src/Spec2-Examples/SpOpenOnNilExample.class.st
@@ -14,13 +14,6 @@ Class {
 	#category : #'Spec2-Examples-Wrapper'
 }
 
-{ #category : #layout }
-SpOpenOnNilExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #text withConstraints: [ :constraints | constraints height: 25 ];
-		yourself
-]
-
 { #category : #examples }
 SpOpenOnNilExample class >> example [
 
@@ -28,6 +21,14 @@ SpOpenOnNilExample class >> example [
 	^ self new
 		  extent: 200 @ 100;
 		  open;
+		  yourself
+]
+
+{ #category : #layout }
+SpOpenOnNilExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: text withConstraints: [ :constraints | constraints height: 25 ];
 		  yourself
 ]
 

--- a/src/Spec2-Examples/SpOpenOnNilExample.class.st
+++ b/src/Spec2-Examples/SpOpenOnNilExample.class.st
@@ -28,7 +28,7 @@ SpOpenOnNilExample class >> example [
 SpOpenOnNilExample >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		  add: text withConstraints: [ :constraints | constraints height: 25 ];
+		  add: text expand: false;
 		  yourself
 ]
 

--- a/src/Spec2-Examples/SpOpenOnStringExample.class.st
+++ b/src/Spec2-Examples/SpOpenOnStringExample.class.st
@@ -18,25 +18,6 @@ Class {
 	#category : #'Spec2-Examples-Wrapper'
 }
 
-{ #category : #specs }
-SpOpenOnStringExample class >> bottomLayout [
-
-	^ SpBoxLayout newTopToBottom
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #input;
-				add: #button;
-				yourself)
-			withConstraints: [ :constraints | constraints height: 25 ];
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #label;
-				add: #check withConstraints: [ :constraints | constraints width: 100 ];
-				yourself)
-			withConstraints: [ :constraints | constraints height: 25 ];
-		yourself
-]
-
 { #category : #examples }
 SpOpenOnStringExample class >> example [
 

--- a/src/Spec2-Examples/SpOpenOnStringExample.class.st
+++ b/src/Spec2-Examples/SpOpenOnStringExample.class.st
@@ -37,24 +37,6 @@ SpOpenOnStringExample class >> bottomLayout [
 		yourself
 ]
 
-{ #category : #layout }
-SpOpenOnStringExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #label;
-				add: #check withConstraints: [ :constraints | constraints width: 100 ];
-				yourself)
-			withConstraints: [ :constraints | constraints height: 25 ];
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #input;
-				add: #button;
-				yourself)
-			withConstraints: [ :constraints | constraints height: 25 ];
-		yourself
-]
-
 { #category : #examples }
 SpOpenOnStringExample class >> example [
 
@@ -89,6 +71,23 @@ SpOpenOnStringExample >> connectPresenters [
 			self buildWithSpecLayout: self class defaultLayout ];
 		whenDeactivatedDo: [ self needRebuild: false.
 			self buildWithSpecLayout: self class bottomLayout ]
+]
+
+{ #category : #layout }
+SpOpenOnStringExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: (SpBoxLayout newLeftToRight
+			add: label;
+			add: check withConstraints: [ :constraints | constraints width: 100 ];
+			yourself)
+		withConstraints: [ :constraints | constraints height: 25 ];
+		add: (SpBoxLayout newLeftToRight
+			add: input;
+			add: button;
+			yourself)
+		withConstraints: [ :constraints | constraints height: 25 ];
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpOptionPresenterExample.class.st
+++ b/src/Spec2-Examples/SpOptionPresenterExample.class.st
@@ -16,11 +16,12 @@ SpOptionPresenterExample class >> open [
 	self new open.
 ]
 
-{ #category : #initialization }
-SpOptionPresenterExample >> defaultLayout [ 
-	^ SpBoxLayout newTopToBottom 
-		add: radioPresenter;
-		yourself.
+{ #category : #layout }
+SpOptionPresenterExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: radioPresenter;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpPopoverExample.class.st
+++ b/src/Spec2-Examples/SpPopoverExample.class.st
@@ -19,24 +19,24 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpPopoverExample class >> defaultLayout [
-
-	^ SpBoxLayout newLeftToRight
-		hAlignCenter;
-		vAlignCenter; 
-		add: #top expand: false;
-		add: #left  expand: false;
-		add: #bottom expand: false;
-		add: #right expand: false;
-		yourself
-]
-
 { #category : #showing }
 SpPopoverExample class >> open [
 	<script>
 
 	^ self new open
+]
+
+{ #category : #layout }
+SpPopoverExample >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		  hAlignCenter;
+		  vAlignCenter;
+		  add: top expand: false;
+		  add: left expand: false;
+		  add: bottom expand: false;
+		  add: right expand: false;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpPresenterSelectorExample.class.st
+++ b/src/Spec2-Examples/SpPresenterSelectorExample.class.st
@@ -12,20 +12,20 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpPresenterSelectorExample class >> defaultLayout [
-
-	^ SpPanedLayout newLeftToRight
-		add: #list;
-		add: #choice;
-		yourself.
-
-]
-
 { #category : #specs }
 SpPresenterSelectorExample class >> defaultSpec [
 
 	^ nil
+]
+
+{ #category : #layout }
+SpPresenterSelectorExample >> defaultLayout [
+
+	^ SpPanedLayout newLeftToRight
+		add: list;
+		add: choice;
+		yourself.
+
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpProgressBarDemo.class.st
+++ b/src/Spec2-Examples/SpProgressBarDemo.class.st
@@ -16,25 +16,6 @@ Class {
 	#category : #'Spec2-Examples-Demo-Loading'
 }
 
-{ #category : #layout }
-SpProgressBarDemo class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #indeterminated withConstraints: [ :constraints | constraints height: 6 ];
-		add: 'Indeterminated';
-		add: #fixed withConstraints: [ :constraints | constraints height: 10 ];
-		add: 'Fixed';
-		add: #withProgressionBlock withConstraints: [ :constraints | constraints height: 20 ];
-		add: 'With progression block';
-		add:
-			(SpBoxLayout newLeftToRight
-				add: #withText;
-				add: #label withConstraints: [ :constraints | constraints width: 40 ];
-				yourself)
-			withConstraints: [ :constraints | constraints height: 40 ];
-		add: 'With label';
-		yourself
-]
-
 { #category : #examples }
 SpProgressBarDemo class >> example [
 	<sampleInstance>
@@ -45,6 +26,23 @@ SpProgressBarDemo class >> example [
 { #category : #initialization }
 SpProgressBarDemo >> connectPresenters [
 	withText whenValueChangedDo: [ :value | label label: (value * 100) asInteger asString , '%' ]
+]
+
+{ #category : #layout }
+SpProgressBarDemo >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: 'Indeterminated';
+		  add: indeterminated;
+		  add: 'Fixed';
+		  add: fixed;
+		  add: 'With progression block';
+		  add: withProgressionBlock;
+		  add: 'With text';
+		  add: withText;
+		  add: 'With label';
+		  add: label;
+		  yourself
 ]
 
 { #category : #accessing }
@@ -69,6 +67,7 @@ SpProgressBarDemo >> indeterminated: anObject [
 
 { #category : #initialization }
 SpProgressBarDemo >> initializePresenters [
+
 	| progress progress2 |
 	indeterminated := self newProgressBar.
 	fixed := self newProgressBar.
@@ -77,14 +76,18 @@ SpProgressBarDemo >> initializePresenters [
 	label := self newLabel.
 
 	indeterminated indeterminate.
-	
+
 	fixed fixedPercentage: 30.
 
 	progress := 0.
-	withProgressionBlock progress: [ progress := progress + 0.01 ] every: 0.5 second.
-	
+	withProgressionBlock
+		progress: [ progress := progress + 0.01 ]
+		every: 0.5 second.
+
 	progress2 := 0.
-	withText progress: [ progress2 := progress2 + 0.01 ] every: 0.1 second.
+	withText
+		progress: [ progress2 := progress2 + 0.01 ]
+		every: 0.1 second.
 	label label: 'This is a progress bar'
 ]
 

--- a/src/Spec2-Examples/SpProgressBarDemo.class.st
+++ b/src/Spec2-Examples/SpProgressBarDemo.class.st
@@ -10,8 +10,7 @@ Class {
 		'indeterminated',
 		'fixed',
 		'withProgressionBlock',
-		'withText',
-		'label'
+		'withText'
 	],
 	#category : #'Spec2-Examples-Demo-Loading'
 }
@@ -21,11 +20,6 @@ SpProgressBarDemo class >> example [
 	<sampleInstance>
 	
 	^ self new open
-]
-
-{ #category : #initialization }
-SpProgressBarDemo >> connectPresenters [
-	withText whenValueChangedDo: [ :value | label label: (value * 100) asInteger asString , '%' ]
 ]
 
 { #category : #layout }
@@ -40,29 +34,7 @@ SpProgressBarDemo >> defaultLayout [
 		  add: withProgressionBlock;
 		  add: 'With text';
 		  add: withText;
-		  add: 'With label';
-		  add: label;
 		  yourself
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> fixed [
-	^ fixed
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> fixed: anObject [
-	fixed := anObject
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> indeterminated [
-	^ indeterminated
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> indeterminated: anObject [
-	indeterminated := anObject
 ]
 
 { #category : #initialization }
@@ -70,30 +42,22 @@ SpProgressBarDemo >> initializePresenters [
 
 	| progress progress2 |
 	indeterminated := self newProgressBar.
-	fixed := self newProgressBar.
-	withProgressionBlock := self newProgressBar.
-	withText := self newProgressBar.
-	label := self newLabel.
-
 	indeterminated indeterminate.
-
+	
+	fixed := self newProgressBar.
 	fixed fixedPercentage: 30.
 
+	withProgressionBlock := self newProgressBar.
 	progress := 0.
 	withProgressionBlock
 		progress: [ progress := progress + 0.01 ]
 		every: 0.5 second.
 
+	withText := self newProgressBar.
 	progress2 := 0.
 	withText
 		progress: [ progress2 := progress2 + 0.01 ]
-		every: 0.1 second.
-	label label: 'This is a progress bar'
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> label [
-	^ label
+		every: 1 second
 ]
 
 { #category : #'option list presenter' }
@@ -106,24 +70,4 @@ SpProgressBarDemo >> optionIcon [
 SpProgressBarDemo >> optionTitle [
 
 	^ 'Progress bar Presenter'
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> withProgressionBlock [
-	^ withProgressionBlock
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> withProgressionBlock: anObject [
-	withProgressionBlock := anObject
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> withText [
-	^ withText
-]
-
-{ #category : #accessing }
-SpProgressBarDemo >> withText: anObject [
-	withText := anObject
 ]

--- a/src/Spec2-Examples/SpProgressBarDemoPage.class.st
+++ b/src/Spec2-Examples/SpProgressBarDemoPage.class.st
@@ -16,6 +16,12 @@ SpProgressBarDemoPage class >> pageName [
 ]
 
 { #category : #initialization }
+SpProgressBarDemoPage class >> priority [
+
+	^ 1400
+]
+
+{ #category : #initialization }
 SpProgressBarDemoPage >> pageClass [
 	^ SpProgressBarDemo
 ]

--- a/src/Spec2-Examples/SpRadioButtonExample.class.st
+++ b/src/Spec2-Examples/SpRadioButtonExample.class.st
@@ -12,20 +12,8 @@ Class {
 		'button3',
 		'label'
 	],
-	#category : #'Spec2-Examples-Demo-Checkboxes'
+	#category : #'Spec2-Examples-Demo-Buttons'
 }
-
-{ #category : #layout }
-SpRadioButtonExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: (SpBoxLayout newTopToBottom
-				add: #button1 expand: false;
-				add: #button2 expand: false;
-				add: #button3 expand: false;
-				yourself);
-		add: #label expand: false;
-		yourself
-]
 
 { #category : #examples }
 SpRadioButtonExample class >> example [
@@ -47,6 +35,19 @@ SpRadioButtonExample >> connectPresenters [
 	button2 whenChangedDo: [ self updateLabel ].
 
 	button3 whenChangedDo: [ self updateLabel ]
+]
+
+{ #category : #layout }
+SpRadioButtonExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: (SpBoxLayout newTopToBottom
+				add: button1 expand: false;
+				add: button2 expand: false;
+				add: button3 expand: false;
+				yourself);
+		add: label expand: false;
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpScrollableLayoutExamplePage.class.st
+++ b/src/Spec2-Examples/SpScrollableLayoutExamplePage.class.st
@@ -4,7 +4,7 @@ I am a demo page for the spec examples demo app to exemplify the use of SpScroll
 Class {
 	#name : #SpScrollableLayoutExamplePage,
 	#superclass : #SpDemoPage,
-	#category : #'Spec2-Examples-Layouts'
+	#category : #'Spec2-Examples-Demo-Layouts'
 }
 
 { #category : #initialization }
@@ -12,6 +12,12 @@ SpScrollableLayoutExamplePage class >> pageName [
 
 	^'Scrollable layout'
 
+]
+
+{ #category : #initialization }
+SpScrollableLayoutExamplePage class >> priority [
+
+	^ 2100
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpScrollableLayoutExamplePresenter.class.st
+++ b/src/Spec2-Examples/SpScrollableLayoutExamplePresenter.class.st
@@ -1,10 +1,13 @@
 "
-In the current spec status (19/10/2021), I am a documented example of how to use SpScrollableLayouts.
+In the current spec status (08/03/2022), I am a documented example of how to use SpScrollableLayouts.
 "
 Class {
 	#name : #SpScrollableLayoutExamplePresenter,
 	#superclass : #SpPresenter,
-	#category : #'Spec2-Examples-Layouts'
+	#instVars : [
+		'scrollablePresenter'
+	],
+	#category : #'Spec2-Examples-Demo-Layouts'
 }
 
 { #category : #building }
@@ -20,28 +23,30 @@ SpScrollableLayoutExamplePresenter >> addTextFieldTo: aLayout [
 	aLayout add: self newText withConstraints: [ :c | c height: 120 ]
 ]
 
+{ #category : #layout }
+SpScrollableLayoutExamplePresenter >> defaultLayout [
+
+	^ SpScrollableLayout with: scrollablePresenter
+]
+
 { #category : #initialization }
 SpScrollableLayoutExamplePresenter >> initializePresenters [
-	<script: 'self new openWithSpec'>
-	|scrollablePresenter|
+
+	| largeLayout |
 	super initializePresenters.
 	
 	"We initialize the layout to a vertical box layout.
 	Presenters will stack vertically."
-	layout := SpBoxLayout newTopToBottom.
+	largeLayout := SpBoxLayout newTopToBottom.
 	
 	"For this demo, we add a lot of presenters (here, text fields.
 	The idea is to fill the entire vertical space so that we need 
 	to scroll up and down to see all the presenters."
-	10 timesRepeat: [ self addTextFieldTo: layout ].		
+	10 timesRepeat: [ self addTextFieldTo: largeLayout ].		
 
 	self flag: 'The following is how SpScrollablePresenter work today. 
 	It should change in the future to directly take our box layout as input instead of the following.'.
 	"To use a scroll layout, we need to embed our own layout into an intermediate presenter."
 	scrollablePresenter := SpPresenter new.
-	scrollablePresenter layout: layout.
-	
-	"We then set our layout to a scrollable layout in which we
-	have a single presenter (our intermediate presenter)"
-	self layout: (SpScrollableLayout with: scrollablePresenter)
+	scrollablePresenter layout: largeLayout
 ]

--- a/src/Spec2-Examples/SpTextFieldExample.class.st
+++ b/src/Spec2-Examples/SpTextFieldExample.class.st
@@ -36,10 +36,11 @@ SpTextFieldExample >> connectPresenters [
 
 { #category : #layout }
 SpTextFieldExample >> defaultLayout [
+
 	^ SpBoxLayout newTopToBottom
-		add: textField withConstraints: [ :constraints | constraints height: StandardFonts defaultFont height + 15 ];
-		add: methodBrowser;
-		yourself
+		  add: textField expand: false;
+		  add: methodBrowser;
+		  yourself
 ]
 
 { #category : #api }

--- a/src/Spec2-Examples/SpTextFieldExample.class.st
+++ b/src/Spec2-Examples/SpTextFieldExample.class.st
@@ -11,14 +11,6 @@ Class {
 	#category : #'Spec2-Examples-Standalone'
 }
 
-{ #category : #layout }
-SpTextFieldExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: #textField withConstraints: [ :constraints | constraints height: StandardFonts defaultFont height + 15 ];
-		add: #methodBrowser;
-		yourself
-]
-
 { #category : #examples }
 SpTextFieldExample class >> example [
 
@@ -40,6 +32,14 @@ SpTextFieldExample >> connectPresenters [
 			at: text asSymbol
 			ifPresent: [ :class | methodBrowser messages: class methods ]
 			ifAbsent: [ methodBrowser messages: #() ] ]
+]
+
+{ #category : #layout }
+SpTextFieldExample >> defaultLayout [
+	^ SpBoxLayout newTopToBottom
+		add: textField withConstraints: [ :constraints | constraints height: StandardFonts defaultFont height + 15 ];
+		add: methodBrowser;
+		yourself
 ]
 
 { #category : #api }

--- a/src/Spec2-Examples/SpToggleButtonExample.class.st
+++ b/src/Spec2-Examples/SpToggleButtonExample.class.st
@@ -12,20 +12,8 @@ Class {
 		'button3',
 		'label'
 	],
-	#category : #'Spec2-Examples-Demo-Checkboxes'
+	#category : #'Spec2-Examples-Demo-Buttons'
 }
-
-{ #category : #layout }
-SpToggleButtonExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: (SpBoxLayout newTopToBottom
-				add: #button1 expand: false;
-				add: #button2 expand: false;
-				add: #button3 expand: false;
-				yourself);
-		add: #label expand: false;
-		yourself
-]
 
 { #category : #examples }
 SpToggleButtonExample class >> example [
@@ -46,6 +34,19 @@ SpToggleButtonExample >> connectPresenters [
 	button1 whenDeactivatedDo: [ self updateLabel ].
 	button2 whenChangedDo: [ self updateLabel ].
 	button3 whenChangedDo: [ self updateLabel ]
+]
+
+{ #category : #layout }
+SpToggleButtonExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: (SpBoxLayout newTopToBottom
+				   add: button1 expand: false;
+				   add: button2 expand: false;
+				   add: button3 expand: false;
+				   yourself);
+		  add: label expand: false;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpToolbarToggleButtonExample.class.st
+++ b/src/Spec2-Examples/SpToolbarToggleButtonExample.class.st
@@ -13,19 +13,8 @@ Class {
 		'label',
 		'toolbar'
 	],
-	#category : #'Spec2-Examples-Demo-Checkboxes'
+	#category : #'Spec2-Examples-Demo-Buttons'
 }
-
-{ #category : #layout }
-SpToolbarToggleButtonExample class >> defaultLayout [
-	^ SpBoxLayout newTopToBottom
-		add: (SpBoxLayout newTopToBottom
-			vAlignStart;
-			add: #toolbar expand: false;
-			yourself);
-		add: #label expand: false;
-		yourself
-]
 
 { #category : #examples }
 SpToolbarToggleButtonExample class >> example [
@@ -46,6 +35,18 @@ SpToolbarToggleButtonExample >> connectPresenters [
 	button1 whenDeactivatedDo: [ self updateLabel ].
 	button2 whenChangedDo: [ self updateLabel ].
 	button3 whenChangedDo: [ self updateLabel ]
+]
+
+{ #category : #layout }
+SpToolbarToggleButtonExample >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: (SpBoxLayout newTopToBottom
+				   vAlignStart;
+				   add: toolbar expand: false;
+				   yourself);
+		  add: label expand: false;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Examples/SpTransmissionExample.class.st
+++ b/src/Spec2-Examples/SpTransmissionExample.class.st
@@ -1,3 +1,6 @@
+"
+I am an example how transmissions work
+"
 Class {
 	#name : #SpTransmissionExample,
 	#superclass : #SpPresenter,
@@ -8,21 +11,8 @@ Class {
 		'methods',
 		'code'
 	],
-	#category : #'Spec2-Examples-Standalone'
+	#category : #'Spec2-Examples-Demo-Transmission'
 }
-
-{ #category : #layout }
-SpTransmissionExample class >> defaultLayout [
-
-	^ SpBoxLayout newTopToBottom
-		add: (SpBoxLayout newLeftToRight 
-			add: #packages;
-			add: #classes;
-			add: #protocols;
-			add: #methods);
-		add: #code;
-		yourself
-]
 
 { #category : #showing }
 SpTransmissionExample class >> open [ 
@@ -33,76 +23,174 @@ SpTransmissionExample class >> open [
 
 { #category : #initialization }
 SpTransmissionExample >> classTemplateFor: aPackage [
-	
+
 	aPackage ifNil: [ ^ '' ].
 
 	^ 'Object subclass: #NameOfSubclass
 	slots: {}
 	classVariables: {}
-	package: ''', aPackage name,''' ' 
+	package: ''' , aPackage name , ''' '
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> connectClassesPresenter [
+
+	classes
+		transmitTo: protocols
+		transform: [ :aClass | 
+			aClass
+				ifNotNil: [ 
+					aClass organization allProtocols
+						collect: [ :each | aClass -> each ]
+						as: OrderedCollection ]
+				ifNil: [ #(  ) ] ]
+		postTransmission: [ :destination :origin | destination selectIndex: 1 ].
 	
+	classes
+		transmitTo: code
+		transform: [ :aClass | aClass ifNotNil: [ aClass definitionString ] ifNil: [ '' ] ]
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> connectMethodsPresenter [
+
+	methods
+		transmitTo: code
+		transform: [ :aMethod | aMethod ifNotNil: [ aMethod sourceCode ] ifNil: [ '' ] ]
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> connectPackagesPresenter [
+
+	packages
+		transmitTo: classes
+		transform: [ :aPackage | 
+			aPackage
+				ifNotNil: [ aPackage definedClasses asArray ]
+				ifNil: [ #(  ) ] ].
+
+	packages
+		transmitTo: code
+		transform: [ :aPackage | self classTemplateFor: aPackage ]
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> connectPresenters [
+
+	self connectPackagesPresenter.
+	self connectClassesPresenter.
+	self connectProtocolsPresenter.
+	self connectMethodsPresenter
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> connectProtocolsPresenter [
+
+	protocols
+		transmitTo: methods
+		transform: [ :aPair | 
+			aPair
+				ifNotNil: [ 
+					aPair value methodSelectors
+						collect: [ :each | aPair key >> each ]
+						as: OrderedCollection ]
+				ifNil: [ #(  ) ] ].
+			
+	protocols
+		transmitTo: code
+		transform: [ :aPair | aPair ifNotNil: [ aPair key sourceCodeTemplate ] ifNil: [ '' ] ]
+]
+
+{ #category : #layout }
+SpTransmissionExample >> defaultLayout [
+
+	| packagesLayout classesLayout protocolsLayout methodsLayout |
+	packagesLayout := SpBoxLayout newTopToBottom
+		add: 'Packages' expand: false;
+		add: packages;
+		yourself.
+	
+	classesLayout := SpBoxLayout newTopToBottom
+		add: 'Classes' expand: false;
+		add: classes;
+		yourself.
+		
+	protocolsLayout := SpBoxLayout newTopToBottom
+		add: 'Protocols' expand: false;
+		add: protocols;
+		yourself.
+		
+	methodsLayout := SpBoxLayout newTopToBottom
+		add: 'Methods' expand: false;
+		add: methods;
+		yourself.
+		
+	^ SpBoxLayout newTopToBottom
+		spacing: 5;
+		add: (SpBoxLayout newLeftToRight
+			spacing: 5;
+			add: packagesLayout;
+			add: classesLayout;
+			add: protocolsLayout;
+			add: methodsLayout;
+			yourself);	
+		add: code;
+		yourself
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> initializeClassesPresenter [
+
+	classes := self newList.
+	classes
+		display: [ :class | class name];
+		displayIcon: [ :class | class systemIcon ];
+		sortingBlock: [ :a :b | a name < b name ]
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> initializeCodePresenter [
+
+	code := self newCode
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> initializeMethodsPresenter [
+
+	methods := self newList.
+	methods
+		display: [ :method | method selector ];
+		sortingBlock: [ :a :b | a selector < b selector ]
+]
+
+{ #category : #initialization }
+SpTransmissionExample >> initializePackagesPresenter [
+
+	packages := self newList.
+	packages
+		display: [ :package | package name ];
+		displayIcon: [ self iconNamed: #package ];
+		sortingBlock: [ :a :b | a name < b name ];
+		items: RPackageOrganizer default packages
 ]
 
 { #category : #initialization }
 SpTransmissionExample >> initializePresenters [
 
-	packages := self newList display: #name.
-	classes := self newList display: #name.
-	protocols := self newList display: [ :aPair | aPair value name ].
-	methods := self newList display: #selector.
-	code := self newCode.
+	self initializePackagesPresenter.
+	self initializeClassesPresenter.
+	self initializeProtocolsPresenter.
+	self initializeMethodsPresenter.
+	self initializeCodePresenter
+]
 
-	packages
-		transmitTo: classes
-		transform: [ :aPackage | 
-			aPackage 
-				ifNotNil: [ aPackage definedClasses asArray ]
-				ifNil: [ #() ] ].
-	packages
-		transmitTo: code
-		transform: [ :aPackage | self classTemplateFor: aPackage ].
-	
-	classes
-		transmitTo: protocols
-		transform: [ :aClass | 
-			aClass 
-				ifNotNil: [ 
-					aClass organization allProtocols
-						collect: [ :each | aClass -> each ]
-						as: OrderedCollection ]
-				ifNil: [ #() ] ]
-		postTransmission: [ :destination :origin | destination selectIndex: 1 ].
-	classes 
-		transmitTo: code 
-		transform: [ :aClass | 
-			aClass 
-				ifNotNil: [ aClass definitionString ] 
-				ifNil: [ '' ] ].
-	
+{ #category : #initialization }
+SpTransmissionExample >> initializeProtocolsPresenter [
+
+	protocols := self newList.
 	protocols
-		transmitTo: methods
-		transform: [ :aPair | 
-			aPair 
-				ifNotNil:[ 
-					aPair value methodSelectors
-						collect: [ :each | aPair key >> each ]
-						as: OrderedCollection ]
-				ifNil: [ #() ] ].
-	protocols
-		transmitTo: code
-		transform: [ :aPair | 
-			aPair 
-				ifNotNil: [ aPair key sourceCodeTemplate ]
-				ifNil: [ '' ] ].
-
-	methods 
-		transmitTo: code 
-		transform: [ :aMethod | 
-			aMethod 
-				ifNotNil: [ aMethod sourceCode ] 
-				ifNil: [ '' ] ].
-
-	packages items: RPackageOrganizer default packages
+		display: [ :aPair | aPair value name ];
+		sortingBlock: [ :a :b | a value name < b value name ]
 ]
 
 { #category : #initialization }
@@ -110,5 +198,5 @@ SpTransmissionExample >> initializeWindow: aWindowPresenter [
 
 	aWindowPresenter
 		title: 'Transmission example browser';
-		initialExtent: 800@600
+		initialExtent: 800 @ 600
 ]

--- a/src/Spec2-Morphic-Examples/SpImagePresenter.extension.st
+++ b/src/Spec2-Morphic-Examples/SpImagePresenter.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #SpImagePresenter }
 
 { #category : #'*Spec2-Morphic-Examples' }
-SpImagePresenter classSide >> example [
+SpImagePresenter class >> example [
 
 	<sampleInstance>
 	^ self new


### PR DESCRIPTION
Done things

- Created dynamic layout example
- Moved all defaultLayout methods from class side to instance side
- Recategorised the classes inside the package Spec2-Examples
- Reordered the examples
- Added filtering list example
- Moved the form example to the right package
- Refactored the transmission example and added it to the spec demo presenter

![Enregistrement-de-lecran-2022-03](https://user-images.githubusercontent.com/33934979/157252404-433bf84c-fc8c-4f10-9fd8-d4c5b7756476.gif)

