### PR TITLE
[Pharo11] Error Fueling out SpStyleEnvironmentColorProxyTest instances

### DIFF
--- a/src/Spec2-Adapters-Morphic-Tests/SpStyleEnvironmentColorProxyTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStyleEnvironmentColorProxyTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #SpStyleEnvironmentColorProxyTest,
+	#superclass : #TestCase,
+	#category : #'Spec2-Adapters-Morphic-Tests'
+}
+
+{ #category : #tests }
+SpStyleEnvironmentColorProxyTest >> testSerializationWithFuelMaintainProxy [
+
+ 	| proxy byteArray deserialized |
+	
+	proxy := SpStyleEnvironmentColorProxy new
+		colorSelector: #backgroundColor;
+		yourself.
+		
+	self assert: proxy class equals: SpStyleEnvironmentColorProxy.
+	
+	byteArray := FLSerializer serializeToByteArray: proxy.
+	deserialized := FLMaterializer materializeFromByteArray: byteArray.
+	
+	self assert: deserialized class equals: proxy class.
+	self assert: (MirrorPrimitives fieldOf: deserialized at: 1) equals: (MirrorPrimitives fieldOf: proxy at: 1)
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleEnvironmentColorProxy.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleEnvironmentColorProxy.class.st
@@ -32,6 +32,35 @@ SpStyleEnvironmentColorProxy >> doesNotUnderstand: aMessage [
 	^ aMessage sendTo: (Smalltalk ui theme perform: colorSelector)
 ]
 
+{ #category : #hooks }
+SpStyleEnvironmentColorProxy >> fuelAccept: aGeneralMapper [
+
+	^ aGeneralMapper visitFixedObject: self 
+]
+
+{ #category : #accessing }
+SpStyleEnvironmentColorProxy >> instVarAt: index [
+	"Primitive. Answer a fixed variable in an object. The numbering of the variables
+	 corresponds to the named instance variables, followed by the indexed instance
+	 variables. Fail if the index is not an Integer or is not the index of a fixed
+	 variable or indexed variable. Essential. See Object documentation whatIsAPrimitive."
+
+	<primitive: 173 error: ec>
+	self primitiveFailed	
+]
+
+{ #category : #accessing }
+SpStyleEnvironmentColorProxy >> instVarAt: index put: anObject [
+	"Primitive. Store a value into a fixed variable in an object. The numbering of the
+	 variables corresponds to the named instance variables, followed by the indexed
+	 instance variables. Fail if the index is not an Integer or is not the index of a fixed
+	 variable or indexed variable. Essential. See Object documentation whatIsAPrimitive."
+
+	<primitive: 174 error: ec>
+	
+	self primitiveFailed
+]
+
 { #category : #accessing }
 SpStyleEnvironmentColorProxy >> yourself [
 ]


### PR DESCRIPTION

- As the proxy extends from ProtoObject we have to correctly implement #fuelAccept:, #instVarAt: and #instVarAt:put:

- Add a Test
- Fix https://github.com/pharo-project/pharo/issues/13788

