### PR TITLE
Extend SpDiffPresenter to make it navigable accross differences

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicDiffAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicDiffAdapter.class.st
@@ -8,6 +8,18 @@ Class {
 }
 
 { #category : #'widget API' }
+SpMorphicDiffAdapter >> beNavigable [
+
+	^ self model beNavigable
+]
+
+{ #category : #'spec protocol' }
+SpMorphicDiffAdapter >> beNavigable: aBoolean [
+
+	self widgetDo: [ :w | w beNavigable: aBoolean ]
+]
+
+{ #category : #'widget API' }
 SpMorphicDiffAdapter >> beWrapped [
 
 	^ self model beWrapped
@@ -31,6 +43,8 @@ SpMorphicDiffAdapter >> buildWidget [
 		  vResizing: #spaceFill;
 		  setBalloonText: self help;
 		  showOptions: self showOptions;
+		  beNavigable: self beNavigable;
+		  beWrapped: self beWrapped;
 		  leftLabel: self leftLabel rightLabel: self rightLabel;
 		  showOnlyDestination: self showOnlyDestination;
 		  yourself

--- a/src/Spec2-Core/SpDiffPresenter.class.st
+++ b/src/Spec2-Core/SpDiffPresenter.class.st
@@ -20,7 +20,8 @@ Class {
 		'#leftText => ObservableSlot',
 		'#rightLabel => ObservableSlot',
 		'#rightText => ObservableSlot',
-		'#beWrapped => ObservableSlot'
+		'#beWrapped => ObservableSlot',
+		'#beNavigable => ObservableSlot'
 	],
 	#category : #'Spec2-Core-Widgets'
 }
@@ -29,6 +30,18 @@ Class {
 SpDiffPresenter class >> adapterName [
 
 	^ #DiffAdapter
+]
+
+{ #category : #api }
+SpDiffPresenter >> beNavigable [
+
+	^ beNavigable
+]
+
+{ #category : #api }
+SpDiffPresenter >> beNavigable: aBoolean [
+
+	beNavigable := aBoolean
 ]
 
 { #category : #api }
@@ -60,6 +73,7 @@ SpDiffPresenter >> contextClass: anObject [
 
 { #category : #initialization }
 SpDiffPresenter >> initialize [
+
 	super initialize.
 
 	leftText := ''.
@@ -68,16 +82,48 @@ SpDiffPresenter >> initialize [
 	showOnlyDestination := false.
 	showOnlySource := false.
 	beWrapped := true.
+	beNavigable := false.
 
-	self property: #beWrapped whenChangedDo: [ :aBoolean | self changed: #beWrapped: with: {aBoolean} ].
-	self property: #leftText whenChangedDo: [ :newText | self changed: #leftText: with: {newText} ].
-	self property: #rightText whenChangedDo: [ :newText | self changed: #rightText: with: {newText} ].
-	self property: #contextClass whenChangedDo: [ :newClass | self changed: #contextClass: with: {newClass} ].
-	self property: #showOptions whenChangedDo: [ :aBoolean | self changed: #showOptions: with: {aBoolean} ].
-	self property: #showOnlyDestination whenChangedDo: [ :aBoolean | self changed: #showOnlyDestination: with: {aBoolean} ].
-	self property: #showOnlySource whenChangedDo: [ :aBoolean | self changed: #showOnlySource: with: {aBoolean} ].
-	self property: #leftLabel whenChangedDo: [ :newText | self changed: #leftLabel: with: {newText} ].
-	self property: #rightLabel whenChangedDo: [ :newText | self changed: #rightLabel: with: {newText} ]
+	self
+		property: #beWrapped
+		whenChangedDo: [ :aBoolean | 
+		self changed: #beWrapped: with: { aBoolean } ].
+	self
+		property: #beNavigable
+		whenChangedDo: [ :aBoolean | 
+		self changed: #beNavigable: with: { aBoolean } ].
+	self
+		property: #leftText
+		whenChangedDo: [ :newText | 
+		self changed: #leftText: with: { newText } ].
+	self
+		property: #rightText
+		whenChangedDo: [ :newText | 
+		self changed: #rightText: with: { newText } ].
+	self
+		property: #contextClass
+		whenChangedDo: [ :newClass | 
+		self changed: #contextClass: with: { newClass } ].
+	self
+		property: #showOptions
+		whenChangedDo: [ :aBoolean | 
+		self changed: #showOptions: with: { aBoolean } ].
+	self
+		property: #showOnlyDestination
+		whenChangedDo: [ :aBoolean | 
+		self changed: #showOnlyDestination: with: { aBoolean } ].
+	self
+		property: #showOnlySource
+		whenChangedDo: [ :aBoolean | 
+		self changed: #showOnlySource: with: { aBoolean } ].
+	self
+		property: #leftLabel
+		whenChangedDo: [ :newText | 
+		self changed: #leftLabel: with: { newText } ].
+	self
+		property: #rightLabel
+		whenChangedDo: [ :newText | 
+		self changed: #rightLabel: with: { newText } ]
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpDiffPresenter.extension.st
+++ b/src/Spec2-Examples/SpDiffPresenter.extension.st
@@ -1,6 +1,23 @@
 Extension { #name : #SpDiffPresenter }
 
 { #category : #'*Spec2-Examples' }
+SpDiffPresenter class >> exampleNavigableWithOptionsAndLabels [
+	"
+	self exampleNavigableWithOptionsAndLabels
+	"
+	<sampleInstance>
+	^ self new
+		showOptions: true;
+		beNavigable: true;
+		leftText: (True >> #and:) sourceCode;
+		leftLabel: '#and: implementation';
+		rightText: (True >> #or:) sourceCode;
+		rightLabel: '#or: implementation';
+		contextClass: True;
+		open
+]
+
+{ #category : #'*Spec2-Examples' }
 SpDiffPresenter class >> exampleWithOptions [
 	"
 	self exampleWithOptions
@@ -10,6 +27,22 @@ SpDiffPresenter class >> exampleWithOptions [
 		showOptions: true;
 		leftText: (True >> #and:) sourceCode;
 		rightText: (True >> #or:) sourceCode;
+		contextClass: True;
+		open
+]
+
+{ #category : #'*Spec2-Examples' }
+SpDiffPresenter class >> exampleWithOptionsAndLabels [
+	"
+	self exampleWithOptionsAndLabels
+	"
+	<sampleInstance>
+	^ self new
+		showOptions: true;
+		leftText: (True >> #and:) sourceCode;
+		leftLabel: '#and: implementation';
+		rightText: (True >> #or:) sourceCode;
+		rightLabel: '#or: implementation';
 		contextClass: True;
 		open
 ]


### PR DESCRIPTION
Add Top, Next difference, Previous difference in SpDiffPresenter to easily navigate

![navigableDiffPresenter](https://user-images.githubusercontent.com/49032546/188273557-96306f36-f2d9-4eac-b5d0-93469aab0a70.PNG)

https://github.com/pharo-project/pharo/pull/11641 required! (because I had to change the morphic class DiffMorph)

Defult behavior of SpDiffPresenter unchanged (by default no buttons will show up)