### PR TITLE
Replace allProtocols by protocols

### DIFF
--- a/src/Spec2-Examples/SpTransmissionExample.class.st
+++ b/src/Spec2-Examples/SpTransmissionExample.class.st
@@ -40,7 +40,7 @@ SpTransmissionExample >> connectClassesPresenter [
 		transform: [ :aClass | 
 			aClass
 				ifNotNil: [ 
-					aClass organization allProtocols
+					aClass organization protocols
 						collect: [ :each | aClass -> each ]
 						as: OrderedCollection ]
 				ifNil: [ #(  ) ] ]


### PR DESCRIPTION
#allProtocols is used only by examples or code that is to be removed soon.  I updated one of the only example using it to use the more classic #protocols one