### PR TITLE
Add class variable to control scaling in SpFontStyle

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpFontStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpFontStyle.class.st
@@ -155,7 +155,7 @@ SpFontStyle >> calculateFontSize [
 	
 	self sizeVariable ifNotNil: [ :aVariable |
 		aVariable value ifNotNil: [ 
-			^ self sizeVariable scaledValue ] ].
+			^ self scaledSize ] ].
 	self nameVariable isEnvironmentVariable ifTrue: [ 
 		^ self nameVariable pointSize * self currentWorld displayScaleFactor ].
 	self hasPredefinedFont ifTrue: [ 

--- a/src/Spec2-Adapters-Morphic/SpFontStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpFontStyle.class.st
@@ -54,6 +54,7 @@ Class {
 		'color'
 	],
 	#classVars : [
+		'ApplyDisplayScaleFactor',
 		'FontCache'
 	],
 	#category : #'Spec2-Adapters-Morphic-StyleSheet'
@@ -63,6 +64,18 @@ Class {
 SpFontStyle class >> addFontToCache: aFont [
 
 	self fontCache add: aFont
+]
+
+{ #category : #accessing }
+SpFontStyle class >> applyDisplayScaleFactor [
+
+	^ ApplyDisplayScaleFactor ifNil: [ true ]
+]
+
+{ #category : #accessing }
+SpFontStyle class >> applyDisplayScaleFactor: aBoolean [
+
+	ApplyDisplayScaleFactor := aBoolean
 ]
 
 { #category : #private }
@@ -90,6 +103,12 @@ SpFontStyle >> anyFontDecorator [
 		or: [ size notNil 
 		or: [ bold notNil 
 		or: [ italic notNil ] ] ]
+]
+
+{ #category : #private }
+SpFontStyle >> applyDisplayScaleFactor [
+
+	^ self class applyDisplayScaleFactor
 ]
 
 { #category : #operations }
@@ -157,9 +176,9 @@ SpFontStyle >> calculateFontSize [
 		aVariable value ifNotNil: [ 
 			^ self scaledSize ] ].
 	self nameVariable isEnvironmentVariable ifTrue: [ 
-		^ self nameVariable pointSize * self currentWorld displayScaleFactor ].
+		^ self nameVariable pointSize * self displayScaleFactor ].
 	self hasPredefinedFont ifTrue: [ 
-		^ self obtainPredefinedFont pointSize * self currentWorld displayScaleFactor ].
+		^ self obtainPredefinedFont pointSize * self displayScaleFactor ].
 
 	^ nil
 ]
@@ -204,6 +223,14 @@ SpFontStyle >> definedFont [
 	definedFont := self calculateDefinedFont.
 	self addFontToCache: definedFont.
 	^ definedFont
+]
+
+{ #category : #private }
+SpFontStyle >> displayScaleFactor [
+
+	^ self applyDisplayScaleFactor
+		ifTrue: [ self currentWorld displayScaleFactor ]
+		ifFalse: [ 1 ]
 ]
 
 { #category : #private }
@@ -305,7 +332,9 @@ SpFontStyle >> predefinedFont: aSymbol [
 { #category : #accessing }
 SpFontStyle >> scaledSize [
 
-	^ self sizeVariable scaledValue
+	^ self applyDisplayScaleFactor
+		ifTrue: [ self sizeVariable scaledValue ]
+		ifFalse: [ self sizeVariable nonscaledValue ]
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Adapters-Morphic/SpStyleAbstractVariable.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleAbstractVariable.class.st
@@ -26,6 +26,12 @@ SpStyleAbstractVariable >> isResetVariable [
 ]
 
 { #category : #evaluating }
+SpStyleAbstractVariable >> nonscaledValue [
+
+	^ self value
+]
+
+{ #category : #evaluating }
 SpStyleAbstractVariable >> preferredScaledValueWith: anObject [
 
 	^ self value
@@ -40,7 +46,7 @@ SpStyleAbstractVariable >> preferredValueWith: anObject [
 { #category : #evaluating }
 SpStyleAbstractVariable >> scaledValue [
 
-	^ self value
+	^ self nonscaledValue
 ]
 
 { #category : #evaluating }

--- a/src/Spec2-Adapters-Morphic/SpStyleVariable.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariable.class.st
@@ -26,6 +26,12 @@ SpStyleVariable class >> stonName [
 ]
 
 { #category : #evaluating }
+SpStyleVariable >> nonscaledValue [
+
+	^ self value ifNil: [ 0 ]
+]
+
+{ #category : #evaluating }
 SpStyleVariable >> preferredScaledValueWith: anObject [
 
 	^ self value = 0 
@@ -44,7 +50,7 @@ SpStyleVariable >> preferredValueWith: anObject [
 { #category : #evaluating }
 SpStyleVariable >> scaledValue [
 
-	^ (self value ifNil: [ 0 ]) * self currentWorld displayScaleFactor
+	^ self nonscaledValue * self currentWorld displayScaleFactor
 ]
 
 { #category : #private }


### PR DESCRIPTION
When setting ‘Standard fonts’ in the Settings Browser to the predefined style ‘Very large’, some text becomes too large:

<p align="center">
<img width="400" src="https://github.com/pharo-spec/Spec/assets/1611248/20b9e1e8-8815-4a73-947d-decd99823fbe">
</p>

This is because besides setting the fonts to a larger point size, the style also sets a larger display scale factor, which SpFontStyle then uses to further scale up the point size. This pull request adds a class variable that allows turning that off:

```smalltalk
SpFontStyle applyDisplayScaleFactor: false
```

<p align="center">

<img width="400" src="https://github.com/pharo-spec/Spec/assets/1611248/87adf3fb-c45d-420d-8788-5bdd9836ce56">

</p>


For additional context, see this pull request: https://github.com/pharo-project/pharo/pull/13767.