### PR TITLE
Fix code highlighting for no-header doIts

### DIFF
--- a/src/Spec2-Code/SpCodeMethodInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeMethodInteractionModel.class.st
@@ -37,6 +37,12 @@ SpCodeMethodInteractionModel >> hasBindingOf: aString [
 	^ self behavior hasBindingOf: aString
 ]
 
+{ #category : #testing }
+SpCodeMethodInteractionModel >> isScripting [ 
+
+	^method isDoIt
+]
+
 { #category : #accessing }
 SpCodeMethodInteractionModel >> method [
 

--- a/src/Spec2-Code/SpContextInteractionModel.class.st
+++ b/src/Spec2-Code/SpContextInteractionModel.class.st
@@ -64,6 +64,11 @@ SpContextInteractionModel >> hasUnsavedCodeChanges [
 	^ context notNil and: [ context sourceCode ~= owner text asString ]
 ]
 
+{ #category : #testing }
+SpContextInteractionModel >> isScripting [ 
+	^context method isDoIt 
+]
+
 { #category : #accessing }
 SpContextInteractionModel >> object [
 

--- a/src/Spec2-Morphic-Examples/SpMethodBrowser.class.st
+++ b/src/Spec2-Morphic-Examples/SpMethodBrowser.class.st
@@ -56,7 +56,7 @@ SpMethodBrowser >> connectPresenters [
 		selection isEmpty
 			ifTrue: [ 
 				textModel text: ''.
-				textModel beForMethod: nil.
+				textModel clearInteractionModel.
 				toolbarModel method: nil ]
 			ifFalse: [ | m |
 				m := selection selectedItem. 


### PR DESCRIPTION
Fix code highlighting for no-header doIts in debugger and method and AST inspections.

Integration into Pharo should be done after https://github.com/pharo-project/pharo/pull/11463