### PR TITLE
Do not use #classComment

### DIFF
--- a/src/Spec2-Examples/SpDemoListsPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoListsPresenter.class.st
@@ -74,13 +74,12 @@ SpDemoListsPresenter >> iconFor: class [
 			class hasFailedTest ifTrue: [ ^ self iconNamed: #testYellow ].
 			class hasErrorTest ifTrue: [ ^ self iconNamed: #testRed ].
 			^ self iconNamed: #testNotRun ].
-	class organization classComment ifEmpty: [ ^ self iconNamed: #uncommentedClass ].
+	class comment ifEmpty: [ ^ self iconNamed: #uncommentedClass ].
 	((class includesBehavior: (Smalltalk globals at: #TestCase ifAbsent: [ false ])) and: [ class isAbstract not ])
 		ifTrue: [ class hasPassedTest ifTrue: [ ^ self iconNamed: #testGreen ].
 			class hasFailedTest ifTrue: [ ^ self iconNamed: #testYellow ].
 			class hasErrorTest ifTrue: [ ^ self iconNamed: #testRed ].
 			^ self iconNamed: #testNotRun ].
-	class organization classComment ifEmpty: [ ^ self iconNamed: #uncommentedClass ].
 	^ self iconNamed: class systemIconName
 ]
 


### PR DESCRIPTION
ClassOrganization>>#classComment will soon be removed from the system.  Instead we should directly call #comment on a class.