### PR TITLE
SpCodeInteractionModel: add compile and test it

### DIFF
--- a/src/Spec2-Code-Tests/SpCodeObjectInteractionModelTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodeObjectInteractionModelTest.class.st
@@ -47,6 +47,21 @@ SpCodeObjectInteractionModelTest >> testBindingOf [
 ]
 
 { #category : #tests }
+SpCodeObjectInteractionModelTest >> testCompiler [
+
+	| result |
+	result := interactionModel compiler evaluate: 'self'.
+	self assert: result equals: self.
+
+	instanceVariableForTest := 42.
+	result := interactionModel compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 42.
+
+	result := interactionModel compiler evaluate: 'instanceVariableForTest := 43'.
+	self assert: instanceVariableForTest equals: 43
+]
+
+{ #category : #tests }
 SpCodeObjectInteractionModelTest >> testDoItReceiver [
 
 	self assert: interactionModel doItReceiver equals: objectToTest

--- a/src/Spec2-Code-Tests/SpCodeObjectInteractionModelTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodeObjectInteractionModelTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #SpCodeObjectInteractionModelTest,
 	#superclass : #SpCodeInteractionModelTest,
 	#instVars : [
-		'objectToTest'
+		'objectToTest',
+		'instanceVariableForTest'
 	],
 	#category : #'Spec2-Code-Tests'
 }
@@ -16,13 +17,13 @@ SpCodeObjectInteractionModelTest >> classToTest [
 { #category : #running }
 SpCodeObjectInteractionModelTest >> initializeInstance: anInteractionModel [
 
-	anInteractionModel object: objectToTest
+	anInteractionModel object: self objectToTest
 ]
 
 { #category : #accessing }
 SpCodeObjectInteractionModelTest >> objectToTest [
 
-	^ objectToTest ifNil: [ objectToTest := SpCodePresenter new ]
+	^ objectToTest ifNil: [ objectToTest := self ]
 ]
 
 { #category : #running }

--- a/src/Spec2-Code-Tests/SpContextInteractionModelTest.class.st
+++ b/src/Spec2-Code-Tests/SpContextInteractionModelTest.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #SpContextInteractionModelTest,
 	#superclass : #SpCodeInteractionModelTest,
 	#instVars : [
-		'objectToTest',
 		'instanceVariableForTest'
 	],
 	#category : #'Spec2-Code-Tests'

--- a/src/Spec2-Code-Tests/SpContextInteractionModelTest.class.st
+++ b/src/Spec2-Code-Tests/SpContextInteractionModelTest.class.st
@@ -1,0 +1,83 @@
+Class {
+	#name : #SpContextInteractionModelTest,
+	#superclass : #SpCodeInteractionModelTest,
+	#instVars : [
+		'objectToTest',
+		'instanceVariableForTest'
+	],
+	#category : #'Spec2-Code-Tests'
+}
+
+{ #category : #accessing }
+SpContextInteractionModelTest >> classToTest [
+
+	^ SpContextInteractionModel
+]
+
+{ #category : #running }
+SpContextInteractionModelTest >> initializeInstance: anInteractionModel [
+
+	| context |
+	context := [
+	           | tempVariableForTest |
+	           instanceVariableForTest := 42.
+	           tempVariableForTest := 43.
+	           44 ] asContext.
+	context step; step; step; step. "Perform the 2 assigments"
+	anInteractionModel context: context
+]
+
+{ #category : #tests }
+SpContextInteractionModelTest >> testBehavior [
+
+	self assert: interactionModel behavior equals: self class
+]
+
+{ #category : #tests }
+SpContextInteractionModelTest >> testBindingOf [
+
+	self assert: (interactionModel bindingOf: #somethingNotExistent) isNil.
+	self assert: (interactionModel bindingOf: #Object) isNotNil.
+	self assert: (interactionModel bindingOf: #instanceVariableForTest) isNotNil.
+	self assert: (interactionModel bindingOf: #tempVariableForTest) isNotNil
+]
+
+{ #category : #tests }
+SpContextInteractionModelTest >> testCompile [
+
+	| result |
+	
+	result := interactionModel compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 42.
+	instanceVariableForTest := 52.
+	result := interactionModel compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 52.
+
+	result := interactionModel compiler evaluate: 'instanceVariableForTest := 62'.
+	self assert: result equals: 62.
+	result := interactionModel compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 62.
+	self assert: instanceVariableForTest equals: 62.
+
+	result := interactionModel compiler evaluate: 'tempVariableForTest'.
+	self assert: result equals: 43.
+	result := interactionModel compiler evaluate: 'tempVariableForTest := 53'.
+	self assert: result equals: 53.
+	result := interactionModel compiler evaluate: 'tempVariableForTest'.
+	self assert: result equals: 53
+]
+
+{ #category : #tests }
+SpContextInteractionModelTest >> testDoItReceiver [
+
+	self assert: interactionModel doItReceiver equals: self
+]
+
+{ #category : #tests }
+SpContextInteractionModelTest >> testHasBindingOf [
+
+	self deny: (interactionModel hasBindingOf: #somethingNotExistent).
+	self assert: (interactionModel hasBindingOf: #Object).
+	self assert: (interactionModel hasBindingOf: #instanceVariableForTest).
+	self assert: (interactionModel hasBindingOf: #tempVariableForTest)
+]

--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -43,6 +43,16 @@ SpCodeInteractionModel >> canAddBindingOf: name [
 ]
 
 { #category : #accessing }
+SpCodeInteractionModel >> compiler [
+	"Provide a compiler set up on the current context/class/receiver"
+
+	^ self doItReceiver class compiler
+		  context: self doItContext;
+		  receiver: self doItReceiver;
+		  requestor: self
+]
+
+{ #category : #accessing }
 SpCodeInteractionModel >> doItContext [
 
 	^ nil

--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -37,6 +37,11 @@ SpCodeInteractionModel >> bindings [
 	^ #() asDictionary
 ]
 
+{ #category : #testing }
+SpCodeInteractionModel >> canAddBindingOf: name [
+	^ false
+]
+
 { #category : #accessing }
 SpCodeInteractionModel >> doItContext [
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -422,17 +422,13 @@ SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: 
 	 anything. 
 	 Instead, the on:do: will catch all errors happening while executing the code once it is 
 	 compiled. "
-	| receiver result oldBindings |
+	| result oldBindings |
 	
 	^ [
 		self announcer announce: (SpCodeWillBeEvaluatedAnnouncement newContent: aString).
 		oldBindings := self interactionModel bindings copy.
-		receiver := self interactionModel doItReceiver.
-		result := receiver class compiler
+		result := self interactionModel compiler
 			source: aString;
-			context: self interactionModel doItContext;
-			receiver: self interactionModel doItReceiver;
-			requestor: self interactionModel;
 			environment: self environment;
 			failBlock:  [ 
 				self announcer announce: (SpCodeEvaluationFailedAnnouncement newContent: aString).


### PR DESCRIPTION
https://github.com/pharo-project/pharo/pull/13498 did solve a regression with dolt evaluation in the debugger.

This PR move a `compiler` helper to the code interaction model (used by SpCodePresenter) and add (and fix) tests to prevent future issues.

Because of the regression, I assume that #13498 should be merged first.