### PR TITLE
Compiler-Cleanup-interactive 

### DIFF
--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -68,12 +68,6 @@ SpCodeInteractionModel >> hasBindingThatBeginsWith: aString [
 		anySatisfy: [ :each | each beginsWith: aString ]
 ]
 
-{ #category : #'interactive error protocol' }
-SpCodeInteractionModel >> interactive [
-
-	^ true
-]
-
 { #category : #testing }
 SpCodeInteractionModel >> isForScripting [
 


### PR DESCRIPTION
remove #interactive as a requestor is interactive by default