### PR TITLE
Fix for closing a Playground after moving it out of a window group signals a MessageNotUnderstood

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpWindow.class.st
+++ b/src/Spec2-Adapters-Morphic/SpWindow.class.st
@@ -19,6 +19,7 @@ SpWindow >> aboutText [
 SpWindow >> allowedToClose [
 
 	super allowedToClose ifFalse: [ ^ false ].
+	self model ifNil: [ ^ true ].
 	^ self model askOkToClose 
 		ifTrue: [ self model requestWindowClose ]
 		ifFalse: [ true ].

--- a/src/Spec2-Tests/SpWindowTest.class.st
+++ b/src/Spec2-Tests/SpWindowTest.class.st
@@ -28,6 +28,32 @@ SpWindowTest >> testAboutText [
 ]
 
 { #category : #tests }
+SpWindowTest >> testAllowedToClose [
+
+	| application appWindow |
+	application := SpApplication new.
+	windowPresenter := (application newPresenter: SpTextPresenter) open.
+	appWindow := windowPresenter window.
+
+	windowPresenter askOkToClose: true.
+	self 
+		deny: appWindow model isNil
+		description: 'It tests the window presenter model is not nil by default'.
+	self 
+		assert: appWindow allowedToClose 
+		description: 'It tests the window presenter is allowed to close if its application window does have a model'.
+	windowPresenter askOkToClose: false.
+	self 
+		assert: appWindow allowedToClose
+		description: 'It tests the window presenter is allowed to close if its application window does NOT have a model'.
+
+	appWindow close.
+	
+	self deny: (application windows includes: windowPresenter).
+	self assert: application windows isEmpty
+]
+
+{ #category : #tests }
 SpWindowTest >> testCloseWindowRemovesItFromApplicationWindowCollection [
 
 	| application |


### PR DESCRIPTION
It fixes the issue "Closing a Playground after moving it out of a window group signals a MessageNotUnderstood" reported in pharo-project/pharo#12133 by allowing the window to be closed if the window model is nil. Also add a test for SpWindow>>allowedToClose

