### PR TITLE
Little fixes on tests

### DIFF
--- a/src/Spec2-Backend-Tests/SpAbstractBackendForTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractBackendForTest.class.st
@@ -15,4 +15,10 @@ SpAbstractBackendForTest >> emulateClick: mouseButtonCode onTest: anAdapterTest 
 	MouseButtonEvent redButton = mouseButtonCode 
 		ifTrue: [ anAdapterTest adapter clicked ].
 
+	self waitUntilUIRedrawed
+]
+
+{ #category : #testing }
+SpAbstractBackendForTest >> waitUntilUIRedrawed [
+	"Hook. I wait until the UI has been redrawn and events have been handled."
 ]

--- a/src/Spec2-Backend-Tests/SpButtonAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpButtonAdapterTest.class.st
@@ -22,7 +22,7 @@ SpButtonAdapterTest >> testChangingIconAffectTheWidget [
 SpButtonAdapterTest >> testChangingLabelAffectTheWidget [
 	
 	presenter label: 'ALabel'.
-	self assert: self widget label equals: 'ALabel'
+	self assert: self adapter label equals: 'ALabel'
 ]
 
 { #category : #tests }

--- a/src/Spec2-Backend-Tests/SpLabelAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpLabelAdapterTest.class.st
@@ -13,7 +13,7 @@ SpLabelAdapterTest >> classToTest [
 ]
 
 { #category : #tests }
-SpLabelAdapterTest >> testSetLabelInPresenterSetsInInMorph [
+SpLabelAdapterTest >> testSetLabelInPresenterAffectsWidget [
 	presenter label: 'something'.
 	self assert: self adapter label equals: 'something'
 ]


### PR DESCRIPTION
- Add empty waitUntilUIRedrawed to SpAbstractBackendForTest
- rename testSetLabelInPresenterSetsInInMorph to testSetLabelInPresenterAffectsWidget to follow the naming pattern
- fix testChangingLabelAffectTheWidget, to assert over the adapter instead of the widget (it's part of an adapter test suit)

Pair programmed with @tesonep 