### PR TITLE
skip a test that fails on the CI often (due to checking timing issues)

### DIFF
--- a/src/Spec2-Morphic-Tests/SpJobListPresenterTest.class.st
+++ b/src/Spec2-Morphic-Tests/SpJobListPresenterTest.class.st
@@ -14,6 +14,7 @@ SpJobListPresenterTest >> testJobIsFinishedWhenWaitingMoreThanWorkBlockDuration 
 
 	| progress job |
 
+	self skipOnPharoCITestingEnvironment.
 	progress := 0.
 	job := SpJob
 			newTitle: 'some job'


### PR DESCRIPTION
this is testJobIsFinishedWhenWaitingMoreThanWorkBlockDuration