### PR TITLE
[backport] SpMorphicBackendForTest>>#doubleClickFirstRowAndColumn:

### DIFF
--- a/src/Spec2-Backend-Tests/SpMorphicBackendForTest.class.st
+++ b/src/Spec2-Backend-Tests/SpMorphicBackendForTest.class.st
@@ -97,7 +97,7 @@ SpMorphicBackendForTest >> doubleClickFirstRowAndColumn: anAdapter [
 
 	self waitUntilUIRedrawed.
 
-	anAdapter widget doubleClick: (MouseEvent new
+	anAdapter widget doubleClick: (MouseButtonEvent new
 		setPosition: anAdapter widget submorphs first submorphs first bounds center;
 		yourself).
 


### PR DESCRIPTION
now uses MouseButtonEvent (instead of MouseEvent)Essentially doesn't change much, but allows #asPseudoDoubleClickEvent to be sent to the event.This supports changes made to improve double click handling (e.g. on FTTableMorph)See pharo-project/pharo#14168