### PR TITLE
avoid #asSymbol for the defaultFont. fixes #1329

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpStyleEnvironmentFontVariable.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleEnvironmentFontVariable.class.st
@@ -48,6 +48,7 @@ SpStyleEnvironmentFontVariable >> pointSize [
 
 { #category : #evaluating }
 SpStyleEnvironmentFontVariable >> value [
-
-	^ StandardFonts perform: (self name, 'Font') asSymbol
+	^ self name = 'default' 
+		ifTrue: [ StandardFonts defaultFont ]
+		ifFalse: [ StandardFonts perform: (self name, 'Font') asSymbol ]
 ]


### PR DESCRIPTION
avoid #asSymbol for the defaultFont. fixes #1329