### PR TITLE
Fix DNU trimBoth on non-strings

### DIFF
--- a/src/Spec2-Core/SpTSearchable.trait.st
+++ b/src/Spec2-Core/SpTSearchable.trait.st
@@ -58,7 +58,7 @@ SpTSearchable >> isSearchEnabled [
 SpTSearchable >> performDefaultSearch: item matching: pattern [
 	| text |
 	
-	text := (self searchValueOf: item) trimBoth asLowercase.
+	text := (self searchValueOf: item) asString trimBoth asLowercase.
 	^ text beginsWith: pattern
 ]
 


### PR DESCRIPTION
`searchValueOf:` does not systematically return strings.

I tried to look at how to write a test, but there is no API to programmatically force a key event.