### PR TITLE
[fix] Pharo issue # 11390: Browsing implementors/senders from source code editors doesn't browse expected selector

### DIFF
--- a/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
@@ -596,7 +596,7 @@ SpCodePresenterTest >> testNilTestSelectedSelectorDoesNotBreakExecution [
 ]
 
 { #category : #'tests - command support' }
-SpCodePresenterTest >> testSelectedSelector [
+SpCodePresenterTest >> testSelectedSelectorForMethodEditing [
 
 	"Testing border cases to avoid breaking execution. The selector extraction logic should be tested in the extractor class"
 
@@ -604,6 +604,40 @@ SpCodePresenterTest >> testSelectedSelector [
 
 	| selector |
 	presenter text: nil.
+	selector := presenter selectedSelector.
+	self assert: selector isNil.
+
+	"Code presenter is empty"
+	presenter text: ''.
+	selector := presenter selectedSelector.
+	self assert: selector isNil.
+
+	"Code has valid code"
+	selector := presenter text: 'aMethod do: 1 with: 2'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #aMethod.
+
+	"Code has faulty code"
+	selector := presenter text: 'aMethod do : 1 with: 2'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #aMethod.
+
+	"Code has invalid code (no selectors at all)"
+	"selector := presenter text: 'anObjectdo : 2'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #noMethod"
+]
+
+{ #category : #'tests - command support' }
+SpCodePresenterTest >> testSelectedSelectorForScripting [
+
+	"Testing border cases to avoid breaking execution. The selector extraction logic should be tested in the extractor class"
+
+	"Code presenter has nil text for some reason"
+
+	| selector |
+	presenter text: nil.
+	presenter beForScripting.
 	selector := presenter selectedSelector.
 	self assert: selector isNil.
 

--- a/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
@@ -622,6 +622,11 @@ SpCodePresenterTest >> testSelectedSelectorForMethodEditing [
 	selector := presenter selectedSelector.
 	self assert: selector equals: #aMethod.
 
+	"Code depends on contextual information"
+	selector := presenter text: 'aMethodName: anArg anArg aMessageSend: anotherArg'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #aMethodName:.
+
 	"Code has invalid code (no selectors at all)"
 	"selector := presenter text: 'anObjectdo : 2'.
 	selector := presenter selectedSelector.
@@ -655,6 +660,11 @@ SpCodePresenterTest >> testSelectedSelectorForScripting [
 	selector := presenter text: 'anObject do : 1 with: 2'.
 	selector := presenter selectedSelector.
 	self assert: selector equals: #do.
+
+	"Code depends on contextual information"
+	selector := presenter text: 'aMethodName: anArg anArg aMessageSend: anotherArg'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #aMethodName:aMessageSend:.
 
 	"Code has invalid code (no selectors at all)"
 	"selector := presenter text: 'anObjectdo : 2'.
@@ -694,7 +704,17 @@ Smalltalk allClassesAndTraits reject: #hasComment'.
 	presenter clearSelection.
 	presenter selectionInterval: ((string size + 1) to: string size).
 	selector := presenter selectedSelector.
-	self assert: selector equals: #hasComment
+	self assert: selector equals: #hasComment.
+	
+
+	"Code depends on contextual information"
+	selector := presenter text: 'aMethodName: anArg anArg aMessageSend: anotherArg'.
+	presenter cursorPositionIndex: string size + 1.
+	"ensure there is no selection"
+	presenter clearSelection.
+	presenter selectionInterval: ((string size + 1) to: string size).
+	selector := presenter selectedSelector.
+	self assert: selector equals: #aMessageSend:.
 ]
 
 { #category : #tests }

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -657,10 +657,17 @@ SpCodePresenter >> selectedSelector [
 	^ selectedText
 		  ifNotEmpty: [ 
 				extractor extractSelectorFromSelection: selectedText ]
-		  ifEmpty: [
-				extractor
-				  extractSelectorFromSource: fullSource
-				  atPosition: (self cursorPositionIndex ifNil: [ 1 ]) ]
+		  ifEmpty: [ | index |
+				index := (self cursorPositionIndex ifNil: [ 1 ]).
+				self isScripting 
+					ifTrue: [ 
+						extractor
+						  extractSelectorFromSource: fullSource
+						  atPosition: index ]
+					ifFalse: [ 
+						extractor extractSelectorFromAST: (RBParser parseFaultyMethod: fullSource)
+		  					atPosition: index ]
+					]
 ]
 
 { #category : #api }


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/11390
The problem comes from the fact that we are (before this fix) not using information about the string we get, unlike the previous version in RubCodeEditor.
Therefore we do not know when this is a method and when this is not, and this fails for keyword methods.