### PR TITLE
cleanup SpCodePresenter>>#findClassFromSelection

### DIFF
--- a/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodePresenterTest.class.st
@@ -601,26 +601,6 @@ SpCodePresenterTest >> testEvaluateSendAnnouncements [
 ]
 
 { #category : #tests }
-SpCodePresenterTest >> testFindClassFrom [
-
-	self assert: (presenter findClassFrom: '') equals: nil.
-	self assert: (presenter findClassFrom: 'Object') equals: Object.
-	self assert: (presenter findClassFrom: 'Object.') equals: Object.
-	self assert: (presenter findClassFrom: '.Object.') equals: Object.
-	self
-		assert: (presenter findClassFrom: 'somethingBefore := 42.Object')
-		equals: Object.
-	self
-		assert:
-			(presenter
-				findClassFrom: 'somethingBefore := 42.Object. somethingAfter := 11')
-		equals: Object.
-	self
-		assert: (presenter findClassFrom: 'NonExistingClass.Object.')
-		equals: Object
-]
-
-{ #category : #tests }
 SpCodePresenterTest >> testNilTestSelectedSelectorDoesNotBreakExecution [
 	"Code presenter has nil text for some reason"
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -446,29 +446,6 @@ SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: 
 		errorBlock value: e ]
 ]
 
-{ #category : #accessing }
-SpCodePresenter >> findClassFrom: aString [
-	| ast |
-	
-	self flag: #TODO. "Does this really has to be part of the code api?"
-
-	ast := RBParser parseExpression: aString onError: [ ^ nil ].
-	ast nodesDo: [ :node | 
-		(node isVariable and: [ node name first isUppercase ])
-			ifTrue: [ 
-				(self class environment classNamed: node name)
-					ifNotNil: [ :aClass | ^ aClass ] ] ].
-
-	^ nil
-]
-
-{ #category : #accessing }
-SpCodePresenter >> findClassFromSelection [
-	self flag: #TODO. "Does this really has to be part of the text api?"
-
-	^ self findClassFrom: self selectedTextOrLine trimmed
-]
-
 { #category : #'private - bindings' }
 SpCodePresenter >> hasBindingOf: aString [
 


### PR DESCRIPTION
SpCodePresenter had methods with "self flag:" that are not used

- findClassFromSelection
- findClassFrom:

This PR just removes that code and the test.

This is nice as this removes one direct use of RBParser