### PR TITLE
fix #canAddBindingOf: to not allow synthetic names

### DIFF
--- a/src/Spec2-Code/SpCodeScriptingInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeScriptingInteractionModel.class.st
@@ -32,7 +32,7 @@ SpCodeScriptingInteractionModel >> bindings [
 SpCodeScriptingInteractionModel >> canAddBindingOf: name [
 
 	"Check is a special variable named `name` can be declared but without declaring it."
-	^ name first isUppercase not.
+	^ name first isUppercase not and: [ name startsWithDigit not ]
 
 ]
 


### PR DESCRIPTION
 fix #canAddBindingOf: to not allow synthetic names (starting with a number) as used in optimized constructs