### PR TITLE
Fix isScripting for block contexts from DoIts

### DIFF
--- a/src/Spec2-Code/SpContextInteractionModel.class.st
+++ b/src/Spec2-Code/SpContextInteractionModel.class.st
@@ -66,7 +66,7 @@ SpContextInteractionModel >> hasUnsavedCodeChanges [
 
 { #category : #testing }
 SpContextInteractionModel >> isScripting [ 
-	^context method isDoIt 
+	^context belongsToDoIt
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
It requires Pharo PR with #belongsToDoIt method: https://github.com/pharo-project/pharo/pull/11473