### PR TITLE
Align browse refences for symbols and classes

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -315,10 +315,12 @@ SpCodePresenter >> doBrowseImplementors [
 SpCodePresenter >> doBrowseMethodReferences [
 	"Browse references to Variables (Cmd-shift-n)"
 	| variableOrClassName variable usingMethods |
+
 	variableOrClassName := self selectedSelector ifNil: [ ^ nil ].
 
 	variable := self lookupEnvironment lookupVar: variableOrClassName.
-	variable ifNil: [ ^ nil ].
+	variable ifNil: [ 
+		^ self doBrowseSenders ].
 	usingMethods := variable usingMethods ifEmpty: [ ^ application inform: 'No users found.'].
 
 	"the dialog sadly hard-codes 'senders'"


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/11404

This adopts the same behavior as in Calypso