### PR TITLE
Make #extent in SpToolbarDisplayMode hierarchy take the display scale factor into account

### DIFF
--- a/src/Spec2-Core/SpIconAndLabelToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpIconAndLabelToolbarDisplayMode.class.st
@@ -19,7 +19,7 @@ SpIconAndLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem 
 
 { #category : #accessing }
 SpIconAndLabelToolbarDisplayMode >> extent [
-	^ 45@45
+	^ (45@45) scaledByDisplayScaleFactor
 ]
 
 { #category : #printing }

--- a/src/Spec2-Core/SpIconToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpIconToolbarDisplayMode.class.st
@@ -18,7 +18,7 @@ SpIconToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 { #category : #accessing }
 SpIconToolbarDisplayMode >> extent [
 
-	^ 30@30
+	^ (30@30) scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Core/SpLabelToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpLabelToolbarDisplayMode.class.st
@@ -17,7 +17,7 @@ SpLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 
 { #category : #accessing }
 SpLabelToolbarDisplayMode >> extent [
-	^ 45@25
+	^ (45@25) scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This pull request makes `#extent` in SpToolbarDisplayMode hierarchy take the display scale factor into account.