### PR TITLE
Update usage of protocols

### DIFF
--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -19,14 +19,18 @@ Class {
 
 { #category : #documentation }
 SpAbstractListPresenter class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'Examples'. self class methods select: [ :each | each protocol = self documentExamplesProtocol ].
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'API Selection Methods'. self methods select: [ :each | each protocol = #'api - selection' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	 }
+			  'Examples'.
+			  (self class methods select: [ :method | method protocolName = self documentExamplesProtocol ]).
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'API Selection Methods'.
+			  (self methods select: [ :method | method protocolName = #'api - selection' ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #testing }

--- a/src/Spec2-Core/SpAbstractSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractSelectionMode.class.st
@@ -28,13 +28,16 @@ SpAbstractSelectionMode class >> addDocumentSectionHierarchy: aBuilder [
 
 { #category : #documentation }
 SpAbstractSelectionMode class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'API Selection Methods'. self methods select: [ :each | each protocol = #'api - selection' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	}
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'API Selection Methods'.
+			  (self methods select: [ :method | method protocolName = #'api - selection' ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
@@ -90,7 +90,7 @@ SpAbstractWidgetPresenter class >> addDocumentSectionTransmissions: aBuilder [
 	| transmissions defaultInputPort defaultOutputPort |
 	
 	transmissions := self methods select: [ :each | 
-		(each protocol = self documentTransmissionsProtocol) 
+		(each protocolName = self documentTransmissionsProtocol) 
 		and: [ (each selector beginsWith: 'default') not ] ].
 	transmissions ifEmpty: [ ^ self ].
 	
@@ -119,19 +119,13 @@ SpAbstractWidgetPresenter class >> defaultLayout [
 
 { #category : #documentation }
 SpAbstractWidgetPresenter class >> documentExampleCode [
+
 	| exampleMethod |
-	
-	exampleMethod := self class methods 
-		detect: [ :each | 
-			(each protocol = self documentExamplesProtocol) 
-			and: [ each selector = self documentExampleCodeSelector ] ]
-		ifNone: [ ^ nil ].
-			
-	^ (exampleMethod sourceCode lines 
-		allButFirst 	"Remove method name"
-		reject: [ :each | each trimLeft beginsWith: '<' ]) "Remove pragmas"
-		asStringWithCr
-		trimmed
+	exampleMethod := self class methods
+		                 detect: [ :method | method protocolName = self documentExamplesProtocol and: [ method selector = self documentExampleCodeSelector ] ]
+		                 ifNone: [ ^ nil ].
+
+	^ (exampleMethod sourceCode lines allButFirst reject: [ :each | each trimLeft beginsWith: '<' ]) asStringWithCr trimmed "Remove method name" "Remove pragmas"
 ]
 
 { #category : #documentation }
@@ -154,13 +148,16 @@ SpAbstractWidgetPresenter class >> documentFactoryMethodSelector [
 
 { #category : #documentation }
 SpAbstractWidgetPresenter class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'Examples'. self class methods select: [ :each | each protocol = self documentExamplesProtocol ].
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	 }
+			  'Examples'.
+			  (self class methods select: [ :method | method protocolName = self documentExamplesProtocol ]).
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #documentation }

--- a/src/Spec2-Core/SpNotebookPage.class.st
+++ b/src/Spec2-Core/SpNotebookPage.class.st
@@ -51,12 +51,14 @@ SpNotebookPage class >> documentFactoryMethodSelector [
 
 { #category : #documentation }
 SpNotebookPage class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	 }
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Core/SpTableColumn.class.st
+++ b/src/Spec2-Core/SpTableColumn.class.st
@@ -31,11 +31,12 @@ SpTableColumn class >> addDocumentSectionHierarchy: aBuilder [
 
 { #category : #documentation }
 SpTableColumn class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-	 }
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]) }
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Core/SpTreePresenter.class.st
+++ b/src/Spec2-Core/SpTreePresenter.class.st
@@ -33,14 +33,18 @@ SpTreePresenter class >> documentFactoryMethodSelector [
 
 { #category : #documentation }
 SpTreePresenter class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'Examples'. self class methods select: [ :each | each protocol = self documentExamplesProtocol ].
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'API Selection Methods'. self methods select: [ :each | each protocol = #'api - selection' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	 }
+			  'Examples'.
+			  (self class methods select: [ :method | method protocolName = self documentExamplesProtocol ]).
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'API Selection Methods'.
+			  (self methods select: [ :method | method protocolName = #'api - selection' ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #api }

--- a/src/Spec2-Core/SpTreeTablePresenter.class.st
+++ b/src/Spec2-Core/SpTreeTablePresenter.class.st
@@ -42,14 +42,18 @@ SpTreeTablePresenter class >> documentFactoryMethodSelector [
 
 { #category : #documentation }
 SpTreeTablePresenter class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'Examples'. self class methods select: [ :each | each protocol = self documentExamplesProtocol ].
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'API Selection Methods'. self methods select: [ :each | each protocol = #'api - selection' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	 }
+			  'Examples'.
+			  (self class methods select: [ :method | method protocolName = self documentExamplesProtocol ]).
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'API Selection Methods'.
+			  (self methods select: [ :method | method protocolName = #'api - selection' ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #api }

--- a/src/Spec2-Dialogs/SpDialogPresenter.class.st
+++ b/src/Spec2-Dialogs/SpDialogPresenter.class.st
@@ -71,19 +71,13 @@ SpDialogPresenter class >> defaultCancelLabel [
 
 { #category : #documentation }
 SpDialogPresenter class >> documentExampleCode [
+
 	| exampleMethod |
-	
-	exampleMethod := self class methods 
-		detect: [ :each | 
-			(each protocol = #example) 
-			and: [ each selector = #exampleModal ] ]
-		ifNone: [ ^ nil ].
-			
-	^ (exampleMethod sourceCode lines 
-		allButFirst 	"Remove method name"
-		reject: [ :each | each trimLeft beginsWith: '<' ]) "Remove pragmas"
-		asStringWithCr
-		trimmed
+	exampleMethod := self class methods
+		                 detect: [ :method | method protocolName = #example and: [ method selector = #exampleModal ] ]
+		                 ifNone: [ ^ nil ].
+
+	^ (exampleMethod sourceCode lines allButFirst reject: [ :each | each trimLeft beginsWith: '<' ]) asStringWithCr trimmed "Remove method name" "Remove pragmas"
 ]
 
 { #category : #documentation }
@@ -94,13 +88,16 @@ SpDialogPresenter class >> documentFactoryMethodSelector [
 
 { #category : #documentation }
 SpDialogPresenter class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'API Show Methods'. self methods select: [ :each | each protocol = #'api - showing' ].
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ].
-		'Testing Methods'. self methods select: [ :each | each protocol = #'testing' ].
-		'Events'. self methods select: [ :each | each protocol = #'api - events' ].
-	}
+			  'API Show Methods'.
+			  (self methods select: [ :method | method protocolName = #'api - showing' ]).
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]).
+			  'Testing Methods'.
+			  (self methods select: [ :method | method protocolName = #testing ]).
+			  'Events'.
+			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Layout/SpExecutableLayout.class.st
+++ b/src/Spec2-Layout/SpExecutableLayout.class.st
@@ -49,12 +49,14 @@ SpExecutableLayout class >> addDocumentSectionHierarchy: aBuilder [
 
 { #category : #documentation }
 SpExecutableLayout class >> documentSections [
-		
+
 	^ OrderedDictionary newFromPairs: {
-		'Examples'. self class methods select: [ :each | each protocol = '*Spec2-Examples' ].	
-		'Adding Methods'. self methods select: [ :each | each protocol = #'api - adding' ].
-		'API Methods'. self methods select: [ :each | each protocol = #'api' ]
-	}
+			  'Examples'.
+			  (self class methods select: [ :method | method protocolName = '*Spec2-Examples' ]).
+			  'Adding Methods'.
+			  (self methods select: [ :method | method protocolName = #'api - adding' ]).
+			  'API Methods'.
+			  (self methods select: [ :method | method protocolName = #api ]) }
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
CompiledMethod>>protocol currently returns a symbol. In the future it will return a real protocol. To help with the change a method #protocolName was introduced. Here I am updating Spec usage of protocols to use this new methods when needed and keep #protocol when it makes sense