### PR TITLE
[improvement] ask the object what to select when adding a presenter to a MillerCollumnPresenter

### DIFF
--- a/src/Spec2-Core/Association.extension.st
+++ b/src/Spec2-Core/Association.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Association }
+
+{ #category : #'*Spec2-Core' }
+Association >> objectToSelectOnSelection [
+	^ value
+]

--- a/src/Spec2-Core/Object.extension.st
+++ b/src/Spec2-Core/Object.extension.st
@@ -23,3 +23,8 @@ Object >> isSpLayout [
 
 	^ false
 ]
+
+{ #category : #'*Spec2-Core' }
+Object >> objectToSelectOnSelection [
+	^ self
+]

--- a/src/Spec2-Core/SpMillerColumnPresenter.class.st
+++ b/src/Spec2-Core/SpMillerColumnPresenter.class.st
@@ -28,7 +28,7 @@ Class {
 SpMillerColumnPresenter >> addPresenter: newSubPresenter [
 
 	newSubPresenter whenActivatedDo: [ :selection | 
-		self changeSelection: selection from: newSubPresenter ].
+		self changeSelection: selection objectToSelectOnSelection from: newSubPresenter ].
 	newSubPresenter owner: self.
 	layout add: newSubPresenter
 ]


### PR DESCRIPTION
One common usage is to remove association inspecting in the inspector.
I'm not a fan of the name of the selector, nor the package in which it is added.
But I trust @estebanlm to correct me !

Dictionary inspection with change:
![Screenshot 2022-10-28 at 15 28 12](https://user-images.githubusercontent.com/21278554/198610422-1a1f6fe6-df59-440a-a5ff-5d43268f0f24.png)
