### PR TITLE
skip all job tests 

### DIFF
--- a/src/Spec2-Morphic-Tests/SpJobListPresenterTest.class.st
+++ b/src/Spec2-Morphic-Tests/SpJobListPresenterTest.class.st
@@ -29,8 +29,9 @@ SpJobListPresenterTest >> testJobIsFinishedWhenWaitingMoreThanWorkBlockDuration 
 
 { #category : #tests }
 SpJobListPresenterTest >> testJobIsNotFinishedWhenWaitingLessThanWorkBlockDuration [
-
 	| progress job |
+
+	self skipOnPharoCITestingEnvironment.
 
 	progress := 0.
 	job := SpJob
@@ -46,10 +47,11 @@ SpJobListPresenterTest >> testJobIsNotFinishedWhenWaitingLessThanWorkBlockDurati
 
 { #category : #tests }
 SpJobListPresenterTest >> testProgressDoesNotRefreshMoreThanRefreshRate [
-
 	"Ensure progress presenter will not slow down the workblock by calling too many UI refresh"
 	| job waitBetweenJobUpdate counter refreshRateInMs nbUpdates maxExpected |
 
+	self skipOnPharoCITestingEnvironment.
+	
 	waitBetweenJobUpdate := 30 milliSeconds.
 	refreshRateInMs := 150.
 	nbUpdates := 25.


### PR DESCRIPTION
because they fail on jenkins (while running with UI opened, in local)