### PR TITLE
Spec2-Code: declare 'playground'-related capabilities as a compiler requestor

### DIFF
--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -62,6 +62,11 @@ SpCodeInteractionModel >> isScripting [
 	^ false
 ]
 
+{ #category : #testing }
+SpCodeInteractionModel >> needRequestorScope [
+	^false
+]
+
 { #category : #'interactive error protocol' }
 SpCodeInteractionModel >> notify: message at: location in: code [
 	| currentSelection stripMessage |

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -236,6 +236,14 @@ SpCodePresenter >> buildContextMenuWith: aValuable [
 	^ menuPresenter
 ]
 
+{ #category : #testing }
+SpCodePresenter >> canAddBindingOf: name [
+
+	^ self interactionModel
+		  ifNotNil: [ :sp | sp canAddBindingOf: name ]
+		  ifNil: [ false ]
+]
+
 { #category : #api }
 SpCodePresenter >> clearInteractionModel [
 
@@ -611,6 +619,14 @@ SpCodePresenter >> lookupEnvironment [
 		ifNil: [ interactionModel behavior ])
 			ifNil: [ environment
 				ifNil: [ self class environment ] ])
+]
+
+{ #category : #testing }
+SpCodePresenter >> needRequestorScope [
+
+	^ self interactionModel
+		  ifNotNil: [ :sp | sp needRequestorScope ]
+		  ifNil: [ false ]
 ]
 
 { #category : #private }

--- a/src/Spec2-Code/SpCodeScriptingInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeScriptingInteractionModel.class.st
@@ -29,6 +29,14 @@ SpCodeScriptingInteractionModel >> bindings [
 ]
 
 { #category : #testing }
+SpCodeScriptingInteractionModel >> canAddBindingOf: name [
+
+	"Check is a special variable named `name` can be declared but without declaring it."
+	^ name first isUppercase not.
+
+]
+
+{ #category : #testing }
 SpCodeScriptingInteractionModel >> hasBindingOf: aString [
 
 	^ self bindings includesKey: aString asSymbol


### PR DESCRIPTION
"requestor" do not have a nice API, so add two methods to simplify the job of the compiler (better than classname based heuristic)

* `needRequestorScope` to test if a special scope associated to the model (or worse, the window), is needed
* `canAddBindingOf:` to test if the model (or worse, the window) can automatically create new variables (used for workspace variables)

In a near future, requestors that do not answer positively will lose these implicit features