### PR TITLE
Add alternateRowsColor for Tree Table presenter.

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -113,6 +113,11 @@ SpMorphicTreeTableAdapter >> addModelTo: tableMorph [
 			to: self
 ]
 
+{ #category : 'drawing' }
+SpMorphicTreeTableAdapter >> alternateRowsColor [
+	self widgetDo: [ :w | w alternateRowsColor: true ]
+]
+
 { #category : 'factory' }
 SpMorphicTreeTableAdapter >> basicSelectionChanged: ann [
 	| selection |

--- a/src/Spec2-Core/KMCategory.extension.st
+++ b/src/Spec2-Core/KMCategory.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #KMCategory }
+Extension { #name : 'KMCategory' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 KMCategory >> , aKMCategory [ 
 	| newCategory |
 	

--- a/src/Spec2-Core/MacOSPlatform.extension.st
+++ b/src/Spec2-Core/MacOSPlatform.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MacOSPlatform }
+Extension { #name : 'MacOSPlatform' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 MacOSPlatform >> configureApplication: anApplication configuration: aConfiguration [
 	
 	aConfiguration configureOSX: anApplication

--- a/src/Spec2-Core/ManifestSpec2Core.class.st
+++ b/src/Spec2-Core/ManifestSpec2Core.class.st
@@ -6,42 +6,44 @@ Spec is a framework in Pharo for describing user interfaces. It allows for the c
 I contain the core of Spec 2. By core I mean all the code defining the basics of Spec and the basic widgets users should use to build their applications.
 "
 Class {
-	#name : #ManifestSpec2Core,
-	#superclass : #PackageManifest,
-	#category : #'Spec2-Core-Manifest'
+	#name : 'ManifestSpec2Core',
+	#superclass : 'PackageManifest',
+	#category : 'Spec2-Core-Manifest',
+	#package : 'Spec2-Core',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleExcessiveMethodsRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#SpPresenter)) #'2016-07-01T15:56:13.465539+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleExcessiveVariablesRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#SpPresenter)) #'2016-07-01T15:56:13.372336+02:00') #(#(#RGClassDefinition #(#SpAbstractWidgetPresenter)) #'2016-07-01T15:56:13.372528+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleGTExampleNotDefinedRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#SpPresenter)) #'2016-07-01T15:56:13.363445+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleImplementedNotSentRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'TreePresenter class' #exampleWithNoSpecifiedNodes #true)) #'2016-07-01T15:56:13.496495+02:00') #(#(#RGMethodDefinition #(#'DiffPresenter class' #exampleWithoutOptions #true)) #'2016-07-01T15:56:13.496444+02:00') #(#(#RGMethodDefinition #(#'DiffPresenter class' #exampleWithOptions #true)) #'2016-07-01T15:56:13.496455+02:00') #(#(#RGMethodDefinition #(#'TreePresenter class' #exampleWithCustomColumnsAndNodesAndChildren #true)) #'2016-07-01T15:56:13.496426+02:00') #(#(#RGMethodDefinition #(#'TreePresenter class' #exampleOfAutoRefreshOnExpand #true)) #'2016-07-01T15:56:13.496465+02:00') #(#(#RGMethodDefinition #(#'TreePresenter class' #exampleWithCustomColumnsAndNodes #true)) #'2016-07-01T15:56:13.496478+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleLongMethodsRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#SpAbstractWidgetPresenter #initialize #false)) #'2016-07-01T15:56:13.356024+02:00') #(#(#RGMethodDefinition #(#SpPresenter #initialize #false)) #'2016-07-01T15:56:13.355982+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleRBOverridesDeprecatedMethodRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#SpMenuItemPresenter #name #false)) #'2016-07-01T15:56:13.378417+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Core class >> ruleUsesTrueRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'DiffPresenter class' #exampleWithOptions #true)) #'2016-07-01T15:56:13.475288+02:00') )
 ]

--- a/src/Spec2-Core/Model.extension.st
+++ b/src/Spec2-Core/Model.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Model }
+Extension { #name : 'Model' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 Model >> isSpAnnouncingObject [
 
 	^ true

--- a/src/Spec2-Core/OSPlatform.extension.st
+++ b/src/Spec2-Core/OSPlatform.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #OSPlatform }
+Extension { #name : 'OSPlatform' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 OSPlatform >> configureApplication: anApplication configuration: aConfiguration [
 
 ]

--- a/src/Spec2-Core/Object.extension.st
+++ b/src/Spec2-Core/Object.extension.st
@@ -1,24 +1,24 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 Object >> asPresenter [
 
 	^ self asString asPresenter
 ]
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 Object >> isPresenter [
 
 	^ false
 ]
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 Object >> isSpAnnouncingObject [
 
 	^ false
 ]
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 Object >> isSpLayout [
 
 	^ false

--- a/src/Spec2-Core/ObservableValueHolder.extension.st
+++ b/src/Spec2-Core/ObservableValueHolder.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ObservableValueHolder }
+Extension { #name : 'ObservableValueHolder' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 ObservableValueHolder >> unsubscribe: anObject [ 
 
 	subscriptions := subscriptions reject: [ :each | each receiver = anObject ].

--- a/src/Spec2-Core/OrderedDictionary.extension.st
+++ b/src/Spec2-Core/OrderedDictionary.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #OrderedDictionary }
+Extension { #name : 'OrderedDictionary' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 OrderedDictionary >> replaceKey: aKey with: otherKey [
 	| value index |
 	

--- a/src/Spec2-Core/SpAbstractAdapter.class.st
+++ b/src/Spec2-Core/SpAbstractAdapter.class.st
@@ -10,8 +10,8 @@ In the future my instances should just be responsible to create a widget and ins
 I'm only interesting for back-ends developers. As a developer, using Spec to define application, you should not care and have to deal with me. 
 "
 Class {
-	#name : #SpAbstractAdapter,
-	#superclass : #Model,
+	#name : 'SpAbstractAdapter',
+	#superclass : 'Model',
 	#instVars : [
 		'model',
 		'widget',
@@ -19,10 +19,12 @@ Class {
 		'owner',
 		'unsubscribed'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpAbstractAdapter class >> adapt: aPresenter [
 	
 	^ self new
@@ -30,39 +32,39 @@ SpAbstractAdapter class >> adapt: aPresenter [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter class >> adaptingAliases [
 	"Answers an array of aliases my class can adapt."
 
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter class >> adaptingName [
 	"Answers the name this component adapts."
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter class >> allAdapters [
 	"The abstract adapters should be able to return all the adapters for a framework"
 	
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractAdapter class >> isAbstract [
 	^ self == SpAbstractAdapter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter class >> owner: anOwner [
 
 	^ self new owner: anOwner; yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractAdapter >> adapt: aPresenter [
 
 	unsubscribed := false.
@@ -76,18 +78,18 @@ SpAbstractAdapter >> adapt: aPresenter [
 	widget := self buildWidget
 ]
 
-{ #category : #factory }
+{ #category : 'factory' }
 SpAbstractAdapter >> adapterWasBuilt [
 	"hook to add after-build opeations (for example, initial status, etc.)"
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> add: aWidget [
 
 	self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractAdapter >> addEventsTo: aWidget [
 	
 	aWidget ifNil: [ ^ self ].
@@ -97,114 +99,114 @@ SpAbstractAdapter >> addEventsTo: aWidget [
 		target: (self eventHandlerReceiver: aWidget)
 ]
 
-{ #category : #factory }
+{ #category : 'factory' }
 SpAbstractAdapter >> buildWidget [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractAdapter >> eventHandlerReceiver: aWidget [
 
 	^ aWidget
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> hRigid [
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> hShrinkWrap [
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> hSpaceFill [
 
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractAdapter >> hasWidget: aMorphicButtonAdapter [ 
 	
 	^ self widget hasWidget: aMorphicButtonAdapter widget
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> isRedrawable [
 	"This must be overriden in the adapter representing your container"
 	
 	^ false
 ]
 
-{ #category : #visibility }
+{ #category : 'visibility' }
 SpAbstractAdapter >> isVisible [
 	
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> layout: aLayout [
 
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> model [
 	^ model
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> owner [
 
 	"Every object instantiated by the SpecInerpreter should have an owner that will assign it to a particular presenter"
 	^ owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> owner: anObject [
 	owner := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> presenter [
 	^ model
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> removeSubWidgets [
 
 	self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractAdapter >> replaceLayoutWith: aLayout [
 	
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> selector [
 	
 	^ selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> selector: anObject [
 	
 	selector := anObject
 ]
 
-{ #category : #emulating }
+{ #category : 'emulating' }
 SpAbstractAdapter >> sendRightClickEvent [
 
 	self subclassResponsibility
 ]
 
-{ #category : #releasing }
+{ #category : 'releasing' }
 SpAbstractAdapter >> unsubscribe [ 
 	"During initialization, adapters usually subscribe to various observable slots in the presenter. When the adapters are replaced by another during dynamic layouts switching, they need to be unsubscribed because it may cause a memory leaks and, in case of Gtk, even VM crashes.
 	
@@ -215,54 +217,54 @@ SpAbstractAdapter >> unsubscribe [
 	unsubscribed := true
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 SpAbstractAdapter >> update: aSymbol [
 
 	self changed: aSymbol
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 SpAbstractAdapter >> update: aSymbol with: anArray [
 
 	self perform: aSymbol withArguments: anArray
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> useProportionalLayout [
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> vRigid [
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> vShrinkWrap [
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> vSpaceFill [
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAbstractAdapter >> when: anAnnouncement do: aBlock [
 
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractAdapter >> widget [
 	^ widget
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractAdapter >> widgetDo: aBlock [
 
 	^ self widget ifNotNil: aBlock

--- a/src/Spec2-Core/SpAbstractButtonPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractButtonPresenter.class.st
@@ -2,29 +2,31 @@
 A base for button presenters, it defines basic functionality common to all buttons.
 "
 Class {
-	#name : #SpAbstractButtonPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpAbstractButtonPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#icon => ObservableSlot',
 		'#label => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractButtonPresenter class >> isAbstract [
 
 	^ super isAbstract or: [ self = SpAbstractButtonPresenter ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractButtonPresenter >> icon [
 	"Answer the icon (an instance of `Form`) defined for this button (it can be nil)"
 
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractButtonPresenter >> icon: anIcon [
 	"Sets the icon to be displayed by the button. 
 	 The icon must be a `Form`"
@@ -32,13 +34,13 @@ SpAbstractButtonPresenter >> icon: anIcon [
 	icon := anIcon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractButtonPresenter >> iconName: aSymbol [
 
 	self icon: (self iconNamed: aSymbol)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractButtonPresenter >> initialize [
 
 	super initialize.
@@ -50,21 +52,21 @@ SpAbstractButtonPresenter >> initialize [
 
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractButtonPresenter >> label [
 	"Answer the label to be shown by the button"
 
 	^ label
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractButtonPresenter >> label: aString [
 	"Set the label to be shown by the button."
 
 	label := aString
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpAbstractButtonPresenter >> localeChanged [
 
 	super localeChanged.
@@ -72,13 +74,13 @@ SpAbstractButtonPresenter >> localeChanged [
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractButtonPresenter >> shortcutCharacter [
 
 	^ nil
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractButtonPresenter >> whenIconChangedDo: aBlock [
 	"Inform when icon property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -89,7 +91,7 @@ SpAbstractButtonPresenter >> whenIconChangedDo: aBlock [
 	self property: #icon whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractButtonPresenter >> whenLabelChangedDo: aBlock [
 	"Inform when label property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpAbstractFormButtonPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractFormButtonPresenter.class.st
@@ -3,22 +3,24 @@ A base for _form control buttons_ (like radiobuttons or checkboxes).
 
 "
 Class {
-	#name : #SpAbstractFormButtonPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpAbstractFormButtonPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#state => ObservableSlot',
 		'#label => ObservableSlot',
 		'#labelClickable => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractFormButtonPresenter class >> isAbstract [
 	^ self = SpAbstractFormButtonPresenter
 ]
 
-{ #category : #simulating }
+{ #category : 'simulating' }
 SpAbstractFormButtonPresenter >> click [
 	"Simulate a click on the checkbox
 	Used when the checkbox is a list item"
@@ -26,7 +28,7 @@ SpAbstractFormButtonPresenter >> click [
 	self toggleState
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> enabled: aBoolean [
 	"Set if the button is enabled."
 
@@ -35,7 +37,7 @@ SpAbstractFormButtonPresenter >> enabled: aBoolean [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractFormButtonPresenter >> initialize [
 	super initialize.
 
@@ -46,35 +48,35 @@ SpAbstractFormButtonPresenter >> initialize [
 	self whenLabelClickableChangedDo: [ :aBoolean | self changed: {#labelClickable: . aBoolean} ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> label [
 	"Answers the label to be shown by the button"
 
 	^ label
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> label: aString [
 	"Sets the label to be shown by the button."
 
 	label := aString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> labelClickable [
 	"Answer if the label can be clicked to select the control button"
 
 	^ labelClickable
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> labelClickable: aBoolean [
 	"Set if the label can be clicked to select the control button"
 
 	labelClickable := aBoolean
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpAbstractFormButtonPresenter >> localeChanged [
 
 	super localeChanged.
@@ -82,14 +84,14 @@ SpAbstractFormButtonPresenter >> localeChanged [
 	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> state [
 	"Answer the current state of the control button"
 
 	^ state
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> state: aBoolean [
 	"Set the state of the control button."
 
@@ -99,14 +101,14 @@ SpAbstractFormButtonPresenter >> state: aBoolean [
 	state := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractFormButtonPresenter >> toggleState [
 	"Toogle the current state of the control button"
 
 	self state: self state not
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractFormButtonPresenter >> whenActivatedDo: aBlock [
 	"Informs when the control button has been activated (see `SpAbstractFormButtonPresenter>>#state:`.
 	 `aBlock` receives zero arguments." 
@@ -114,7 +116,7 @@ SpAbstractFormButtonPresenter >> whenActivatedDo: aBlock [
 	self whenChangedDo: [ :aBoolean | aBoolean ifTrue: aBlock ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractFormButtonPresenter >> whenChangedDo: aBlock [
 	"Informs when the control button state has been changed (see `SpAbstractFormButtonPresenter>>#state:`.
 	 `aBlock` receives one argument: 
@@ -123,7 +125,7 @@ SpAbstractFormButtonPresenter >> whenChangedDo: aBlock [
 	self property: #state whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractFormButtonPresenter >> whenDeactivatedDo: aBlock [
 	"Informs when the control button has been deactivated (see `SpAbstractFormButtonPresenter>>#state:`.
 	 `aBlock` receives zero arguments." 
@@ -131,7 +133,7 @@ SpAbstractFormButtonPresenter >> whenDeactivatedDo: aBlock [
 	self whenChangedDo: [ :aBoolean | aBoolean ifFalse: aBlock ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractFormButtonPresenter >> whenLabelChangedDo: aBlock [
 	"Informs when the control button label been changed (see `SpAbstractFormButtonPresenter>>#label:`.
 	 `aBlock` receives zero arguments." 
@@ -139,7 +141,7 @@ SpAbstractFormButtonPresenter >> whenLabelChangedDo: aBlock [
 	self property: #label whenChangedDo: aBlock 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractFormButtonPresenter >> whenLabelClickableChangedDo: aBlock [
 	"Informs when the control button label clickable state has been changed (see `SpAbstractFormButtonPresenter>>#labelClickable:`.
 	 `aBlock` receives zero arguments." 

--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -2,8 +2,8 @@
 A base for list presenters, it defines basic functionality common to all lists.
 "
 Class {
-	#name : #SpAbstractListPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpAbstractListPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#traits : 'SpTHaveWrappingScrollBars + SpTContextMenu + SpTAlignableColumn',
 	#classTraits : 'SpTHaveWrappingScrollBars classTrait + SpTContextMenu classTrait + SpTAlignableColumn classTrait',
 	#instVars : [
@@ -14,10 +14,12 @@ Class {
 		'#itemFilter => ObservableSlot',
 		'#verticalAlignment'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractListPresenter class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -33,13 +35,13 @@ SpAbstractListPresenter class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenter class >> isAbstract [
 
 	^ super isAbstract or: [ self = SpAbstractListPresenter ]	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> activateOnDoubleClick [
 	"Configure the list to trigger activation on double click.
 	 An element on a list can be 'activated', meaning it will trigger an event to execute an 
@@ -50,7 +52,7 @@ SpAbstractListPresenter >> activateOnDoubleClick [
 	activateOnSingleClick := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> activateOnSingleClick [
 	"Configure the list to trigger activation on single click.
 	 An element on a list can be 'activated', meaning it will trigger an event to execute an 
@@ -61,7 +63,7 @@ SpAbstractListPresenter >> activateOnSingleClick [
 	activateOnSingleClick := true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenter >> activatesOnDoubleClick [
 	"Answer true if activation event is triggered on double click"
 
@@ -72,7 +74,7 @@ SpAbstractListPresenter >> activatesOnDoubleClick [
 	^ activateOnSingleClick not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenter >> activatesOnSingleClick [
 	"Answer true if activation event is triggered on single click"
 
@@ -83,21 +85,21 @@ SpAbstractListPresenter >> activatesOnSingleClick [
 	^ activateOnSingleClick
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> beMultipleSelection [
 	"Enable multiple selection."
 
 	self selectionMode: (SpMultipleSelectionMode on: self)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> beSingleSelection [
 	"Enable single selection (this is the default)."
 	
 	self selectionMode: (SpSingleSelectionMode on: self)
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 SpAbstractListPresenter >> clickAtIndex: anIndex [
 
 	self selectIndex: anIndex.
@@ -106,13 +108,13 @@ SpAbstractListPresenter >> clickAtIndex: anIndex [
 	self doActivateAtIndex: anIndex
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 SpAbstractListPresenter >> clickItem: anInteger [ 
 	
 	self selectIndex: anInteger
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractListPresenter >> disableActivationDuring: aBlock [
 	| oldActivate |
 	
@@ -122,12 +124,12 @@ SpAbstractListPresenter >> disableActivationDuring: aBlock [
 		activationBlock := oldActivate ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractListPresenter >> disableFilter [
 	self itemFilter: nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractListPresenter >> doActivateAtIndex: anIndex [
 
 	"Activate only if there is an item at that position"
@@ -138,7 +140,7 @@ SpAbstractListPresenter >> doActivateAtIndex: anIndex [
 		yourself)
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 SpAbstractListPresenter >> doubleClickAtIndex: anIndex [
 	self selectIndex: anIndex.
 	
@@ -146,7 +148,7 @@ SpAbstractListPresenter >> doubleClickAtIndex: anIndex [
 	self doActivateAtIndex: anIndex
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractListPresenter >> initialize [
 
 	super initialize.
@@ -164,28 +166,28 @@ SpAbstractListPresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenter >> isActiveOnDoubleClick [
 	"Answer true if activation event is triggered on double click"
 
 	^ activateOnSingleClick not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenter >> isActiveOnSingleClick [
 	"Answer true if activation event is triggered on single click"
 
 	^ activateOnSingleClick
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenter >> isMultipleSelection [
 	"Answer true if list accepts multiple selection"
 	
 	^ selectionMode isMultipleSelection
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractListPresenter >> itemAt: index [ 
 	"If there is an adapter the widget items indexes can be different thant the model items indexes, 
 	e.g. when the sort by a column is activated. In this case, ask the adapter to get the element 
@@ -196,33 +198,33 @@ SpAbstractListPresenter >> itemAt: index [
 		ifNil: [ self model at: index ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractListPresenter >> itemAtPath: anArray [
 	"This is to provide polymorphism with SpTreeTablePresentrer"
 
 	^ self itemAt: anArray first
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractListPresenter >> itemFilter [
 	^ itemFilter
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractListPresenter >> itemFilter: aBlock [
 	"This block will be used with the search field of the list to filter it with the user input dynamically."
 
 	itemFilter := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> items [
 	"Answer the items of the list"
 	
 	^ self model collection
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> items: aSequenceableCollection [
 	"Set the items of the list.
 	`aSequenceableCollection` is a collection of your domain specific items.
@@ -232,12 +234,12 @@ SpAbstractListPresenter >> items: aSequenceableCollection [
 	self unselectAll
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractListPresenter >> itemsAt: aCollectionOfIndex [
 	^ aCollectionOfIndex collect: [ :anIndex | self itemAt: anIndex ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> listSize [
 	"Return the size of the item list contained in model (see `SpAbstractListPresenter>>#model`)"
 
@@ -245,17 +247,17 @@ SpAbstractListPresenter >> listSize [
 	^ self model size
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractListPresenter >> matchBeginOfString [
 	self itemFilter: [ :each :pattern | each asLowercase beginsWith: pattern asLowercase ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractListPresenter >> matchSubstring [
 	self itemFilter: [ :each :pattern | each asLowercase includesSubstring: pattern asLowercase ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> model [
 	"Answer the model for this list. 
 	 It is tipically, an instance of `SpCollectionListModel`."
@@ -263,7 +265,7 @@ SpAbstractListPresenter >> model [
 	^ model
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> model: aModel [
 	"Sets the model used to feed the list presenter with elements of the list. 
 	 It is tipically an instance of `SpCollectionListModel`."
@@ -273,13 +275,13 @@ SpAbstractListPresenter >> model: aModel [
 		self withAdapterDo: [ :anAdapter | anAdapter refreshList ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractListPresenter >> newEmptyModel [
 
 	^ SpCollectionListModel on: #()
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> refresh [
 	"Forces a refresh of the list. 
 	 This is useful when some model contents has changed, but we do not want to reset the whole list 
@@ -288,7 +290,7 @@ SpAbstractListPresenter >> refresh [
 	self withAdapterDo: [ :anAdapter | anAdapter refreshList ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractListPresenter >> registerEvents [
 
 	self whenSelectionModeChangedDo: [ :selection | 
@@ -297,7 +299,7 @@ SpAbstractListPresenter >> registerEvents [
 		self withAdapterDo: [ :anAdapter | anAdapter updateMenu ] ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectAll [
 	"Select all items in the list or table. 
 	 It does not triggers activation event."
@@ -305,7 +307,7 @@ SpAbstractListPresenter >> selectAll [
 	self selection selectAll
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectFirst [
 	"Select first element in list. 
 	 Useful to avoid selecting by index."
@@ -313,7 +315,7 @@ SpAbstractListPresenter >> selectFirst [
 	^ self selectIndex: 1
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectIndex: anInteger [ 
 	"Select item at position `anInteger`.
 	 Selection will not scroll the presenter view to show selected element."
@@ -321,7 +323,7 @@ SpAbstractListPresenter >> selectIndex: anInteger [
 	self selectionMode selectIndex: anInteger
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectIndex: anIndex scrollToSelection: shouldScrollToSelection [
 	"Select item at position `anInteger`.
 	 If `shouldScrollToSelection` is true, selection will scroll the presenter view 
@@ -332,7 +334,7 @@ SpAbstractListPresenter >> selectIndex: anIndex scrollToSelection: shouldScrollT
         self verticalAlignment desiredVisibleRow: anIndex ].
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectIndexes: aCollectionOfIndexes [
 	"Select items at positions included in `aCollectionOfIndexes`.
 	 NOTE: in single selection mode, first element of `aCollectionOfIndexes` will be selected.
@@ -341,7 +343,7 @@ SpAbstractListPresenter >> selectIndexes: aCollectionOfIndexes [
 	self selectionMode selectIndexes: aCollectionOfIndexes
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectIndexes: aCollectionOfIndexes scrollToSelection: shouldScrollToSelection [
 	"Select items at positions included in `aCollectionOfIndexes`.
 	 NOTE: in single selection mode, first element of `aCollectionOfIndexes` will be selected.
@@ -353,7 +355,7 @@ SpAbstractListPresenter >> selectIndexes: aCollectionOfIndexes scrollToSelection
         self verticalAlignment desiredVisibleRow: aCollectionOfIndexes first ].
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectItem: anItem [ 
 	"Select `anItem` if it is included in model list.
 	 It does not scrolls to selected element."
@@ -361,7 +363,7 @@ SpAbstractListPresenter >> selectItem: anItem [
 	self selectionMode selectItem: anItem
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectItems: aCollection [
 	"Select items included in `aCollection` if they are included in model list.
 	 NOTE: In single selection mode it will select the first element of `aCollection` 
@@ -370,28 +372,28 @@ SpAbstractListPresenter >> selectItems: aCollection [
 	self selectionMode selectItems: aCollection
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectedItem [
 	"Return selected item."
 
 	^ self selection selectedItem
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectedItems [
 	"Return all the selected items in the case of a multiple selection list"
 
 	^ self selection selectedItems
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectedItemsSorted [
 	"Return all the selected items sorted by their index"
 
 	^ self itemsAt: self selection selectedIndexes sort
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selection [
 	"Answer the selection object (an instance of `SpSingleSelectionMode` or `SpMultipleSelectionMode`).
 	 This is not the item selected, but the selection container (it may contain one or many selected 
@@ -400,7 +402,7 @@ SpAbstractListPresenter >> selection [
 	^ selectionMode
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectionMode [
 	"Answer the selection object (an instance of `SpSingleSelectionMode` or `SpMultipleSelectionMode`).
 	 This is not the item selected, but the selection container (it may contain one or many selected 
@@ -410,7 +412,7 @@ SpAbstractListPresenter >> selectionMode [
 	^ selectionMode
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> selectionMode: aMode [
 	
 	selectionMode ifNotNil: [ 
@@ -418,7 +420,7 @@ SpAbstractListPresenter >> selectionMode: aMode [
 	selectionMode := aMode
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> sortingBlock [
 	"Answer the sorting block defined to sort the model list.
 	 `aBlock` is a two arguments block that answer a boolean (e.g. `[ :a :b | a < b ]`) 
@@ -428,7 +430,7 @@ SpAbstractListPresenter >> sortingBlock [
 	^ self model sortingBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> sortingBlock: aBlock [
 	"Set sorting block to sort the model list.
 	 `aBlock` is a two arguments block that answer a boolean (e.g. `[ :a :b | a < b ]`) 
@@ -437,28 +439,28 @@ SpAbstractListPresenter >> sortingBlock: aBlock [
 	self model sortingBlock: aBlock
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> unselectAll [
 	"Remove all selections"
 	
 	self selection unselectAll
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> unselectIndex: anInteger [ 
 	"Remove selection of element at index `anInteger`"
 	
 	self selection unselectIndex: anInteger
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractListPresenter >> unselectItem: anObject [ 
 	"Remove selection of element `anObject`"
 	
 	self selection unselectItem: anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractListPresenter >> updateItemsKeepingSelection: aCollection [
 	"Update list items keeping current selection. 
 	 WARNING: aCollection must includes the elements selected."
@@ -470,13 +472,13 @@ SpAbstractListPresenter >> updateItemsKeepingSelection: aCollection [
 		self selectItems: items ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractListPresenter >> verticalAlignment [
 
 	^ verticalAlignment
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenActivatedDo: aBlock [
 	"Inform when an element has been 'activated'. 
 	 `aBlock` receives one argument (a selection object, see `SpAbstractSelectionMode`)"
@@ -484,13 +486,13 @@ SpAbstractListPresenter >> whenActivatedDo: aBlock [
 	activationBlock := aBlock
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractListPresenter >> whenItemFilterBlockChangedDo: aBlock [
 
 	self property: #itemFilter whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenModelChangedDo: aBlock [
 	"Inform when model has been changed (see `SpAbstractListPresenter>>#model:`. 
 	 `aBlock` receive 3 optional arguments: 
@@ -501,7 +503,7 @@ SpAbstractListPresenter >> whenModelChangedDo: aBlock [
 	model whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenNoneSelectedDo: aBlock [
 	"Inform when the list has clean selection (there are no items selected).
 	 `aBlock` receives zero arguments"
@@ -511,7 +513,7 @@ SpAbstractListPresenter >> whenNoneSelectedDo: aBlock [
 			ifNil: [ aBlock value ] ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenSearchEnabledChangedDo: aBlock [
 	"Inform when search enabled/disabled has changed.
 	`aBlock` receives zero arguments."
@@ -519,7 +521,7 @@ SpAbstractListPresenter >> whenSearchEnabledChangedDo: aBlock [
 	self property: #searchEnabled whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenSelectedDo: aBlock [
 	"Inform when an item was selected (a real object in the items list).
 	 `aBlock` receives one argument (the new selected element)"
@@ -529,7 +531,7 @@ SpAbstractListPresenter >> whenSelectedDo: aBlock [
 			ifNotNil: [ :item | aBlock value: item ] ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenSelectedItemChangedDo: aBlock [
 	"Inform when the selected item is changed.
 	 `aBlock` receive one optional argument: the selected item (can be nil)"
@@ -537,7 +539,7 @@ SpAbstractListPresenter >> whenSelectedItemChangedDo: aBlock [
 	self selection whenChangedDo: [ aBlock cull: self selectedItem ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenSelectionChangedDo: aBlock [
 	"Inform when there are changes in selection.
 	This method works for all selection modes (single, multiple and no selection).
@@ -546,7 +548,7 @@ SpAbstractListPresenter >> whenSelectionChangedDo: aBlock [
 	self selection whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenSelectionModeChangedDo: aBlock [
 	"Inform when selection mode (single/multiple) changed. 
 	 `aBlock` receives zero arguments."
@@ -554,7 +556,7 @@ SpAbstractListPresenter >> whenSelectionModeChangedDo: aBlock [
 	selectionMode whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractListPresenter >> whenSortingBlockChangedDo: aBlock [
 	"Inform when sorting block changed. 
 	 `aBlock` receives one argument with the new sort function (or block with two arguments).

--- a/src/Spec2-Core/SpAbstractPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractPresenter.class.st
@@ -10,8 +10,8 @@ From a Spec2 users, my key methods are
 - `SpAbstractPresenter>>#openWithSpec: aSpecLayout` to open the receiver with the specified layout.
 "
 Class {
-	#name : #SpAbstractPresenter,
-	#superclass : #Model,
+	#name : 'SpAbstractPresenter',
+	#superclass : 'Model',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
 	#instVars : [
@@ -20,22 +20,24 @@ Class {
 		'needRebuild',
 		'eventHandler'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter class >> buttonHeight [
 
 	^ self defaultFont height + 12
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter class >> buttonWidth [
 
 	^ (self defaultFont widthOfString: 'eilwp') + 44
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter class >> defaultFont [ 
 
 	self flag: #TODO. "This is so wrong. All this needs to be in the theme and in the 
@@ -53,31 +55,31 @@ SpAbstractPresenter class >> defaultFont [
 
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpAbstractPresenter class >> defaultLayout [
 	"Overrides me to define a layout in a static way"
 	
 	Error signal: 'You must define a layout either by defining #defaulLayout on your presenter or setting explicitly a layout with #layout:'.
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter class >> inputTextHeight [
 
 	^ self defaultFont height + 12
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter class >> isAbstract [
 	^ self = SpAbstractPresenter
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter class >> labelHeight [
 
 	^ self defaultFont height
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpAbstractPresenter class >> owner: anOwningPresenter [
 
 	^ self basicNew
@@ -86,32 +88,32 @@ SpAbstractPresenter class >> owner: anOwningPresenter [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter class >> systemIconName [
 
 	^ #smallWindow
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter class >> toolName [
 	"The tool name can be used in some places such as the About window's title."
 	
 	^ self name
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter class >> toolbarHeight [
 
 	^ self defaultFont height + 12
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> adapter [
 
 	^ adapter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> adapter: anAdapter [
 
 	"if there existed an adapter already, we need to unsubscribe it to avoid memory leaks"
@@ -122,7 +124,7 @@ SpAbstractPresenter >> adapter: anAdapter [
 	adapter := anAdapter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> application [
 	"Answer application owner of this composition.
 	 The tree for a composition starts always with an application, which is responsible of 
@@ -131,35 +133,35 @@ SpAbstractPresenter >> application [
 	^ self owner application
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> asBlockedDialogWindow [
 
 	^ self defaultBlockedDialogWindowPresenterClass presenter: self
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> asDialogWindow [
 
 	^ self defaultDialogWindowPresenterClass presenter: self
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> asModalWindow [
 
 	^ self defaultModalWindowPresenterClass presenter: self
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> asWindow [
 
 	^ self defaultWindowPresenterClass presenter: self
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractPresenter >> autoAccept: aBoolean [
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpAbstractPresenter >> basicBuildAdapterWithLayout: aSpecLayout [
 	"I assume the SpecBindings is well defined"
 	aSpecLayout ifNil: [ Error signal: 'You must define a layout either by defining #defaulLayout on your presenter or setting explicitly a layout with #layout:' ].
@@ -176,14 +178,14 @@ SpAbstractPresenter >> basicBuildAdapterWithLayout: aSpecLayout [
 	^ adapter
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 SpAbstractPresenter >> build [
 	"Build the widget using the default layout"
 	
 	^ self buildWithLayout: self layout
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpAbstractPresenter >> buildAdapterWithLayout: aSpecLayout [
 	"Build the adapter using the spec name provided as argument"
 	
@@ -192,7 +194,7 @@ SpAbstractPresenter >> buildAdapterWithLayout: aSpecLayout [
 		during: [ self basicBuildAdapterWithLayout: aSpecLayout ]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 SpAbstractPresenter >> buildWithLayout: aSpecLayout [
 
 	"Build the widget using the layout provided as argument"
@@ -200,7 +202,7 @@ SpAbstractPresenter >> buildWithLayout: aSpecLayout [
 	^ (self buildAdapterWithLayout: aSpecLayout) widget
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 SpAbstractPresenter >> buildWithSelector: aSelector [
 
 	"Build the widget using the layout selector name provided as argument"
@@ -208,19 +210,19 @@ SpAbstractPresenter >> buildWithSelector: aSelector [
 	^ self buildWithLayout: (self retrieveLayout: aSelector)
 ]
 
-{ #category : #'private - showing' }
+{ #category : 'private - showing' }
 SpAbstractPresenter >> defaultBlockedDialogWindowPresenterClass [
 
 	^ self application defaultBlockedDialogWindowPresenterClass
 ]
 
-{ #category : #'private - showing' }
+{ #category : 'private - showing' }
 SpAbstractPresenter >> defaultDialogWindowPresenterClass [
 		
 	^ self application defaultDialogWindowPresenterClass
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpAbstractPresenter >> defaultLayout [
 	" You should define a #defaulLayout method returning a Spec layout for your presenter.
 	See SpExecutableLayout hierarchy class comments for more information on how to use / define layouts.
@@ -229,25 +231,25 @@ SpAbstractPresenter >> defaultLayout [
 	^ self class defaultLayout
 ]
 
-{ #category : #'private - showing' }
+{ #category : 'private - showing' }
 SpAbstractPresenter >> defaultModalWindowPresenterClass [
 		
 	^ self application defaultModalWindowPresenterClass
 ]
 
-{ #category : #'private - showing' }
+{ #category : 'private - showing' }
 SpAbstractPresenter >> defaultWindowPresenterClass [ 
 
 	^ self application defaultWindowPresenterClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> enabled: aBoolean [ 
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> eventHandler [
 	"Answers an generic event handler where you can make your presenter listen to specific 
 	low-level events. 
@@ -260,43 +262,43 @@ SpAbstractPresenter >> eventHandler [
 	^ eventHandler ifNil: [ eventHandler := SpEventHandler for: self ]
 ]
 
-{ #category : #'private - utilities' }
+{ #category : 'private - utilities' }
 SpAbstractPresenter >> forceUpdateSlot: aSymbol [
 
 	^ (self rawValueHolderNamed: aSymbol) valueChanged
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> hasAdapter [
 
 	^ adapter notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> hasAnnouncer [
 
 	^ announcer notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> hasEventHandler [
 
 	^ eventHandler notNil and: [ eventHandler hasEvents ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> hasOwner [
 
 	^ self owner notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> hasWindow [
 
 	^ self root isWindowPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractPresenter >> initialize [ 
 
 	self class initializeSlots: self.
@@ -304,7 +306,7 @@ SpAbstractPresenter >> initialize [
 	needRebuild := true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractPresenter >> initializeDialogWindow: aDialogWindowPresenter [
 	"Used to initialize the model in the case of the use into a dialog window.
 	 Override this to set buttons other than the default (Ok, Cancel)."
@@ -318,7 +320,7 @@ SpAbstractPresenter >> initializeDialogWindow: aDialogWindowPresenter [
 			presenter close ]	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractPresenter >> initializeWindow: aWindowPresenter [
 	"Override this to set window values before opening. 
 	 You may want to add a menu, a toolbar or a statusbar"
@@ -327,48 +329,48 @@ SpAbstractPresenter >> initializeWindow: aWindowPresenter [
 	want to do ButtonPresenter new openWithSpec)."
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> isMenuPresenter [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> isPresenter [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractPresenter >> isWindowPresenter [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> layout [
 	self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> needRebuild [
 
 	^ needRebuild
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> needRebuild: aBoolean [
 
 	needRebuild := aBoolean
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> open [
 
 	^ self asWindow open
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openBlockedDialog [
 	"Build the widget using the default layout and display it into a dialog. 
 	 Beware: this way will not create a real modal in the sense that the user will keep the focus on other windows. If you want to make the user focus on your dialog only you should use #openModalWithSpec instead."
@@ -384,7 +386,7 @@ open
 	^ self asBlockedDialogWindow open
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openBlockedDialogWithLayout: aSpecLayout [
 	"Build the widget using the given layout and display it into a dialog. 
 	 Beware: this way will not create a real modal in the sense that the user will keep the focus on other windows. If you want to make the user focus on your dialog only you should use #openDialogAsModalWithSpec: instead."
@@ -392,7 +394,7 @@ SpAbstractPresenter >> openBlockedDialogWithLayout: aSpecLayout [
 	^ self asBlockedDialogWindow openWith: aSpecLayout
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openDialog [
 	"Build the widget using the default layout and display it into a dialog. 
 	 Beware: this way will not create a real modal in the sense that the user will keep the focus on other windows. If you want to make the user focus on your dialog only you should use #openModalWithSpec instead."
@@ -409,7 +411,7 @@ open
 	^ self asDialogWindow open
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openDialogWithLayout: aSpecLayout [
 	"Build the widget using the provided spec layout and display it into a dialog. 
 	 Beware: this way will not create a real modal in the sense that the user will 
@@ -419,43 +421,43 @@ SpAbstractPresenter >> openDialogWithLayout: aSpecLayout [
 	^ self asDialogWindow openWith: aSpecLayout
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openModal [
 
 	^ self asModalWindow open
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openModalWithLayout: aSpecLayout [
 
 	^ self asModalWindow openWith: aSpecLayout
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpAbstractPresenter >> openWithLayout: aSpecLayout [
 
 	^ self asWindow openWith: aSpecLayout
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> owner [
 
 	^ owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> owner: aPresenter [
 
 	owner := aPresenter
 ]
 
-{ #category : #'private - utilities' }
+{ #category : 'private - utilities' }
 SpAbstractPresenter >> rawValueHolderNamed: aSymbol [
 
 	^ (self class slotNamed: aSymbol) rawRead: self.
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpAbstractPresenter >> retrieveLayout: aSelector [
 	| layout |
 
@@ -467,7 +469,7 @@ SpAbstractPresenter >> retrieveLayout: aSelector [
 	^ layout
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> root [
 	"Answer root presenter of this composition."
 	
@@ -476,7 +478,7 @@ SpAbstractPresenter >> root [
 		ifNil: [ self ]
 ]
 
-{ #category : #subscription }
+{ #category : 'subscription' }
 SpAbstractPresenter >> unsubscribe: anObject [
 	"Observable slots keep subscriptions to them that can leak if not removed in certain cases."
 	| observableSlots |
@@ -491,20 +493,20 @@ SpAbstractPresenter >> unsubscribe: anObject [
 			slotValue unsubscribe: anObject ] ]
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 SpAbstractPresenter >> update: aParameter [
 
 	self changed: aParameter
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 SpAbstractPresenter >> validate [ 
 	" Validate inputs of the presenter are valid.
 	You should override me in a subclass if you need validation. 
 	"
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 SpAbstractPresenter >> validateInto: aValidationReport [
 	" Validate inputs of the presenter are valid.
 	You should override me in a subclass if you need to add validation failures
@@ -513,7 +515,7 @@ SpAbstractPresenter >> validateInto: aValidationReport [
 	self validate.
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpAbstractPresenter >> whenBuiltDo: aBlock [
 
 	self announcer 
@@ -521,7 +523,7 @@ SpAbstractPresenter >> whenBuiltDo: aBlock [
 		do: aBlock
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpAbstractPresenter >> whenWillBeBuiltDo: aBlock [
 
 	self announcer 
@@ -529,7 +531,7 @@ SpAbstractPresenter >> whenWillBeBuiltDo: aBlock [
 		do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractPresenter >> window [
 	"Answer window containing this composition."
 	
@@ -538,21 +540,21 @@ SpAbstractPresenter >> window [
 		ifFalse: [ nil ]
 ]
 
-{ #category : #'private - utilities' }
+{ #category : 'private - utilities' }
 SpAbstractPresenter >> withAdapterDo: aValuable [
 	"a convenience method to avoid verify by nil all the time"
 	
 	^ self adapter ifNotNil: aValuable
 ]
 
-{ #category : #'private - utilities' }
+{ #category : 'private - utilities' }
 SpAbstractPresenter >> withWidgetDo: aValuable [
 	"a convenience method to avoid verify by nil all the time"
 
 	^ self adapter ifNotNil: aValuable
 ]
 
-{ #category : #'private - utilities' }
+{ #category : 'private - utilities' }
 SpAbstractPresenter >> withWindowDo: aValuable [
 
 	self hasWindow ifFalse: [ ^ self ].

--- a/src/Spec2-Core/SpAbstractSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractSelectionMode.class.st
@@ -4,17 +4,19 @@ A base for selection modes.
 
 "
 Class {
-	#name : #SpAbstractSelectionMode,
-	#superclass : #Object,
+	#name : 'SpAbstractSelectionMode',
+	#superclass : 'Object',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
 	#instVars : [
 		'widget'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractSelectionMode class >> addDocumentSectionHierarchy: aBuilder [
 	
 	aBuilder newLine.
@@ -26,7 +28,7 @@ SpAbstractSelectionMode class >> addDocumentSectionHierarchy: aBuilder [
 		buildFor: self
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractSelectionMode class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -40,7 +42,7 @@ SpAbstractSelectionMode class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpAbstractSelectionMode class >> on: aWidget [
 
 	^ self new
@@ -48,27 +50,27 @@ SpAbstractSelectionMode class >> on: aWidget [
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractSelectionMode >> basicSelectIndex: indexToSelect [
 
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractSelectionMode >> includesIndex: anIndex [
 	"Answer true if selection includes element at index `anIndex`."
 
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractSelectionMode >> includesItem: anItem [
 	"Answer true if selection includes element `anItem`."
 
 	self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractSelectionMode >> indexOfItem: anItem [
 	
 	^ self model
@@ -76,27 +78,27 @@ SpAbstractSelectionMode >> indexOfItem: anItem [
 		ifAbsent: [ 0 ].
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractSelectionMode >> initialize [
 	self class initializeSlots: self.
 	super initialize
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractSelectionMode >> isEmpty [
 	"Answer true if there are no selections"
 	
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractSelectionMode >> isMultipleSelection [
 	"Answer true if this is a multiple selection mode."
 	
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractSelectionMode >> model [
 	"Answer the model used to act the selection.
 	 See also `SpAbstractListPresenter>>#model`."
@@ -104,108 +106,108 @@ SpAbstractSelectionMode >> model [
 	^ widget model
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectAll [
 	"Select all items."
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectIndex: anIndex [
 	"Select item at position `anInteger`."
 	
 	self basicSelectIndex: (self withinRangeIndex: anIndex)
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectIndexes: aCollectionOfIndexes [
 	"Select items at positions included in `aCollectionOfIndexes`."
 
 	self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectItem: anItem [
 	"Select `anItem` if it is included in model list."
 	
 	self basicSelectIndex: (self indexOfItem: anItem)
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectItems: aCollection [
 	"Select items included in `aCollection` if they are included in model list."
 	
 	self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectedIndex [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectedIndexes [
 	"Answer a collection with indexes of all selected items."
 
 	self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectedItem [
 	"Answer selected item"
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> selectedItems [
 	"Answer a collection with all selected items."
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractSelectionMode >> selectionHolder [
 	^ self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractSelectionMode >> transferSubscriptionsTo: anotherSelectionMode [
 
 	self selectionHolder transferSubscriptionsTo: anotherSelectionMode selectionHolder
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> unselectAll [
 	"Remove all selections."
 	
 	self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> unselectIndex: anInteger [ 
 	"Unselect item at position `anInteger`."
 	
 	self subclassResponsibility
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractSelectionMode >> unselectItem: anObject [
 	"Unselect item `anObject`."
 	
 	self unselectIndex: (self indexOfItem: anObject)
 ]
 
-{ #category : #subscription }
+{ #category : 'subscription' }
 SpAbstractSelectionMode >> unsubscribe: anObject [ 
 
 	(self observablePropertyNamed: #selectedIndexes) unsubscribe: anObject.
 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractSelectionMode >> whenChangedDo: aBlock [ 
 	"Inform when selection has changed. 
 	 `aBlock` has three optional arguments: 
@@ -216,18 +218,18 @@ SpAbstractSelectionMode >> whenChangedDo: aBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractSelectionMode >> widget [
 	"Returns the presenter"
 	^ widget
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractSelectionMode >> widget: anObject [
 	widget := anObject
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractSelectionMode >> withinRangeIndex: anIndex [
 	
 	| indexToSelect |

--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -3,8 +3,8 @@ A base for text presenters, it defines basic functionality common to all texts.
 
 "
 Class {
-	#name : #SpAbstractTextPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpAbstractTextPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#traits : 'SpTContextMenu',
 	#classTraits : 'SpTContextMenu classTrait',
 	#instVars : [
@@ -17,15 +17,17 @@ Class {
 		'#readSelection => ObservableSlot',
 		'#placeholder => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTextPresenter class >> isAbstract [
 	^ self = SpAbstractTextPresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTextPresenter >> acceptText: aString [
 	"Used to set the text value comming from the adapter (we do not want to re-send 
 	 this value to the adapter, hence we set it 'raw', not triggering events)"
@@ -33,31 +35,31 @@ SpAbstractTextPresenter >> acceptText: aString [
 	self property: #text rawValue: aString
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> askBeforeDiscardingEdits [
 	^ askBeforeDiscardingEdits
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> askBeforeDiscardingEdits: aBoolean [
 	askBeforeDiscardingEdits := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> clearContent [
 	"Clear current presenter contents"
 
 	self text: ''
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> clearSelection [
 	"Remove selection from the text model"
 
 	self selectionInterval: (0 to: 0)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> clearUndoManager [
 	"Clear undo manager contents"
 
@@ -66,7 +68,7 @@ SpAbstractTextPresenter >> clearUndoManager [
 		anAdapter clearUndoManager ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> cursorPositionIndex [
 	"Answer the index (position in the string) of the cursor (or nil if the cursor is nowhere)"
 	
@@ -74,7 +76,7 @@ SpAbstractTextPresenter >> cursorPositionIndex [
 		anAdapter cursorPositionIndex ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> cursorPositionIndex: index [
 	"Set cursor position index. 
 	 This method will place the cursor in the text index position requested."
@@ -82,7 +84,7 @@ SpAbstractTextPresenter >> cursorPositionIndex: index [
  	^ self withAdapterDo: [ :anAdapter | anAdapter cursorPositionIndex: index ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> enabled: aBoolean [
 	"Set if the widget is enabled (clickable or focusable)"
 
@@ -90,7 +92,7 @@ SpAbstractTextPresenter >> enabled: aBoolean [
 	self changed: #enabled: with: { aBoolean }
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> hasEditingConflicts [
 	"Return if the text zone has editing conflicts"
 
@@ -99,28 +101,28 @@ SpAbstractTextPresenter >> hasEditingConflicts [
 		ifNotNil: [:w | w hasEditingConflicts ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> hasEditingConflicts: aBoolean [
 	"Set if the text zone has editing conflicts"
 	
 	^ self changed: #hasEditingConflicts: with: { aBoolean }
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> hasUnacceptedEdits [
 	"Return if the text zone has unaccepted edits (orange corner)"
 
 	^ hasUnacceptedEdits
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> hasUnacceptedEdits: aBoolean [
 	"Return if the text zone has unaccepted edits (orange corner)"
 
 	hasUnacceptedEdits := aBoolean
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractTextPresenter >> initialize [
 	super initialize.
 
@@ -136,7 +138,7 @@ SpAbstractTextPresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> insert: aString at: positionIndex [
 	"insert `aString` into the text contents at `positionIndex`"
 	
@@ -144,7 +146,7 @@ SpAbstractTextPresenter >> insert: aString at: positionIndex [
 		anAdapter insert: aString at: positionIndex ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> insertAndSelectAfterCurrentSelection: aString [
 	"Insert `aString` at the end of current selection and select the inserted text."
 	| selectionInterval |
@@ -155,13 +157,13 @@ SpAbstractTextPresenter >> insertAndSelectAfterCurrentSelection: aString [
 	self selectionInterval: (selectionInterval last + 1 to: selectionInterval last + aString size)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTextPresenter >> isEditable [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> isForSmalltalkCode [
 
 	"self 
@@ -172,7 +174,7 @@ SpAbstractTextPresenter >> isForSmalltalkCode [
 	^ false
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> isForSmalltalkCode: aBoolean [
 	
 	"self 
@@ -181,7 +183,7 @@ SpAbstractTextPresenter >> isForSmalltalkCode: aBoolean [
 		in: #Pharo8"
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpAbstractTextPresenter >> localeChanged [
 
 	super localeChanged.
@@ -189,33 +191,33 @@ SpAbstractTextPresenter >> localeChanged [
 	
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> notify: errorMessage at: position in: sourceCode [
 
 	self changed: #notify:at:in: with: { errorMessage . position . sourceCode }
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> placeholder [
 	"Answer the place holder (also known as ghost text) for this text component."
 
 	^ placeholder
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> placeholder: aString [
 	"Set the place holder (also known as ghost text) for this text component."
 
 	placeholder := aString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTextPresenter >> rawSelection: anInterval [
 
 	self property: #selection rawValue: anInterval
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTextPresenter >> readSelection [
 
 	^ self readSelectionBlock 
@@ -223,21 +225,21 @@ SpAbstractTextPresenter >> readSelection [
 		cull: self
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> readSelectionBlock [
 	"Return the block used to calculate the text selection"
 
 	^ readSelection
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> readSelectionBlock: aBlock [
 	"Set the block used to calculate the text selection"
 
 	^ readSelection := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractTextPresenter >> registerEvents [
 
 	self whenTextChangedDo: [ self changed: #getText ].
@@ -248,14 +250,14 @@ SpAbstractTextPresenter >> registerEvents [
 	self property: #askBeforeDiscardingEdits whenChangedDo: [ :bool | self changed: #askBeforeDiscardingEdits: with: {bool} ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTextPresenter >> selectAll [
 	"Select all text"
 	
 	self changed: #selectAll with: #()
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTextPresenter >> selectLine [
 	"Select line where the cursor is placed at this moment and answer the resulting selection 
 	(See `SpAbstractTextPresenter>>#selectionInterval`). "
@@ -264,13 +266,13 @@ SpAbstractTextPresenter >> selectLine [
 	^ self selectionInterval
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> selectedClassOrMetaClass [
 
 	^ self behavior
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTextPresenter >> selectedText [ 
 	"Answer the text contained in selection interval 
 	(See `SpAbstractTextPresenter>>#selectionInterval`)"
@@ -284,7 +286,7 @@ SpAbstractTextPresenter >> selectedText [
 		to: selectionInterval last
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTextPresenter >> selectionInterval [
 	"Answer the text selection interval (an interval from start to end)."
 	
@@ -293,7 +295,7 @@ SpAbstractTextPresenter >> selectionInterval [
 	^ selection ifNil: [ 1 to: 0 ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTextPresenter >> selectionInterval: anInterval [
 	"Set the text selection interval.
 	 `anInterval` is an `Interval` from the first character selected to the end."
@@ -302,21 +304,21 @@ SpAbstractTextPresenter >> selectionInterval: anInterval [
 	selection := anInterval
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> text [
 	"Answer current text"
 
 	^ text
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTextPresenter >> text: aString [
 	"Set the text of the text presenter"
 
 	text := aString
 ]
 
-{ #category : #simulating }
+{ #category : 'simulating' }
 SpAbstractTextPresenter >> type: aString [ 
 	"For simulation: Do as if we type the given string"
 	self withAdapterDo: [ :anAdapter | 
@@ -326,7 +328,7 @@ SpAbstractTextPresenter >> type: aString [
 	self text: aString
 ]
 
-{ #category : #simulating }
+{ #category : 'simulating' }
 SpAbstractTextPresenter >> typeByChar: aString [ 
 	"For simulation: Do as if we type the given string"
 	self withAdapterDo: [ :anAdapter | 
@@ -338,24 +340,24 @@ SpAbstractTextPresenter >> typeByChar: aString [
 		self text: (self text ifNil: [ '' ]), (each asString) ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> wantsVisualFeedback [
 	^ wantsVisualFeedback
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> wantsVisualFeedback: aBoolean [
 	wantsVisualFeedback := aBoolean
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractTextPresenter >> whenAcceptBlockChangedDo: aBlock [
 	"Set a block to perform when the accept block changed"
 	
 	self property: #actionToPerform whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTextPresenter >> whenPlaceholderChangedDo: aBlock [
 	"Inform when placeholder has been changed (See `SpAbstractTextPresenter>>#placeholder:`).
 	 `aBlock` receives two optional arguments 
@@ -365,14 +367,14 @@ SpAbstractTextPresenter >> whenPlaceholderChangedDo: aBlock [
 	self property: #placeholder whenChangedDo: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTextPresenter >> whenReadSelectionIsChangedDo: aBlock [
 	"Set a block to perform when the read selection block changed"
 
 	self property: #readSelection whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTextPresenter >> whenResetDo: aBlock [
 	"Inform when a 'reset' event is triggered.
 	 It will react when user presses <meta+l> key (this is for historical reasons)."
@@ -382,7 +384,7 @@ SpAbstractTextPresenter >> whenResetDo: aBlock [
 		toAction: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTextPresenter >> whenSelectionChangedDo: aBlock [
 	"Inform when selection changed. 
 	 `aBlock` receives two optional arguments 
@@ -392,7 +394,7 @@ SpAbstractTextPresenter >> whenSelectionChangedDo: aBlock [
 	self property: #selection whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTextPresenter >> whenSubmitDo: aBlock [
 	"Inform a 'submit' event has been triggered. 
 	 It will react when user presses <meta+s> key (this is for historical reasons) and (in case of text fields) with <cr>.
@@ -401,7 +403,7 @@ SpAbstractTextPresenter >> whenSubmitDo: aBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTextPresenter >> whenTextChangedDo: aBlock [
 	"Inform when text has been changed (a character has been enter or `SpAbstractTextPresenter>>text:` has been called)
 	 `aBlock` receives two optional arguments 

--- a/src/Spec2-Core/SpAbstractTreeFilter.class.st
+++ b/src/Spec2-Core/SpAbstractTreeFilter.class.st
@@ -3,7 +3,9 @@ I am an abstract class for tree filters.
 My children should propose a filter for tree nodes.
 "
 Class {
-	#name : #SpAbstractTreeFilter,
-	#superclass : #Object,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpAbstractTreeFilter',
+	#superclass : 'Object',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -2,8 +2,8 @@
 A base for tree presenters, it defines basic functionality common to all trees.
 "
 Class {
-	#name : #SpAbstractTreePresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpAbstractTreePresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#traits : 'SpTHaveWrappingScrollBars + SpTContextMenu + SpTSearchable + SpTAlignableColumn',
 	#classTraits : 'SpTHaveWrappingScrollBars classTrait + SpTContextMenu classTrait + SpTSearchable classTrait + SpTAlignableColumn classTrait',
 	#instVars : [
@@ -14,16 +14,18 @@ Class {
 		'#selectionMode',
 		'#verticalAlignment'
 	],
-	#category : #'Spec2-Core-Widgets-Tree'
+	#category : 'Spec2-Core-Widgets-Tree',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tree'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenter class >> isAbstract [
 
 	^ super isAbstract or: [ self = SpAbstractTreePresenter ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> activateOnDoubleClick [
 	"Configure the list to trigger activation on double click.
 	 An element on a list can be 'activated', meaning it will trigger an event to execute an 
@@ -34,7 +36,7 @@ SpAbstractTreePresenter >> activateOnDoubleClick [
 	activateOnSingleClick := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> activateOnSingleClick [
 	"Configure the list to trigger activation on single click.
 	 An element on a list can be 'activated', meaning it will trigger an event to execute an 
@@ -45,7 +47,7 @@ SpAbstractTreePresenter >> activateOnSingleClick [
 	activateOnSingleClick := true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenter >> activatesOnDoubleClick [
 	"Answer true if activation event is triggered on double click"
 
@@ -56,7 +58,7 @@ SpAbstractTreePresenter >> activatesOnDoubleClick [
 	^ activateOnSingleClick not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenter >> activatesOnSingleClick [
 	"Answer true if activation event is triggered on single click"
 
@@ -67,27 +69,27 @@ SpAbstractTreePresenter >> activatesOnSingleClick [
 	^ activateOnSingleClick
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> beMultipleSelection [
 	"Enable multiple selection."
 
 	self selectionMode: (SpTreeMultipleSelectionMode on: self)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> beSingleSelection [
 	"Enable single selection (this is the default)."
 	
 	self selectionMode: (SpTreeSingleSelectionMode on: self)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> children [
 
 	^ childrenBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> children: aBlock [
 	"Set a block to answer the children of a node when it is expanded.
 	 `aBlock` receives one argument, the node element to expand.
@@ -96,13 +98,13 @@ SpAbstractTreePresenter >> children: aBlock [
 	childrenBlock := aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> childrenFor: anObject [ 
 
 	^ self children value: anObject
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 SpAbstractTreePresenter >> clickAtPath: aPath [
 
 	self selectPaths: { aPath }.
@@ -111,7 +113,7 @@ SpAbstractTreePresenter >> clickAtPath: aPath [
 	self doActivateAtPath: aPath
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> collapseAll [
 	"Collapse all nodes of the tree. "
 
@@ -119,7 +121,7 @@ SpAbstractTreePresenter >> collapseAll [
 		anAdapter collapseAll ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> collapsePath: aPath [
 	"Collapse the tree path.
 	`aPath` is the path to collapse. A path is an array of node indexes (e.g. #(1 2 3))"
@@ -128,7 +130,7 @@ SpAbstractTreePresenter >> collapsePath: aPath [
 		anAdapter collapsePath: aPath ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> disableActivationDuring: aBlock [
 	| oldActivate |
 	
@@ -138,7 +140,7 @@ SpAbstractTreePresenter >> disableActivationDuring: aBlock [
 		activationBlock := oldActivate ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> doActivateAtPath: aPath [
 	"Activate only if there is an item at that position"
 
@@ -148,7 +150,7 @@ SpAbstractTreePresenter >> doActivateAtPath: aPath [
 		yourself)
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 SpAbstractTreePresenter >> doubleClickAtPath: aPath [
 	self selectPath: aPath.
 	
@@ -156,7 +158,7 @@ SpAbstractTreePresenter >> doubleClickAtPath: aPath [
 	self doActivateAtPath: aPath
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> expandAll [
 	"Expand all nodes of the tree. 
 	 WARNING: If your tree is big, this operation can be slow."
@@ -165,7 +167,7 @@ SpAbstractTreePresenter >> expandAll [
 		anAdapter expandAll ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> expandPath: aPath [
 	"Expand the tree path.
 	`aPath` is the path to expand. A path is an array of node indexes (e.g. #(1 2 3))"
@@ -174,7 +176,7 @@ SpAbstractTreePresenter >> expandPath: aPath [
 		anAdapter expandPath: aPath ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> expandRoots [
 	"Expand all roots of the tree"
 
@@ -182,7 +184,7 @@ SpAbstractTreePresenter >> expandRoots [
 		anAdapter expandRoots ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractTreePresenter >> initialize [
 	
 	super initialize.
@@ -190,21 +192,21 @@ SpAbstractTreePresenter >> initialize [
 	self initializeTHaveWrappingScrollBars
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenter >> isActiveOnDoubleClick [
 	"Answer true if activation event is triggered on double click"
 
 	^ activateOnSingleClick not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenter >> isActiveOnSingleClick [
 	"Answer true if activation event is triggered on single click"
 
 	^ activateOnSingleClick
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenter >> isExpanded: aPath [ 
 
 	self withAdapterDo: [ :anAdapter |  
@@ -213,7 +215,7 @@ SpAbstractTreePresenter >> isExpanded: aPath [
 	^ false
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> itemAt: index of: anArray then: path [
 	"dives into elements of tree to find the one that corresponds to path"
 	| element |
@@ -229,7 +231,7 @@ SpAbstractTreePresenter >> itemAt: index of: anArray then: path [
 			element ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> itemAtPath: anArray [
 	
 	self withAdapterDo: [ :anAdapter | 
@@ -241,21 +243,21 @@ SpAbstractTreePresenter >> itemAtPath: anArray [
 		then: anArray allButFirst
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> itemAtPath: anArray ifAbsent: aBlock [
 	^ [ self itemAtPath: anArray ]
 		on: SubscriptOutOfBounds
 		do: [ aBlock value ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> items: aCollection [
 	"Set the roots of a tree. This is a convenience method, synonym of `SpTreePresenter>>#roots:`"
 
 	self roots: aCollection
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> pathIndexOf: anArrayOfElements [
 
 	^ self 
@@ -263,7 +265,7 @@ SpAbstractTreePresenter >> pathIndexOf: anArrayOfElements [
 		in: self roots
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> pathIndexOf: pathArray in: aCollection [ 
 	| pathElement |
 	
@@ -276,7 +278,7 @@ SpAbstractTreePresenter >> pathIndexOf: pathArray in: aCollection [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> pathItemOf: aPath [
 	"answer an array of items following a path. 
 	 e.g. #(1 2 3) = { item1. item2. item3 }"
@@ -286,7 +288,7 @@ SpAbstractTreePresenter >> pathItemOf: aPath [
 		in: self roots
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> pathItemOf: pathArray in: aCollection [ 
 	| pathElement |
 	
@@ -299,7 +301,7 @@ SpAbstractTreePresenter >> pathItemOf: pathArray in: aCollection [
 
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> refresh [
 	"Forces a refresh of the tree. 
 	 This is useful when some model contents has changed, but we do not want to reset the whole list 
@@ -308,21 +310,21 @@ SpAbstractTreePresenter >> refresh [
 	self withAdapterDo: [ :anAdapter | anAdapter refreshTree ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractTreePresenter >> registerEvents [
 
 	self whenMenuChangedDo: [ 
 		self withAdapterDo: [ :anAdapter | anAdapter updateMenu ] ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> roots [
 	"Answer the roots of the tree"
 
 	^ roots
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> roots: aCollection [
 	"Set the roots of the tree table.
 	 This is the starting point from where the whole tree will be shown."
@@ -331,13 +333,13 @@ SpAbstractTreePresenter >> roots: aCollection [
 	self selection clearSelection
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> searchValueOf: item [ 
 
 	^ item asString
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectItem: anItem [
 	"Select `anItem` if it is included in model list.
 	 It does not scrolls to selected element."
@@ -345,7 +347,7 @@ SpAbstractTreePresenter >> selectItem: anItem [
 	self selection selectItem: anItem
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectItems: aListOfItem [
 	"Select items included in `aCollection` if they are included in model list.
 	 NOTE: In single selection mode it will select the first element of `aCollection` 
@@ -354,7 +356,7 @@ SpAbstractTreePresenter >> selectItems: aListOfItem [
 	self selection selectItems: aListOfItem
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectPath: aPath [
 	"Selects element in `aPath`
 	`aPath` is the path to select. A path is an array of node indexes (e.g. #(1 2 3)).
@@ -363,7 +365,7 @@ SpAbstractTreePresenter >> selectPath: aPath [
 	self selection selectPath: aPath
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectPath: aPath scrollToSelection: shouldScrollToSelection [
 	"Selects element in `aPath`
 	`aPath` is the path to select. A path is an array of node indexes (e.g. #(1 2 3)).
@@ -378,13 +380,13 @@ SpAbstractTreePresenter >> selectPath: aPath scrollToSelection: shouldScrollToSe
 		shouldScrollToSelection ifTrue: [ adapter scrollToSelection ] ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectPathByItems: pathArray [
 
 	self selectPathByItems: pathArray scrollToSelection: false
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectPathByItems: pathArray scrollToSelection: aBoolean [
 	"IMPORTANT: Scrolling to selection just has sense when the widget is already shown, because before it 
 	 is displayed it does not has real bounds. In morphic (and gtk) it has a minimal extent assigned, 
@@ -400,7 +402,7 @@ SpAbstractTreePresenter >> selectPathByItems: pathArray scrollToSelection: aBool
 		scrollToSelection: aBoolean
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectPaths: pathArray [
 	"Selects all elements in `pathsArray``
 	`pathsArray` is an array of paths. A path is an array of node indexes (e.g. #(1 2 3))"
@@ -408,21 +410,21 @@ SpAbstractTreePresenter >> selectPaths: pathArray [
 	self selection selectPaths: pathArray
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectedItem [
 	"Return selected item."
 	
 	^ self selection selectedItem
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selectedItems [
 	"Return all the selected items in the case of a multiple selection list"
 	
 	^ self selection selectedItems
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> selection [
 	"Answer the selection object (an instance of `SpSingleSelectionMode` or `SpMultipleSelectionMode`).
 	 This is not the item selected, but the selection container (it may contain one or many selected 
@@ -431,7 +433,7 @@ SpAbstractTreePresenter >> selection [
 	^ selectionMode value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> selectionMode: aMode [
 	
 	selectionMode ifNotNil: [ 
@@ -439,21 +441,21 @@ SpAbstractTreePresenter >> selectionMode: aMode [
 	selectionMode := aMode
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> unselectAll [ 
 	"Remove all selections"
 
 	self selection unselectAll
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> unselectItem: anItem [
 	"Remove selection of element `anItem`"
 
 	self selection unselectItem: anItem
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpAbstractTreePresenter >> unselectPath: aPath [
 	"Unselects element in `aPath`
 	`aPath` is the path to select. A path is an array of node indexes (e.g. #(1 2 3))"
@@ -461,7 +463,7 @@ SpAbstractTreePresenter >> unselectPath: aPath [
 	self selection unselectPath: aPath
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractTreePresenter >> updateRootsKeepingSelection: aCollection [ 
 	"Update tree roots keeping current selection. 
 	 WARNING: aCollection must includes the elements selected."
@@ -475,12 +477,12 @@ SpAbstractTreePresenter >> updateRootsKeepingSelection: aCollection [
 			self selectPaths: (selectedPaths collect: [ :each | self pathIndexOf: each ]) ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTreePresenter >> verticalAlignment [
 	^ verticalAlignment
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenActivatedDo: aBlock [
 	"Inform when an element has been 'activated'. 
 	 `aBlock` receives one argument (a selection object, see `SpAbstractSelectionMode`)"
@@ -488,7 +490,7 @@ SpAbstractTreePresenter >> whenActivatedDo: aBlock [
 	activationBlock := aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenMultiSelectionChangedDo: aBlockClosure [ 
 	"Inform when selection mode has changed. 
 	 `aBlock` has three optional arguments: 
@@ -499,7 +501,7 @@ SpAbstractTreePresenter >> whenMultiSelectionChangedDo: aBlockClosure [
 	selectionMode whenChangedDo: aBlockClosure 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenRootsChangedDo: aBlockClosure [ 
 	"Inform when roots have changed. 
 	 `aBlock` has three optional arguments: 
@@ -510,7 +512,7 @@ SpAbstractTreePresenter >> whenRootsChangedDo: aBlockClosure [
 	self property: #roots whenChangedDo: aBlockClosure
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenSelectedIndexChangedDo: aBlock [ 
 	"Inform when selected index has changed. 
 	 `aBlock` receives one optional argument (the new element)."
@@ -519,7 +521,7 @@ SpAbstractTreePresenter >> whenSelectedIndexChangedDo: aBlock [
 		aBlock cull: selection first ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenSelectedItemChangedDo: aBlock [
 	"Inform when selected index has changed. 
 	 `aBlock` receives one optional argument (the new element)."
@@ -528,7 +530,7 @@ SpAbstractTreePresenter >> whenSelectedItemChangedDo: aBlock [
 		aBlock cull: (selection ifNotNil: [ selection selectedItem ]) ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenSelectionChangedDo: aBlock [ 
 	"Inform when selection has changed. 
 	 `aBlock` has three optional arguments: 
@@ -539,7 +541,7 @@ SpAbstractTreePresenter >> whenSelectionChangedDo: aBlock [
 	self selection whenChangedDo: [ aBlock cull: selectionMode ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenShowColumnHeadersChangedDo: aBlock [ 
 	"Inform when showColumnHeaders property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpAbstractTreeSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractTreeSelectionMode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpAbstractTreeSelectionMode,
-	#superclass : #Object,
+	#name : 'SpAbstractTreeSelectionMode',
+	#superclass : 'Object',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
 	#instVars : [
 		'#selection => ObservableSlot',
 		'#presenter'
 	],
-	#category : #'Spec2-Core-Widgets-Tree'
+	#category : 'Spec2-Core-Widgets-Tree',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tree'
 }
 
-{ #category : #'accessing method dictionary' }
+{ #category : 'accessing method dictionary' }
 SpAbstractTreeSelectionMode class >> on: aPresenter [
 
 	^ self new
@@ -18,13 +20,13 @@ SpAbstractTreeSelectionMode class >> on: aPresenter [
 		yourself
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> clearSelection [
 
 	selection := #()
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractTreeSelectionMode >> initialize [
 	self class initializeSlots: self.
 	selection := #().
@@ -32,29 +34,29 @@ SpAbstractTreeSelectionMode >> initialize [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreeSelectionMode >> isEmpty [
 	
 	^ selection isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTreeSelectionMode >> isMultipleSelection [
 	^ false
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> itemNotFoundAction [
 	"ignore. we do not change the selection"
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> pathOf: anItem [
 	^ (self pathOf: anItem from: presenter roots)
 		ifNil: [ 	NotFound signalFor: anItem in: presenter roots ]
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> pathOf: anItem from: aCollection [
     | index |
 
@@ -68,19 +70,19 @@ SpAbstractTreeSelectionMode >> pathOf: anItem from: aCollection [
     ^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTreeSelectionMode >> presenter: aPresenter [
 	presenter := aPresenter
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> selectItem: anItem [
 	[ self selectPath: (self pathOf: anItem) ]
 		on: NotFound
 		do: [ self itemNotFoundAction ]
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> selectItems: aListOfItems [
 	aListOfItems do: 
 		[ :each |
@@ -89,7 +91,7 @@ SpAbstractTreeSelectionMode >> selectItems: aListOfItems [
 			do: [ "ignore. we do not change the selection" ] ]
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> selectPath: aPath [
 	"Select a node in the tree by providing a list of indexes.
 	Example:
@@ -108,17 +110,17 @@ SpAbstractTreeSelectionMode >> selectPath: aPath [
 	self subclassResponsibility
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> selectPaths: pathArray [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTreeSelectionMode >> selectedItem [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTreeSelectionMode >> selectedItemsInPath [
 	"Answer the items on a path, not just the indexes."
 	| path |
@@ -131,48 +133,48 @@ SpAbstractTreeSelectionMode >> selectedItemsInPath [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTreeSelectionMode >> selectedPaths [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTreeSelectionMode >> selectionHolder [
 
 	^ self observablePropertyNamed: #selection
 ]
 
-{ #category : #transfering }
+{ #category : 'transfering' }
 SpAbstractTreeSelectionMode >> transferSubscriptionsTo: anotherSelectionMode [
 
 	self selectionHolder transferSubscriptionsTo: anotherSelectionMode selectionHolder
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> unselectAll [
 
 	self clearSelection
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> unselectItem: anItem [
 	[ self unselectPath: (self pathOf: anItem) ]
 	on: NotFound 
 	do: [ "ignore. nothing to unselect" ]
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpAbstractTreeSelectionMode >> unselectPath: aPath [
 	self subclassResponsibility
 ]
 
-{ #category : #subscription }
+{ #category : 'subscription' }
 SpAbstractTreeSelectionMode >> unsubscribe: anObject [ 
 
 	(self observablePropertyNamed: #selection) unsubscribe: anObject
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractTreeSelectionMode >> whenChangedDo: aBlock [
 	
 	self property: #selection whenChangedDo: aBlock

--- a/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
@@ -2,8 +2,8 @@
 SpAbstractBasicWidget is an abstract class for basic widgets.
 "
 Class {
-	#name : #SpAbstractWidgetPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpAbstractWidgetPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'#borderWidth => ObservableSlot',
 		'#borderColor => ObservableSlot',
@@ -16,22 +16,24 @@ Class {
 		'#acceptDrop => ObservableSlot',
 		'#deferredActions'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpAbstractWidgetPresenter class >> adapterName [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> addDocumentExtraSections: aBuilder [
 	"a hook to add extra sections when needed"
 	
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> addDocumentSection: aBuilder label: label methods: methods [
 	
 	methods ifEmpty: [ ^ self ].
@@ -44,7 +46,7 @@ SpAbstractWidgetPresenter class >> addDocumentSection: aBuilder label: label met
 				aBuilder monospace: (each methodClass name, '>>#', each selector) ] ] ]
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> addDocumentSectionExampleCode: aBuilder [
 	| exampleCode |
 
@@ -57,7 +59,7 @@ SpAbstractWidgetPresenter class >> addDocumentSectionExampleCode: aBuilder [
 	aBuilder codeblock: exampleCode
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> addDocumentSectionFactoryMethod: aBuilder [
 	| selector |
 
@@ -74,7 +76,7 @@ SpAbstractWidgetPresenter class >> addDocumentSectionFactoryMethod: aBuilder [
 	aBuilder text: '.'
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> addDocumentSectionHierarchy: aBuilder [
 	
 	aBuilder newLine.
@@ -85,7 +87,7 @@ SpAbstractWidgetPresenter class >> addDocumentSectionHierarchy: aBuilder [
 		buildFor: self
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> addDocumentSectionTransmissions: aBuilder [
 	| transmissions defaultInputPort defaultOutputPort |
 	
@@ -111,13 +113,13 @@ SpAbstractWidgetPresenter class >> addDocumentSectionTransmissions: aBuilder [
 					ifTrue: [ aBuilder monospace: ' (default)' ] ] ] ]
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpAbstractWidgetPresenter class >> defaultLayout [
 
 	^ SpAbstractWidgetLayout for: self adapterName
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> documentExampleCode [
 
 	| exampleMethod |
@@ -128,25 +130,25 @@ SpAbstractWidgetPresenter class >> documentExampleCode [
 	^ (exampleMethod sourceCode lines allButFirst reject: [ :each | each trimLeft beginsWith: '<' ]) asStringWithCr trimmed "Remove method name" "Remove pragmas"
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> documentExampleCodeSelector [
 	
 	^ #example
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> documentExamplesProtocol [
 	
 	^ #'*Spec2-Examples'
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> documentFactoryMethodSelector [
 
 	^ nil
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -160,34 +162,34 @@ SpAbstractWidgetPresenter class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAbstractWidgetPresenter class >> documentTransmissionsProtocol [
 
 	^ #'*Spec2-Transmission'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractWidgetPresenter class >> isAbstract [
 	^ self = SpAbstractWidgetPresenter
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractWidgetPresenter class >> isWindow [
 
 	^ false
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> acceptDrop [
 	^ acceptDrop
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> acceptDrop: aBlock [
 	acceptDrop := aBlock
 ]
 
-{ #category : #'private - deferring' }
+{ #category : 'private - deferring' }
 SpAbstractWidgetPresenter >> addDeferredAction: aBlock [
 	"Deferred actions are one-shot actions, performed during adapter initialization."
 
@@ -195,7 +197,7 @@ SpAbstractWidgetPresenter >> addDeferredAction: aBlock [
 	deferredActions := deferredActions copyWith: aBlock
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpAbstractWidgetPresenter >> basicBuildAdapterWithLayout: aSpecLayout [
 	| builtAdapter |
 
@@ -204,84 +206,84 @@ SpAbstractWidgetPresenter >> basicBuildAdapterWithLayout: aSpecLayout [
 	^ builtAdapter
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> borderColor [
 	"Return the border color"
 
 	^ borderColor
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> borderColor: aColor [
 	"Set the border width"
 
 	borderColor := aColor
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> borderWidth [
 	"Return the border width"
 
 	^ borderWidth
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> borderWidth: anInteger [
 	"Set the border width"
 
 	borderWidth := anInteger
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> color [
 	^ color
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> color: aColor [
 	^ color := aColor
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractWidgetPresenter >> defaultColor [
 	^ self theme backgroundColor
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractWidgetPresenter >> disable [
 	"Disable the presenter"
 	
 	self enabled: false
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> dragEnabled [
 	^ dragEnabled
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> dragEnabled: aBoolean [
 	dragEnabled := aBoolean
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> dropEnabled [
 	^ dropEnabled
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> dropEnabled: aBoolean [
 	dropEnabled := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractWidgetPresenter >> enable [
 	"Enable the presenter"
 	
 	self enabled: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractWidgetPresenter >> enabled: aBooleanOrValuable [
 	"Set if the widget is enabled (clickable or focusable).
 	This can either be a boolean or a block returning a boolean."
@@ -289,21 +291,21 @@ SpAbstractWidgetPresenter >> enabled: aBooleanOrValuable [
 	enabled := aBooleanOrValuable
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractWidgetPresenter >> help [
 	"Return the help string to display as help (tooltip) to the user."
 
 	^ help
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAbstractWidgetPresenter >> help: aString [
 	"Set a help string to display to the user if he let the mouse over the widget (a tooltip)."
 
 	help := aString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractWidgetPresenter >> initialize [
 	super initialize.
 
@@ -320,14 +322,14 @@ SpAbstractWidgetPresenter >> initialize [
 		self withWidgetDo: [ :w | w update: #dropEnabled: with: { value } ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractWidgetPresenter >> isEnabled [
 	"Answer if presenter is enabled"
 
 	^ enabled
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpAbstractWidgetPresenter >> localeChanged [
 
 	super localeChanged.
@@ -335,7 +337,7 @@ SpAbstractWidgetPresenter >> localeChanged [
 	
 ]
 
-{ #category : #'private - deferring' }
+{ #category : 'private - deferring' }
 SpAbstractWidgetPresenter >> processDeferredActions [
 
 	deferredActions ifNil: [ ^ self ].
@@ -345,12 +347,12 @@ SpAbstractWidgetPresenter >> processDeferredActions [
 		deferredActions := nil ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractWidgetPresenter >> replaceLayoutWith: aLayout [
 	"do nothing, widgets do not have updatable layouts"
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpAbstractWidgetPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	self canTakeKeyboardFocus ifFalse: [ ^ self ].
@@ -359,7 +361,7 @@ SpAbstractWidgetPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes 
 	aBlock value: self
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpAbstractWidgetPresenter >> traversePresentersDo: aBlock excluding: excludes [
 	"Terminate"
 
@@ -367,31 +369,31 @@ SpAbstractWidgetPresenter >> traversePresentersDo: aBlock excluding: excludes [
 	aBlock value: self
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> wantsDrop [
 	^ wantsDrop
 ]
 
-{ #category : #'drag and drop' }
+{ #category : 'drag and drop' }
 SpAbstractWidgetPresenter >> wantsDrop: aBlock [
 	wantsDrop := aBlock
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> whenBorderColorChangedDo: aBlock [
 	"Set a block to be performed when the brder width changed"
 
 	self property: #borderColor whenChangedDo: aBlock
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpAbstractWidgetPresenter >> whenBorderWidthChangedDo: aBlock [
 	"Set a block to be performed when the brder width changed"
 
 	self property: #borderWidth whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractWidgetPresenter >> whenEnabledChangedDo: aBlock [
 	"Inform when enabled status has changed. 
 	 `aBlock` has three optional arguments: 
@@ -402,7 +404,7 @@ SpAbstractWidgetPresenter >> whenEnabledChangedDo: aBlock [
 	self property: #enabled whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAbstractWidgetPresenter >> whenHelpChangedDo: aBlock [
 	"Inform when help property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -413,7 +415,7 @@ SpAbstractWidgetPresenter >> whenHelpChangedDo: aBlock [
 	self property: #help whenChangedDo: aBlock
 ]
 
-{ #category : #'private - deferring' }
+{ #category : 'private - deferring' }
 SpAbstractWidgetPresenter >> withAdapterPerformOrDefer: aBlock [ 
 
 	self adapter 

--- a/src/Spec2-Core/SpActionBarPresenter.class.st
+++ b/src/Spec2-Core/SpActionBarPresenter.class.st
@@ -5,27 +5,29 @@ This is like the small action bars at the bottom of a list in most mobile apps (
 
 "
 Class {
-	#name : #SpActionBarPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpActionBarPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'items'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpActionBarPresenter class >> adapterName [
 
 	^ #ActionBarAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpActionBarPresenter class >> documentFactoryMethodSelector [
 
 	^ #newActionBar
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpActionBarPresenter >> add: aButtonPresenter [
 	"Add a button presenter to be shown at the start of the action bar (at the left)."
 	
@@ -35,7 +37,7 @@ SpActionBarPresenter >> add: aButtonPresenter [
 		add: aButtonPresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpActionBarPresenter >> addLast: aButtonPresenter [
 	"Add a button presenter to be shown at the end of the action bar (at the right)."
 
@@ -45,14 +47,14 @@ SpActionBarPresenter >> addLast: aButtonPresenter [
 		add: aButtonPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpActionBarPresenter >> initialize [
 
 	super initialize.
 	items := Dictionary new asValueHolder
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpActionBarPresenter >> items [
 	"Answer a dictionary containing the pairs:  
 		#start -> anOrderedCollection, 
@@ -61,19 +63,19 @@ SpActionBarPresenter >> items [
 	^ items value
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpActionBarPresenter >> presenters [
 
 	^ self items values flattened
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpActionBarPresenter >> presentersInFocusOrder [
 
 	^ self presenters
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpActionBarPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	self presentersInFocusOrder do: [ :each |

--- a/src/Spec2-Core/SpActivatedSelection.class.st
+++ b/src/Spec2-Core/SpActivatedSelection.class.st
@@ -2,15 +2,17 @@
 I'm a simple object to wrap a selected item for an `SpActivationTransform`.
 "
 Class {
-	#name : #SpActivatedSelection,
-	#superclass : #Object,
+	#name : 'SpActivatedSelection',
+	#superclass : 'Object',
 	#instVars : [
 		'value'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpActivatedSelection class >> newValue: anObject [
 
 	^ self new 
@@ -18,19 +20,19 @@ SpActivatedSelection class >> newValue: anObject [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpActivatedSelection >> selectedItem [
 
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpActivatedSelection >> value [
 
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpActivatedSelection >> value: anObject [
 
 	value := anObject

--- a/src/Spec2-Core/SpActivationHolder.class.st
+++ b/src/Spec2-Core/SpActivationHolder.class.st
@@ -2,63 +2,65 @@
 A holder to allow activation (and selection) events to be listened by more than one object (otherwise, it can hold just one)
 "
 Class {
-	#name : #SpActivationHolder,
-	#superclass : #Object,
+	#name : 'SpActivationHolder',
+	#superclass : 'Object',
 	#instVars : [
 		'subscriptions'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 SpActivationHolder >> add: aBlock [
 
 	subscriptions := subscriptions copyWith: aBlock
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationHolder >> cull: arg [
 
 	subscriptions do: [ :each | 
 		each cull: arg ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationHolder >> cull: firstArg cull: secondArg [
 
 	subscriptions do: [ :each | 
 		each cull: firstArg cull: secondArg ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationHolder >> cull: firstArg cull: secondArg cull: thirdArg [
 
 	subscriptions do: [ :each | 
 		each cull: firstArg cull: secondArg cull: thirdArg ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpActivationHolder >> initialize [
 
 	super initialize.
 	subscriptions := #()
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationHolder >> value: arg [
 
 	subscriptions do: [ :each | 
 		each value: arg ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationHolder >> value: firstArg value: secondArg [
 
 	subscriptions do: [ :each | 
 		each value: firstArg value: secondArg ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationHolder >> value: firstArg value: secondArg value: thirdArg [
 
 	subscriptions do: [ :each | 

--- a/src/Spec2-Core/SpActivationTransform.class.st
+++ b/src/Spec2-Core/SpActivationTransform.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #SpActivationTransform,
-	#superclass : #Object,
+	#name : 'SpActivationTransform',
+	#superclass : 'Object',
 	#instVars : [
 		'block',
 		'transformBlock'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpActivationTransform class >> activateDo: aBlock transform: transformBlock [
 
 	^ self new
@@ -17,13 +19,13 @@ SpActivationTransform class >> activateDo: aBlock transform: transformBlock [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpActivationTransform >> block: aBlock [
 
 	block := aBlock
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationTransform >> cull: aSelection [
 
 	^ block cull: (SpActivatedSelection new 
@@ -31,13 +33,13 @@ SpActivationTransform >> cull: aSelection [
 		yourself).
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpActivationTransform >> transformBlock: aBlock [
 
 	transformBlock := aBlock
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SpActivationTransform >> value: aSelection [
 
 	^ self cull: aSelection

--- a/src/Spec2-Core/SpAdapterBindings.class.st
+++ b/src/Spec2-Core/SpAdapterBindings.class.st
@@ -4,27 +4,29 @@ I am an abstract class
 I am used to link a spec-oriented adapter name to a framework specific adapter class name
 "
 Class {
-	#name : #SpAdapterBindings,
-	#superclass : #Object,
+	#name : 'SpAdapterBindings',
+	#superclass : 'Object',
 	#instVars : [
 		'bindings'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAdapterBindings class >> isAbstract [ 
 
 	^ self name = #SpAdapterBindings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAdapterBindings >> abstractAdapterClass [
 	
 	^ self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SpAdapterBindings >> adapterClass: aSymbol [ 
 	
 	^ Smalltalk 
@@ -32,12 +34,12 @@ SpAdapterBindings >> adapterClass: aSymbol [
 		ifAbsent: [ aSymbol ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAdapterBindings >> allAdapters [
 	^ self abstractAdapterClass allAdapters
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAdapterBindings >> initialize [
 
 	super initialize.
@@ -46,7 +48,7 @@ SpAdapterBindings >> initialize [
 	self initializeBindings
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAdapterBindings >> initializeBindings [
 	
 	self allAdapters do: [ :each |
@@ -59,7 +61,7 @@ SpAdapterBindings >> initializeBindings [
 				put: each name ] ]	
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpAdapterBindings >> translateSymbol: aSymbol [
 
 	^ bindings 

--- a/src/Spec2-Core/SpApplication.class.st
+++ b/src/Spec2-Core/SpApplication.class.st
@@ -42,8 +42,8 @@ MyApplication>>start
 
 "
 Class {
-	#name : #SpApplication,
-	#superclass : #Object,
+	#name : 'SpApplication',
+	#superclass : 'Object',
 	#instVars : [
 		'backend',
 		'windows',
@@ -55,29 +55,31 @@ Class {
 	#classVars : [
 		'DefaultApplication'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication class >> defaultApplication [
 
 	^ DefaultApplication ifNil: [ DefaultApplication := SpNullApplication new ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplication class >> defaultApplication: anApplication [
 	"To be used for testing purposes"
 
 	DefaultApplication := anApplication
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication class >> defaultBackendName [
 
 	^ #Morphic
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpApplication class >> example1 [
 	"This example shows how to change the backend of an application" 
 	| app |
@@ -88,7 +90,7 @@ SpApplication class >> example1 [
 	app run
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpApplication class >> example2 [
 	"This example shows how to change the backend of an application" 
 	| app |
@@ -100,13 +102,13 @@ SpApplication class >> example2 [
 	app run
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplication >> adapterBindings [
 	
 	^ self backend adapterBindings
 ]
 
-{ #category : #'ui - dialogs' }
+{ #category : 'ui - dialogs' }
 SpApplication >> alert: aString [
 	"Displays an inform dialog, for more configurable version please use `self application newInform title: ....`."
 
@@ -116,7 +118,7 @@ SpApplication >> alert: aString [
 		  openModal
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 SpApplication >> backend [
 
 	^ backend ifNil: [ 
@@ -124,7 +126,7 @@ SpApplication >> backend [
 		backend ]
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpApplication >> close [
 	
 	self 
@@ -133,13 +135,13 @@ SpApplication >> close [
 	self closeAllWindows
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication >> closeAllWindows [
 
 	self windows do: [ :each | each close ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 SpApplication >> configuration [
 
 	^ configuration ifNil: [ 
@@ -147,7 +149,7 @@ SpApplication >> configuration [
 		configuration ]
 ]
 
-{ #category : #'ui - dialogs' }
+{ #category : 'ui - dialogs' }
 SpApplication >> confirm: aString [
 	"Displays a confirm dialog, for more configurable version please use `self application newConfirm title: ....`."
 
@@ -157,37 +159,37 @@ SpApplication >> confirm: aString [
 		  openModal
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpApplication >> defaultBlockedDialogWindowPresenterClass [
 
 	^ SpBlockedDialogWindowPresenter
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpApplication >> defaultDialogWindowPresenterClass [
 		
 	^ SpDialogWindowPresenter
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpApplication >> defaultModalWindowPresenterClass [
 		
 	^ SpModalWindowPresenter
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 SpApplication >> defaultWindowPresenterClass [
 		
 	^ SpWindowPresenter
 ]
 
-{ #category : #ui }
+{ #category : 'ui' }
 SpApplication >> defer: aBlock [
 	"doInUIThread: ?"
 	self backend defer: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplication >> ensureBackend [
 
 	backend ifNotNil: [ ^ backend ].
@@ -195,7 +197,7 @@ SpApplication >> ensureBackend [
 	^ backend
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplication >> ensureConfiguration [
 
 	configuration ifNotNil: [ ^ configuration ].
@@ -205,50 +207,50 @@ SpApplication >> ensureConfiguration [
 	^ configuration
 ]
 
-{ #category : #ui }
+{ #category : 'ui' }
 SpApplication >> forceDefer: aBlock [
 	"doInUIThread: ?"
 	self backend forceDefer: aBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpApplication >> hasWindow: aWindow [
 	
 	^ self windows includes: aWindow
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpApplication >> iconManager [
 	"we have icon providers for this"
 	^ iconManager ifNil: [ iconManager := Smalltalk ui icons ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpApplication >> iconManager: anIconManager [
 
 	iconManager := anIconManager 
 	
 ]
 
-{ #category : #'accessing - resources' }
+{ #category : 'accessing - resources' }
 SpApplication >> iconNamed: aString [
 
 	^ self iconProvider iconNamed: aString
 ]
 
-{ #category : #'accessing - resources' }
+{ #category : 'accessing - resources' }
 SpApplication >> iconProvider [
 
 	^ iconProvider ifNil: [ iconProvider := self newIconProvider ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication >> iconProvider: anIconProvider [
 
 	iconProvider := anIconProvider
 ]
 
-{ #category : #'ui - dialogs' }
+{ #category : 'ui - dialogs' }
 SpApplication >> inform: aString [
 	"Displays an inform dialog, for more configurable version please use `self application newInform title: ....`."
 
@@ -258,51 +260,51 @@ SpApplication >> inform: aString [
 		  openModal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication >> locale [
 
 	^ Locale current
 ]
 
-{ #category : #factory }
+{ #category : 'factory' }
 SpApplication >> new: aPresenter [
 	"a synonym for #newPresenter:"
 	
 	^ self newPresenter: aPresenter
 ]
 
-{ #category : #'private - factory' }
+{ #category : 'private - factory' }
 SpApplication >> newIconProvider [
 	
 	^ SpPharoThemeIconProvider new
 ]
 
-{ #category : #factory }
+{ #category : 'factory' }
 SpApplication >> newPresenter: aPresenterClass [
 
 	^ aPresenterClass newApplication: self
 ]
 
-{ #category : #'ui - notifying' }
+{ #category : 'ui - notifying' }
 SpApplication >> notify: aSpecNotification [
 	"how notifications are handled depends on the backend"
 
 	aSpecNotification dispatchTo: self backend
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> properties [
 
 	^ properties ifNil: [ properties := SmallDictionary new ]
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey [
 
 	^ self properties at: aKey
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey ifAbsent: aBlock [
 
 	^ self properties 
@@ -310,7 +312,7 @@ SpApplication >> propertyAt: aKey ifAbsent: aBlock [
 		ifAbsent: aBlock
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey ifAbsentPut: aBlock [
 
 	^ self properties 
@@ -318,7 +320,7 @@ SpApplication >> propertyAt: aKey ifAbsentPut: aBlock [
 		ifAbsentPut: aBlock
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey ifPresent: aBlock [
 
 	^ self properties
@@ -326,7 +328,7 @@ SpApplication >> propertyAt: aKey ifPresent: aBlock [
 		ifPresent: aBlock
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey ifPresent: aBlock ifAbsent: absentBlock [
 
 	^ self properties
@@ -335,7 +337,7 @@ SpApplication >> propertyAt: aKey ifPresent: aBlock ifAbsent: absentBlock [
 		ifAbsent: absentBlock
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey ifPresent: aBlock ifAbsentPut: absentBlock [
 
 	^ self properties
@@ -344,7 +346,7 @@ SpApplication >> propertyAt: aKey ifPresent: aBlock ifAbsentPut: absentBlock [
 		ifAbsentPut: absentBlock
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 SpApplication >> propertyAt: aKey put: aValue [
 
 	^ self properties 
@@ -352,13 +354,13 @@ SpApplication >> propertyAt: aKey put: aValue [
 		put: aValue
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplication >> registerWindow: aWindow [
 
 	self windows add: aWindow
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication >> reset [ 
 
 	self closeAllWindows.
@@ -366,25 +368,25 @@ SpApplication >> reset [
 	self backend resetAdapterBindings
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpApplication >> run [ 
 
 	self start
 ]
 
-{ #category : #'ui - dialogs' }
+{ #category : 'ui - dialogs' }
 SpApplication >> selectDirectoryTitle: aString [
 
 	^ self backend selectDirectoryTitle: aString
 ]
 
-{ #category : #'ui - dialogs' }
+{ #category : 'ui - dialogs' }
 SpApplication >> selectFileTitle: aString [
 
 	^ self backend selectFileTitle: aString
 ]
 
-{ #category : #ui }
+{ #category : 'ui' }
 SpApplication >> showWaitCursorWhile: aBlock [
 
 	self backend 
@@ -392,7 +394,7 @@ SpApplication >> showWaitCursorWhile: aBlock [
 		inApplication: self
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpApplication >> start [ 
 	"This method is a hook automatically invoked. Override this method to start your application.
 	Pay attention that this is your responsibility to configure the presenter you are opening
@@ -408,7 +410,7 @@ SpApplication >> start [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication >> topWindow [
 
 	^ self windows 
@@ -416,19 +418,19 @@ SpApplication >> topWindow [
 		ifNone: [ nil ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplication >> unregisterWindow: aWindow [
 
 	self windows remove: aWindow ifAbsent: [  ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 SpApplication >> useBackend: aName [
 
 	self useBackend: aName with: nil
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 SpApplication >> useBackend: aName with: aConfiguration [
 
 	backend := SpApplicationBackend findBackendNamed: aName.
@@ -436,13 +438,13 @@ SpApplication >> useBackend: aName with: aConfiguration [
 	configuration configure: self
 ]
 
-{ #category : #windows }
+{ #category : 'windows' }
 SpApplication >> windowClosed: aWindowPresenter [
 	
 	self unregisterWindow: aWindowPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplication >> windows [
 	
 	^ windows ifNil: [ windows := Set new ]

--- a/src/Spec2-Core/SpApplicationBackend.class.st
+++ b/src/Spec2-Core/SpApplicationBackend.class.st
@@ -7,21 +7,23 @@ Backends define different things from an application:
 - ...
 "
 Class {
-	#name : #SpApplicationBackend,
-	#superclass : #Object,
+	#name : 'SpApplicationBackend',
+	#superclass : 'Object',
 	#instVars : [
 		'adapterBindings'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplicationBackend class >> backendName [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplicationBackend class >> findBackendNamed: aName [
 
 	^ (self allSubclasses 
@@ -29,38 +31,38 @@ SpApplicationBackend class >> findBackendNamed: aName [
 		new	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplicationBackend >> adapterBindings [
 
 	^ adapterBindings
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpApplicationBackend >> adapterBindingsClass [
 
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplicationBackend >> defaultConfigurationFor: anApplication [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpApplicationBackend >> initialize [
 
 	super initialize.
 	self resetAdapterBindings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplicationBackend >> name [
 
 	^ self class backendName
 ]
 
-{ #category : #'ui - notifying' }
+{ #category : 'ui - notifying' }
 SpApplicationBackend >> notify: aSpecNotification [
 
 	aSpecNotification type 
@@ -68,31 +70,31 @@ SpApplicationBackend >> notify: aSpecNotification [
 		on: self
 ]
 
-{ #category : #'ui - notifying' }
+{ #category : 'ui - notifying' }
 SpApplicationBackend >> notifyError: aSpecNotification [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'ui - notifying' }
+{ #category : 'ui - notifying' }
 SpApplicationBackend >> notifyInfo: aSpecNotification [
 
 	self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpApplicationBackend >> resetAdapterBindings [
 
 	adapterBindings := self adapterBindingsClass new
 ]
 
-{ #category : #'ui - dialogs' }
+{ #category : 'ui - dialogs' }
 SpApplicationBackend >> selectFileTitle: aString [
 
 	self subclassResponsibility
 ]
 
-{ #category : #ui }
+{ #category : 'ui' }
 SpApplicationBackend >> showWaitCursorWhile: aBlock inApplication: anApplication [
 
 	self subclassResponsibility

--- a/src/Spec2-Core/SpApplicationConfiguration.class.st
+++ b/src/Spec2-Core/SpApplicationConfiguration.class.st
@@ -10,12 +10,14 @@ A configuration takes the responsibility to prepare an application to run proper
 See also: `SpMorphicConfiguration` and `SpGtkConfiguration`
 "
 Class {
-	#name : #SpApplicationConfiguration,
-	#superclass : #Object,
-	#category : #'Spec2-Core-Base'
+	#name : 'SpApplicationConfiguration',
+	#superclass : 'Object',
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpApplicationConfiguration >> configure: anApplication [
 	"Override this to add your application configuration"
 	
@@ -24,19 +26,19 @@ SpApplicationConfiguration >> configure: anApplication [
 		configuration: self
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpApplicationConfiguration >> configureOSX: anApplication [
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpApplicationConfiguration >> configureUnix: anApplication [
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpApplicationConfiguration >> configureWindows: anApplication [
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpApplicationConfiguration >> reset [
 	"a hook to allow users to reset its configuration"
 ]

--- a/src/Spec2-Core/SpAthensPresenter.class.st
+++ b/src/Spec2-Core/SpAthensPresenter.class.st
@@ -4,42 +4,44 @@ Users can draw their own vectorial images  and render them as part of a Spec bas
 
 "
 Class {
-	#name : #SpAthensPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpAthensPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#traits : 'SpTContextMenu',
 	#classTraits : 'SpTContextMenu classTrait',
 	#instVars : [
 		'#drawBlock => ObservableSlot',
 		'#surfaceExtent => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Athens'
+	#category : 'Spec2-Core-Widgets-Athens',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Athens'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpAthensPresenter class >> adapterName [
 	^ #AthensAdapter
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SpAthensPresenter class >> defaultSurfaceExtent [
 
 	^ 300@300
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpAthensPresenter class >> documentFactoryMethodSelector [
 
 	^ #newAthens
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAthensPresenter >> drawBlock [
 	"Answer the block used to draw into an athens canvas."
 
 	^ drawBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAthensPresenter >> drawBlock: aBlock [
 	"Set the block used to draw into the athens canvas.
 	 `aBlock` receives one argument, the `AthensCanvas` instance used to draw the surface.
@@ -48,34 +50,34 @@ SpAthensPresenter >> drawBlock: aBlock [
 	drawBlock := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAthensPresenter >> initialize [
 
 	super initialize.
 	self surfaceExtent: self class defaultSurfaceExtent
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAthensPresenter >> redraw [
 
 	self withAdapterDo: [ :anAdapter | anAdapter redraw ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAthensPresenter >> surfaceExtent [
 	"Anwer the surface extent (the size the surface will have)"
 
 	^ surfaceExtent
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpAthensPresenter >> surfaceExtent: anExtent [
 	"Set surface extent (a point) to contain the athens drawing."
 
 	surfaceExtent := anExtent
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAthensPresenter >> whenDrawBlockChangedDo: aBlock [
 	"Inform when drawBlock has changed. 
 	 `aBlock` has three optional arguments: 
@@ -86,7 +88,7 @@ SpAthensPresenter >> whenDrawBlockChangedDo: aBlock [
 	self property: #drawBlock whenChangedDo: aBlock 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpAthensPresenter >> whenExtentChangedDo: aBlock [
 	"Inform when the Athens surface extent has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpBaseEventDefinition.class.st
+++ b/src/Spec2-Core/SpBaseEventDefinition.class.st
@@ -4,31 +4,33 @@ My children will define (and install in an adaptor/widget) a specific kind of lo
 
 "
 Class {
-	#name : #SpBaseEventDefinition,
-	#superclass : #Object,
+	#name : 'SpBaseEventDefinition',
+	#superclass : 'Object',
 	#instVars : [
 		'action'
 	],
-	#category : #'Spec2-Core-Base-Event'
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 SpBaseEventDefinition class >> do: aBlock [
 
 	^ self new action: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBaseEventDefinition >> action [
 	^ action
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBaseEventDefinition >> action: anObject [
 	action := anObject
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpBaseEventDefinition >> installOn: anAdapter target: aWidget [
 
 	self subclassResponsibility

--- a/src/Spec2-Core/SpBindings.class.st
+++ b/src/Spec2-Core/SpBindings.class.st
@@ -8,12 +8,14 @@ Example:
 ```
 "
 Class {
-	#name : #SpBindings,
-	#superclass : #DynamicVariable,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpBindings',
+	#superclass : 'DynamicVariable',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBindings >> default [
 	^ (self class environment at: #SpMorphicAdapterBindings) new
 ]

--- a/src/Spec2-Core/SpBlockedDialogWindowPresenter.class.st
+++ b/src/Spec2-Core/SpBlockedDialogWindowPresenter.class.st
@@ -27,12 +27,14 @@ SomePresenter >> initializeDialogWindow: aDialogPresenter
 ```
 "
 Class {
-	#name : #SpBlockedDialogWindowPresenter,
-	#superclass : #SpDialogWindowPresenter,
-	#category : #'Spec2-Core-Windows'
+	#name : 'SpBlockedDialogWindowPresenter',
+	#superclass : 'SpDialogWindowPresenter',
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpBlockedDialogWindowPresenter class >> adapterName [
 	^ #BlockedDialogWindowAdapter
 ]

--- a/src/Spec2-Core/SpButtonBarPresenter.class.st
+++ b/src/Spec2-Core/SpButtonBarPresenter.class.st
@@ -4,28 +4,30 @@ A button bar can be used to provide a consistent layout of buttons throughout yo
 
 "
 Class {
-	#name : #SpButtonBarPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpButtonBarPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'items',
 		'placeAtStart'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpButtonBarPresenter class >> adapterName [
 
 	^ #ButtonBarAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpButtonBarPresenter class >> documentFactoryMethodSelector [
 
 	^ #newButtonBar
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonBarPresenter >> add: aButtonPresenter [
 	"Add `aButtonPresenter` to the button list."
 	
@@ -33,13 +35,13 @@ SpButtonBarPresenter >> add: aButtonPresenter [
 	items add: aButtonPresenter
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpButtonBarPresenter >> canTakeKeyboardFocus [
 
 	^ false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpButtonBarPresenter >> initialize [
 
 	super initialize.
@@ -47,28 +49,28 @@ SpButtonBarPresenter >> initialize [
 	self placeAtEnd
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpButtonBarPresenter >> isPlaceAtEnd [
 	"Answer when the button bar will place buttons at the end of the bar"
 
 	^ self isPlaceAtStart not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpButtonBarPresenter >> isPlaceAtStart [
 	"Answer when the button bar will place buttons at the start of the bar"
 
 	^ placeAtStart
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonBarPresenter >> items [
 	"Answer list of buttons."
 
 	^ items value
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonBarPresenter >> items: aCollectionOfButtonPresenters [
 	"Set buttons to show, taking elements in `aCollectionOfButtonPresenters`."
 
@@ -78,21 +80,21 @@ SpButtonBarPresenter >> items: aCollectionOfButtonPresenters [
 	items addAll: aCollectionOfButtonPresenters
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonBarPresenter >> placeAtEnd [
 	"Indicate the button bar will place buttons at the end of the bar (arranged to the right)"
 
 	placeAtStart := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonBarPresenter >> placeAtStart [ 
 	"Indicate the button bar will place buttons at the start of the bar (arranged to the left)"
 
 	placeAtStart := true
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpButtonBarPresenter >> presenters [
 	
 	^ self items

--- a/src/Spec2-Core/SpButtonPresenter.class.st
+++ b/src/Spec2-Core/SpButtonPresenter.class.st
@@ -3,8 +3,8 @@ A button who executes an action when pressed.
 
 "
 Class {
-	#name : #SpButtonPresenter,
-	#superclass : #SpAbstractButtonPresenter,
+	#name : 'SpButtonPresenter',
+	#superclass : 'SpAbstractButtonPresenter',
 	#traits : 'SpTContextMenu',
 	#classTraits : 'SpTContextMenu classTrait',
 	#instVars : [
@@ -15,35 +15,37 @@ Class {
 		'#shortcut => ObservableSlot',
 		'#state => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpButtonPresenter class >> adapterName [
 
 	^ #ButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newButton
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpButtonPresenter class >> title [
 
 	^ 'Button'
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonPresenter >> action [
 	"Answer the block performed when the button is clicked."
 
 	^ action
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonPresenter >> action: aBlock [
 	"Set the block performed when the button is clicked. 
 	 `aBlock` receives zero arguments."
@@ -51,17 +53,17 @@ SpButtonPresenter >> action: aBlock [
 	action := aBlock
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> askBeforeChanging [
 	^ askBeforeChanging
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> askBeforeChanging: aBoolean [
 	askBeforeChanging := aBoolean
 ]
 
-{ #category : #simulating }
+{ #category : 'simulating' }
 SpButtonPresenter >> click [
 
 	"I emulate the click from the presenter point of view.
@@ -72,24 +74,24 @@ SpButtonPresenter >> click [
 	^ self performAction
 ]
 
-{ #category : #'private - focus' }
+{ #category : 'private - focus' }
 SpButtonPresenter >> ensureKeyBindingsFor: widget [
 
 	super ensureKeyBindingsFor: widget.
 	self shortcut ifNotNil: [ :s | self registerShortcut: s ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> font [
 	^ font
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> font: aFont [
 	font := aFont
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpButtonPresenter >> initialize [
 	super initialize.
 
@@ -114,7 +116,7 @@ SpButtonPresenter >> initialize [
 	self color: nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpButtonPresenter >> performAction [
 
 	self action value.
@@ -122,7 +124,7 @@ SpButtonPresenter >> performAction [
 	actionPerformed := nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpButtonPresenter >> registerShortcut: newShortcut [
 	| receiver |
 	
@@ -133,14 +135,14 @@ SpButtonPresenter >> registerShortcut: newShortcut [
 		toAction: [ self performAction ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonPresenter >> shortcut [
 	"Answer the shortcut used to trigger button's action from keyboard."
 
 	^ shortcut
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpButtonPresenter >> shortcut: aShortcut [
 	"Set the shortcut used to trigger button's action from keyboard.
 	 `aShortcut` needs to be an instance of `KMKeyCombination` (or polymorphic with it), 
@@ -149,27 +151,27 @@ SpButtonPresenter >> shortcut: aShortcut [
 	shortcut := aShortcut
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpButtonPresenter >> shortcutCharacter [
 
 	^ self shortcut ifNotNil: [ :s | s platformCharacter ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> state [
 
 	self flag: #TODO. "To remove or move to morphic extension"
 	^ state
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> state: aBoolean [
 	"set if the button is highlighted"
 
 	state := aBoolean
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpButtonPresenter >> unregisterShortcut: oldShortcut [
 	| receiver |
 	receiver := self window.
@@ -179,7 +181,7 @@ SpButtonPresenter >> unregisterShortcut: oldShortcut [
 		removeKeyCombination: oldShortcut 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpButtonPresenter >> whenActionChangedDo: aBlock [
 	"Inform when action block has been changed. 
 	 `aBlock` receives two optional arguments: 
@@ -189,7 +191,7 @@ SpButtonPresenter >> whenActionChangedDo: aBlock [
 	self property: #action whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpButtonPresenter >> whenActionPerformedDo: aBlock [
 	"Inform that the button has been aclicked, and its action has been performed.
 	 `aBlock` receive zero arguments."
@@ -197,7 +199,7 @@ SpButtonPresenter >> whenActionPerformedDo: aBlock [
 	self property: #actionPerformed whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpButtonPresenter >> whenActivatedDo: aBlock [
 	"Inform that the button has been aclicked, and its action has been performed.
 	 `aBlock` receive zero arguments.
@@ -206,14 +208,14 @@ SpButtonPresenter >> whenActivatedDo: aBlock [
 	^ self whenActionPerformedDo: aBlock 
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> whenFontChangedDo: aBlock [
 	"set a block to perform after that the button has been aclicked, and its action performed"
 
 	self property: #font whenChangedDo: aBlock
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpButtonPresenter >> whenStateChangedDo: aBlock [
 	"set a block to perform after that the button has been aclicked, and its action performed"
 

--- a/src/Spec2-Core/SpCheckBoxPresenter.class.st
+++ b/src/Spec2-Core/SpCheckBoxPresenter.class.st
@@ -3,36 +3,38 @@ A Checkbox Button that can be activated/deactivated.
 
 "
 Class {
-	#name : #SpCheckBoxPresenter,
-	#superclass : #SpAbstractFormButtonPresenter,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpCheckBoxPresenter',
+	#superclass : 'SpAbstractFormButtonPresenter',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpCheckBoxPresenter class >> adapterName [
 
 	^ #CheckBoxAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpCheckBoxPresenter class >> documentFactoryMethodSelector [
 
 	^ #newCheckBox
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpCheckBoxPresenter class >> title [
 
 	^ 'Checkbox Button'
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpCheckBoxPresenter >> labelOnLeft [
 
 	^ self changed: #labelOnLeft with: #()
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpCheckBoxPresenter >> labelOnRight [
 
 	^ self changed: #labelOnRight with: #()

--- a/src/Spec2-Core/SpCheckBoxTableColumn.class.st
+++ b/src/Spec2-Core/SpCheckBoxTableColumn.class.st
@@ -11,29 +11,31 @@ SpCheckBoxTableColumn
 ```
 "
 Class {
-	#name : #SpCheckBoxTableColumn,
-	#superclass : #SpTableColumn,
+	#name : 'SpCheckBoxTableColumn',
+	#superclass : 'SpTableColumn',
 	#instVars : [
 		'onActivation',
 		'onDeactivation'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpCheckBoxTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitCheckboxColumn: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCheckBoxTableColumn >> onActivation [
 	"Answer the block to be executed when a checkbox is activated (marked)"
 
 	^ onActivation
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCheckBoxTableColumn >> onActivation: aBlock [
 	"Set the block to be executed when a checkbox is activated (marked). 
 	 `aBlock` receives one argument, the element in which the checkbox acts."
@@ -41,14 +43,14 @@ SpCheckBoxTableColumn >> onActivation: aBlock [
 	onActivation := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCheckBoxTableColumn >> onDeactivation [
 	"Answer the block to be executed when a checkbox is deactivated (unmarked)"
 
 	^ onDeactivation
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCheckBoxTableColumn >> onDeactivation: aBlock [
 	"Set the block to be executed when a checkbox is deactivated (unmarked). 
 	 `aBlock` receives one argument, the element in which the checkbox acts."

--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -4,8 +4,8 @@ A collection model to be used with list presenters (`SpAbstractListPresenter` an
 This model receives a `collection` of elements to be served to the list.
 "
 Class {
-	#name : #SpCollectionListModel,
-	#superclass : #Object,
+	#name : 'SpCollectionListModel',
+	#superclass : 'Object',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
 	#instVars : [
@@ -13,10 +13,12 @@ Class {
 		'#collection',
 		'#sorting => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpCollectionListModel class >> on: aCollection [
 	
 	^ self new
@@ -24,7 +26,7 @@ SpCollectionListModel class >> on: aCollection [
 		yourself
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 SpCollectionListModel >> add: anItem [
 	
 	collection := collection copyWith: anItem.
@@ -34,30 +36,30 @@ SpCollectionListModel >> add: anItem [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> announcer [ 
 
 	^ announcer ifNil: [ announcer := Announcer new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> at: anIndex [
 
 	^ collection at: anIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> at: anIndex ifAbsent: aBlock [
 
 	^ collection at: anIndex ifAbsent: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> collection [
 	^ collection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> collection: anObject [
 	| oldValue |
 
@@ -70,43 +72,43 @@ SpCollectionListModel >> collection: anObject [
 		newValue: collection)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpCollectionListModel >> hasElementAt: index [
 
 	^ self size >= index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> indexOf: anIndex ifAbsent: aBlock [
 
 	^ collection indexOf: anIndex ifAbsent: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpCollectionListModel >> initialize [
 	self class initializeSlots: self.
 	super initialize
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpCollectionListModel >> isEmpty [
 
 	^ collection isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> items [
 
 	^ collection
 ]
 
-{ #category : #refreshing }
+{ #category : 'refreshing' }
 SpCollectionListModel >> refreshList [
 
 	self sortingBlock ifNotNil: [ :aSortFunction | collection := collection sorted: aSortFunction ]
 ]
 
-{ #category : #collection }
+{ #category : 'collection' }
 SpCollectionListModel >> removeAll [
 	
 	collection := #().
@@ -116,24 +118,24 @@ SpCollectionListModel >> removeAll [
 		
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCollectionListModel >> size [
 
 	^ collection size
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpCollectionListModel >> sortingBlock [
 	^ sorting
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpCollectionListModel >> sortingBlock: aBlock [
 	sorting := aBlock.
 	self refreshList
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpCollectionListModel >> whenChangedDo: aBlock [
 	
 	self announcer 
@@ -146,7 +148,7 @@ SpCollectionListModel >> whenChangedDo: aBlock [
 		for: self
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpCollectionListModel >> whenSortingBlockChangedDo: aBlock [
 
 	self property: #sorting whenChangedDo: aBlock

--- a/src/Spec2-Core/SpColumnAlignment.class.st
+++ b/src/Spec2-Core/SpColumnAlignment.class.st
@@ -1,37 +1,39 @@
 Class {
-	#name : #SpColumnAlignment,
-	#superclass : #Object,
+	#name : 'SpColumnAlignment',
+	#superclass : 'Object',
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpColumnAlignment class >> center [
 
 	^ SpColumnAlignmentCenter uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpColumnAlignment class >> left [
 
 	^ SpColumnAlignmentLeft uniqueInstance
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpColumnAlignment class >> new [
 
 	self error: 'Use #uniqueInstance'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpColumnAlignment class >> right [
 
 	^ SpColumnAlignmentRight uniqueInstance
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpColumnAlignment class >> uniqueInstance [
 
 	self = SpColumnAlignment 

--- a/src/Spec2-Core/SpColumnAlignmentCenter.class.st
+++ b/src/Spec2-Core/SpColumnAlignmentCenter.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #SpColumnAlignmentCenter,
-	#superclass : #SpColumnAlignment,
-	#category : #'Spec2-Core-Widgets-Table'
+	#name : 'SpColumnAlignmentCenter',
+	#superclass : 'SpColumnAlignment',
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }

--- a/src/Spec2-Core/SpColumnAlignmentLeft.class.st
+++ b/src/Spec2-Core/SpColumnAlignmentLeft.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #SpColumnAlignmentLeft,
-	#superclass : #SpColumnAlignment,
-	#category : #'Spec2-Core-Widgets-Table'
+	#name : 'SpColumnAlignmentLeft',
+	#superclass : 'SpColumnAlignment',
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }

--- a/src/Spec2-Core/SpColumnAlignmentRight.class.st
+++ b/src/Spec2-Core/SpColumnAlignmentRight.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #SpColumnAlignmentRight,
-	#superclass : #SpColumnAlignment,
-	#category : #'Spec2-Core-Widgets-Table'
+	#name : 'SpColumnAlignmentRight',
+	#superclass : 'SpColumnAlignment',
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }

--- a/src/Spec2-Core/SpComponentListPresenter.class.st
+++ b/src/Spec2-Core/SpComponentListPresenter.class.st
@@ -4,30 +4,32 @@ When you do not have a list of elements that can be presented as a single list o
 
 "
 Class {
-	#name : #SpComponentListPresenter,
-	#superclass : #SpAbstractListPresenter,
-	#category : #'Spec2-Core-Widgets-Table'
+	#name : 'SpComponentListPresenter',
+	#superclass : 'SpAbstractListPresenter',
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpComponentListPresenter class >> adapterName [
 	^ #ComponentListAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpComponentListPresenter class >> documentFactoryMethodSelector [
 
 	^ #newComponentList
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpComponentListPresenter >> addPresenter: aPresenter [
 	
 	aPresenter owner: self.
 	self model add: aPresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpComponentListPresenter >> doActivateAtIndex: index [
 	
 	"Activate only if there is an item at that position"
@@ -38,21 +40,21 @@ SpComponentListPresenter >> doActivateAtIndex: index [
 		yourself)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComponentListPresenter >> includes: aPresenter [
 	"Answer true when the presenter includes `aPresenter` as part of its items." 
 
 	^ self presenters includes: aPresenter  
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComponentListPresenter >> isEmpty [
 	"Answer true if presenter list is empty."	
 
 	^ self presenters isEmpty
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpComponentListPresenter >> items: aSequenceableCollection [ 
 	"Set the items of the list. 
 	 `aSequenceableCollection` is a list of presenters OR a list of elements that understand 
@@ -64,7 +66,7 @@ SpComponentListPresenter >> items: aSequenceableCollection [
 			yourself ])
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpComponentListPresenter >> presenters [
 	"Answer the presenters of the list.
 	 This is a synonym of `SpAbstractListPresenter>>#items`"
@@ -72,7 +74,7 @@ SpComponentListPresenter >> presenters [
 	^ self items
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpComponentListPresenter >> presenters: aSequenceableCollection [ 
 	"Set the list of presenters that will be the items to show in the component list.
 	 This is a synonym of `SpAbstractListPresenter>>#items:`
@@ -81,7 +83,7 @@ SpComponentListPresenter >> presenters: aSequenceableCollection [
 	^ self items: aSequenceableCollection
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpComponentListPresenter >> whenPresentersChangedDo: aBlock [
 	"Inform when the presenter list changed (See `SpComponentListPresenter>>#presenters:`.
 	 `aBlock` receive 3 optional arguments: 

--- a/src/Spec2-Core/SpCompositeIconProvider.class.st
+++ b/src/Spec2-Core/SpCompositeIconProvider.class.st
@@ -8,28 +8,30 @@ A typical usage is:
 ```
 "
 Class {
-	#name : #SpCompositeIconProvider,
-	#superclass : #SpIconProvider,
+	#name : 'SpCompositeIconProvider',
+	#superclass : 'SpIconProvider',
 	#instVars : [
 		'providers'
 	],
-	#category : #'Spec2-Core-IconProvider'
+	#category : 'Spec2-Core-IconProvider',
+	#package : 'Spec2-Core',
+	#tag : 'IconProvider'
 }
 
-{ #category : #copying }
+{ #category : 'copying' }
 SpCompositeIconProvider >> , aProvider [
 
 	self addProvider: aProvider.
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCompositeIconProvider >> addProvider: anIconProvider [
 
 	providers := providers copyWith: anIconProvider
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCompositeIconProvider >> iconNamed: aName ifAbsent: aBlock [
 
 	self providers do: [ :each |
@@ -39,14 +41,14 @@ SpCompositeIconProvider >> iconNamed: aName ifAbsent: aBlock [
 	^ aBlock value
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpCompositeIconProvider >> initialize [
 
 	super initialize.
 	providers := #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCompositeIconProvider >> providers [
 	
 	^ providers

--- a/src/Spec2-Core/SpCompositeTableColumn.class.st
+++ b/src/Spec2-Core/SpCompositeTableColumn.class.st
@@ -24,15 +24,17 @@ SpCompositeTableColumn new
 ```
 "
 Class {
-	#name : #SpCompositeTableColumn,
-	#superclass : #SpTableColumn,
+	#name : 'SpCompositeTableColumn',
+	#superclass : 'SpTableColumn',
 	#instVars : [
 		'columns'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpCompositeTableColumn class >> title: aString withAll: aCollection [
 
 	^ self new
@@ -41,7 +43,7 @@ SpCompositeTableColumn class >> title: aString withAll: aCollection [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpCompositeTableColumn class >> with: column [
 
 	^ self new
@@ -49,7 +51,7 @@ SpCompositeTableColumn class >> with: column [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpCompositeTableColumn class >> with: column1 with: column2 [ 
 
 	^ self new
@@ -58,7 +60,7 @@ SpCompositeTableColumn class >> with: column1 with: column2 [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpCompositeTableColumn class >> with: column1 with: column2 with: column3 [
 
 	^ self new
@@ -68,7 +70,7 @@ SpCompositeTableColumn class >> with: column1 with: column2 with: column3 [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpCompositeTableColumn class >> withAll: aCollection [
 
 	^ self new
@@ -76,34 +78,34 @@ SpCompositeTableColumn class >> withAll: aCollection [
 		yourself
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpCompositeTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitCompositeColumn: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCompositeTableColumn >> addAllColumns: aCollection [ 
 	"Add all columns contained in `aCollection` to the composed columns."
 	
 	aCollection do: [ :each | self addColumn: each ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCompositeTableColumn >> addColumn: aTableColumn [ 
 	"Add a column to the composed columns."
 	
 	columns add: aTableColumn
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpCompositeTableColumn >> columns [
 	"Answer the columns composing this composite."
 
 	^ columns
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpCompositeTableColumn >> initialize [
 	
 	super initialize.
@@ -111,7 +113,7 @@ SpCompositeTableColumn >> initialize [
 	columns := OrderedCollection new: 2
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpCompositeTableColumn >> isComposite [
 	"Answer if this is a composite column. 
 	 For this class, answer will always be true."

--- a/src/Spec2-Core/SpDialogWindowPresenter.class.st
+++ b/src/Spec2-Core/SpDialogWindowPresenter.class.st
@@ -29,8 +29,8 @@ SomePresenter >> initializeDialogWindow: aDialogPresenter
 ```
 "
 Class {
-	#name : #SpDialogWindowPresenter,
-	#superclass : #SpWindowPresenter,
+	#name : 'SpDialogWindowPresenter',
+	#superclass : 'SpWindowPresenter',
 	#instVars : [
 		'buttons',
 		'okAction',
@@ -38,23 +38,25 @@ Class {
 		'cancelled',
 		'defaultButton'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpDialogWindowPresenter class >> adapterName [
 
 	^ #DialogWindowAdapter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDialogWindowPresenter >> addButton: aButtonPresenter [
 
 	buttons add: aButtonPresenter.
 	^ aButtonPresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> addButton: aString do: aBlock [
 	"Adds button logic to dialog.
 	 This method will add a standard button to the button bar of the dialog, having `aString` 
@@ -71,7 +73,7 @@ SpDialogWindowPresenter >> addButton: aString do: aBlock [
 		yourself)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDialogWindowPresenter >> addDefaultButton: aButtonPresenter [
 	"Adds button logic to dialog."
 	
@@ -80,7 +82,7 @@ SpDialogWindowPresenter >> addDefaultButton: aButtonPresenter [
 	^ defaultButton
 ]
 
-{ #category : #NOTUSED }
+{ #category : 'NOTUSED' }
 SpDialogWindowPresenter >> addDefaultButton: aString do: aBlock [
 	"Adds button logic to dialog."
 	
@@ -89,7 +91,7 @@ SpDialogWindowPresenter >> addDefaultButton: aString do: aBlock [
 	^ defaultButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> beCancel [
 	"Set the status of this dialog as 'cancelled'. 
 	 See `SpDialogWindowPresenter>>#isCancelled`"
@@ -97,7 +99,7 @@ SpDialogWindowPresenter >> beCancel [
 	cancelled := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> beOk [
 	"Set the status of this dialog as 'Ok'. 
 	 See `SpDialogWindowPresenter>>#isOk`"
@@ -105,7 +107,7 @@ SpDialogWindowPresenter >> beOk [
 	cancelled := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> buttons [ 
 	"Answer an OrderedCollection that contains all defined buttons. 
 	 Default action will always be the last one."
@@ -115,7 +117,7 @@ SpDialogWindowPresenter >> buttons [
 	^ buttons 
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> cancelAction [
 	"Answer the defined cancel action (the one that is executed when pressed 'cancel' button 
 	 by default). In initialization phase, cancel action is defined as: 
@@ -129,14 +131,14 @@ SpDialogWindowPresenter >> cancelAction [
 	^ cancelAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> cancelAction: aBlock [
 	"Set the action to execute when 'cancel' button is pressed."
 
 	cancelAction := aBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDialogWindowPresenter >> cancelled [
 	"Answer true if dialog has been cancelled. 
 	 This is a synonym of `SpDialogWindowPresenter>>#cancelled`"
@@ -144,14 +146,14 @@ SpDialogWindowPresenter >> cancelled [
 	^ cancelled
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDialogWindowPresenter >> executeDefaultAction [
 
 	defaultButton ifNil: [ ^ self ].
 	defaultButton action cull: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDialogWindowPresenter >> initialize [
 
 	super initialize.
@@ -160,7 +162,7 @@ SpDialogWindowPresenter >> initialize [
 	self initializeDefaultActions
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDialogWindowPresenter >> initializeDefaultActions [
 	"default ok/cancel actions. 
 	 this is just for backwards compatibility"
@@ -172,14 +174,14 @@ SpDialogWindowPresenter >> initializeDefaultActions [
 		self close ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDialogWindowPresenter >> initializeWindow [
 		
 	super initializeWindow.
 	self presenter initializeDialogWindow: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDialogWindowPresenter >> isButtonEnabled: aButtonName [
 	| button |
 	button := self buttons detect: [ :aButton | aButton label = aButtonName ].
@@ -187,27 +189,27 @@ SpDialogWindowPresenter >> isButtonEnabled: aButtonName [
 		
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDialogWindowPresenter >> isCancelled [
 	"Answer true if dialog has been cancelled."
 
 	^ cancelled
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDialogWindowPresenter >> isDialog [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDialogWindowPresenter >> isOk [
 	"Answer true if dialog has been accepted."
 
 	^ self isCancelled not
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> okAction [
 	"Answer the defined ok action (the one that is executed when pressed 'ok' button 
 	 by default). In initialization phase, ok action is defined as: 
@@ -221,14 +223,14 @@ SpDialogWindowPresenter >> okAction [
 	^ okAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> okAction: aBlock [
 	"Set the action to execute when 'ok' button is pressed."
 
 	okAction := aBlock
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpDialogWindowPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	super traverseInFocusOrderDo: aBlock excluding: excludes.
@@ -236,7 +238,7 @@ SpDialogWindowPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 		each traverseInFocusOrderDo: aBlock excluding: excludes ]	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> triggerCancelAction [
 	"Trigger defined cancel action. 
 	 See `SpDialogWindowPresenter>>#cancelAction:`"
@@ -245,7 +247,7 @@ SpDialogWindowPresenter >> triggerCancelAction [
 	cancelAction cull: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDialogWindowPresenter >> triggerOkAction [
 	"Trigger defined ok action. 
 	 See `SpDialogWindowPresenter>>#okAction:`"

--- a/src/Spec2-Core/SpDiffPresenter.class.st
+++ b/src/Spec2-Core/SpDiffPresenter.class.st
@@ -9,8 +9,8 @@ self exampleWithoutOptions.
 self exampleWithOptions.
 "
 Class {
-	#name : #SpDiffPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpDiffPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#showOptions => ObservableSlot',
 		'#showOnlyDestination => ObservableSlot',
@@ -22,43 +22,45 @@ Class {
 		'#rightText => ObservableSlot',
 		'#beWrapped => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpDiffPresenter class >> adapterName [
 
 	^ #DiffAdapter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> beWrapped [
 
 	^ beWrapped
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> beWrapped: aBoolean [
 
 	beWrapped := aBoolean
 ]
 
-{ #category : #'undo-redo' }
+{ #category : 'undo-redo' }
 SpDiffPresenter >> clearUndoManager [
 	"The diff presenter does not allow edition, it does not have undo history. But this message is added to have polimorphism in the Message Browser"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> contextClass [
 	^ contextClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> contextClass: anObject [
 	contextClass := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDiffPresenter >> initialize [
 	super initialize.
 
@@ -80,79 +82,79 @@ SpDiffPresenter >> initialize [
 	self property: #rightLabel whenChangedDo: [ :newText | self changed: #rightLabel: with: {newText} ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> leftLabel [
 	^ leftLabel
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> leftLabel: anObject [
 	leftLabel := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> leftText [
 	^ leftText
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> leftText: anObject [
 	leftText := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> rightLabel [
 	^ rightLabel
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> rightLabel: anObject [
 	rightLabel := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> rightText [
 	^ rightText
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDiffPresenter >> rightText: anObject [
 	rightText := anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showBoth [
 	self property: #showOnlySource rawValue: false.
 	self property: #showOnlyDestination rawValue: false.
 	self changed: #showBoth with: {}
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showOnlyDestination [
 	^ showOnlyDestination
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showOnlyDestination: aBoolean [
 	showOnlyDestination := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showOnlySource [
 	^ showOnlySource
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showOnlySource: aBoolean [
 	showOnlySource := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showOptions [
 	^ showOptions
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDiffPresenter >> showOptions: aBoolean [
 	showOptions := aBoolean
 ]

--- a/src/Spec2-Core/SpDocumentHierarchyBuilder.class.st
+++ b/src/Spec2-Core/SpDocumentHierarchyBuilder.class.st
@@ -16,8 +16,8 @@ SpDocumentHierarchyBuilder new
 ```
 "
 Class {
-	#name : #SpDocumentHierarchyBuilder,
-	#superclass : #Object,
+	#name : 'SpDocumentHierarchyBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'topClass',
 		'flattenTree',
@@ -26,10 +26,12 @@ Class {
 		'class',
 		'fromClass'
 	],
-	#category : #'Spec2-Core-Utils'
+	#category : 'Spec2-Core-Utils',
+	#package : 'Spec2-Core',
+	#tag : 'Utils'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 SpDocumentHierarchyBuilder >> addLevel: level from: aClass [
 	"'├ ─ ╰ │'"
 	| path |
@@ -61,7 +63,7 @@ SpDocumentHierarchyBuilder >> addLevel: level from: aClass [
 			from: each ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDocumentHierarchyBuilder >> addLevel: level from: aClass to: stream [
 	"'├ ─ ╰ │'"
 	| path |
@@ -90,14 +92,14 @@ SpDocumentHierarchyBuilder >> addLevel: level from: aClass to: stream [
 			to: stream ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDocumentHierarchyBuilder >> applyFilterTo: aCollection [
 
 	filterBlock ifNil: [ ^ aCollection ].
 	^ aCollection select: filterBlock
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 SpDocumentHierarchyBuilder >> buildFor: aClass [
 
 	self fillTreeOf: aClass.
@@ -106,7 +108,7 @@ SpDocumentHierarchyBuilder >> buildFor: aClass [
 		from: self fromClass
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 SpDocumentHierarchyBuilder >> buildStringFor: aClass [
 	
 	self fillTreeOf: aClass.
@@ -117,13 +119,13 @@ SpDocumentHierarchyBuilder >> buildStringFor: aClass [
 			to: (ZnNewLineWriterStream on: stream) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDocumentHierarchyBuilder >> builder: aBuilder [
 
 	builder := aBuilder
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDocumentHierarchyBuilder >> fillTreeOf: aClass [
 
 	class := aClass.
@@ -134,7 +136,7 @@ SpDocumentHierarchyBuilder >> fillTreeOf: aClass [
 	^ flattenTree
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDocumentHierarchyBuilder >> fillTreeWithSubclassesOf: aClass [
 		
 	flattenTree at: aClass put: (self applyFilterTo: aClass subclasses).
@@ -142,7 +144,7 @@ SpDocumentHierarchyBuilder >> fillTreeWithSubclassesOf: aClass [
 		self fillTreeWithSubclassesOf: each ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDocumentHierarchyBuilder >> fillTreeWithSuperclassesOf: aClass [
 	| superclasses |
 
@@ -156,25 +158,25 @@ SpDocumentHierarchyBuilder >> fillTreeWithSuperclassesOf: aClass [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDocumentHierarchyBuilder >> filter: aBlock [
 
 	filterBlock := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDocumentHierarchyBuilder >> fromClass [
 
 	 ^  fromClass ifNil: [ SpAbstractPresenter ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDocumentHierarchyBuilder >> fromClass: aClass [
 
 	fromClass := aClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDocumentHierarchyBuilder >> isPassingThrough: aClass topLevel: aTopClass [
 	| superclasses |
 	
@@ -185,13 +187,13 @@ SpDocumentHierarchyBuilder >> isPassingThrough: aClass topLevel: aTopClass [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDocumentHierarchyBuilder >> topClass [
 
 	^ topClass ifNil: [ self fromClass superclass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDocumentHierarchyBuilder >> topClass: aClass [
 
 	topClass := aClass

--- a/src/Spec2-Core/SpDropListItem.class.st
+++ b/src/Spec2-Core/SpDropListItem.class.st
@@ -2,18 +2,20 @@
 A DropListItem is an item (wrapper) designed to fit into a DropList.
 "
 Class {
-	#name : #SpDropListItem,
-	#superclass : #Object,
+	#name : 'SpDropListItem',
+	#superclass : 'Object',
 	#instVars : [
 		'model',
 		'displayBlock',
 		'icon',
 		'action'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpDropListItem class >> named: label do: aBlock [
 
 	^ self new
@@ -23,7 +25,7 @@ SpDropListItem class >> named: label do: aBlock [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpDropListItem class >> on: anObject do: aBlock [
 
 	^ self new
@@ -32,7 +34,7 @@ SpDropListItem class >> on: anObject do: aBlock [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SpDropListItem >> = anObject [
 	"Answer whether the receiver and anObject represent the same object."
 
@@ -41,17 +43,17 @@ SpDropListItem >> = anObject [
 	^ self label = anObject label and: [ action = anObject action ]
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpDropListItem >> action [
 	^ action
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpDropListItem >> action: aBlock [
 	action := aBlock
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 SpDropListItem >> display: aBlock [
 	"Set the block whose execution should return the string to be displayed. 
 	aBlock will be executed with an optional argument, which is the underlying item."
@@ -59,24 +61,24 @@ SpDropListItem >> display: aBlock [
 	displayBlock := aBlock.
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SpDropListItem >> hash [
 	"Answer an integer value that is related to the identity of the receiver."
 
 	^ self label hash bitXor: action hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListItem >> icon [
 	^ icon
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListItem >> icon: anObject [
 	icon := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDropListItem >> initialize [
 
 	super initialize.
@@ -84,32 +86,32 @@ SpDropListItem >> initialize [
 	displayBlock := [ :e | e asString ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListItem >> label [
 	
 	^ displayBlock cull: model
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListItem >> label: anObject [
 	"For compatibility with old raw-string usage. Send #display: instead"
 	
 	displayBlock := [ anObject ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListItem >> model [
 
 	^ model
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListItem >> model: anObject [
 
 	model := anObject
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SpDropListItem >> value [
 	"This way, I am polymorphic with nil"
 

--- a/src/Spec2-Core/SpDropListPresenter.class.st
+++ b/src/Spec2-Core/SpDropListPresenter.class.st
@@ -5,8 +5,8 @@ _NOTE: I assume there is a little problem on an empty list, but frankly, who cre
 
 "
 Class {
-	#name : #SpDropListPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpDropListPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#model => ObservableSlot',
 		'#startsWithSelection',
@@ -14,28 +14,30 @@ Class {
 		'#displayBlock => ObservableSlot',
 		'#iconBlock => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpDropListPresenter class >> adapterName [
 
 	^ #DropListAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpDropListPresenter class >> documentFactoryMethodSelector [
 
 	^ #newDropList
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpDropListPresenter class >> title [
 
 	^ 'Drop List'
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> addItemLabeled: aString do: aBlock [
 	"Add an item to the drop list, along with an action.
 	 `aString` is the label of the element.
@@ -44,7 +46,7 @@ SpDropListPresenter >> addItemLabeled: aString do: aBlock [
 	self addItemLabeled: aString do: aBlock icon: nil.
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> addItemLabeled: aString do: aBlock icon: anIcon [
 	"Add an item to the drop list, along with an icon and an action.
 	 `aString` is the label of the element.
@@ -60,13 +62,13 @@ SpDropListPresenter >> addItemLabeled: aString do: aBlock icon: anIcon [
 		ifFalse: [self appendCollection: { item } ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> appendCollection: items [
 
 	model collection: (model collection, items)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> disableSelectionDuring: aBlock [
 	| oldSubscriptions holder |
 	
@@ -77,7 +79,7 @@ SpDropListPresenter >> disableSelectionDuring: aBlock [
 		holder subscriptions: oldSubscriptions ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> display [
 	"Answer the formatting block to transform how the elements will be displayed. 
 	 See also `SpDropListPresenter>>#display:`"
@@ -85,7 +87,7 @@ SpDropListPresenter >> display [
 	^ displayBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> display: aBlock [
 	"Set the formatting block to transform how the elements will be displayed. 
 	 `aBlock` receives one argument (the element to be displayed) and it should answer a string.
@@ -95,14 +97,14 @@ SpDropListPresenter >> display: aBlock [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> displayForItem: anItem [
 	"The order of the arguments may look weird, but then it seems more natural while using the widget"
 
 	^ self display cull: anItem model cull: anItem
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> displayIcon [
 	"Answer the block that will be used to retrieve the icon to be displayed along with the 
 	 elements."
@@ -110,7 +112,7 @@ SpDropListPresenter >> displayIcon [
 	^ iconBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> displayIcon: aBlock [	
 	"Answer a block that will be used to retrieve the icon to be displayed along with the elements.
 	 `aBlock` receives one argument (an element from the list)"
@@ -118,14 +120,14 @@ SpDropListPresenter >> displayIcon: aBlock [
 	iconBlock := aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> dropListItems: dropListItems [
 	"Populate the drop list with a list DropListItems"
 	
 	model collection: dropListItems
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> emptyList [
 	"Empty the list of elements used to populate the drop down list."
 	
@@ -134,25 +136,25 @@ SpDropListPresenter >> emptyList [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> getIconFor: anItem [
 
 	^ self displayIcon cull: anItem model cull: anItem
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> getIndex [
 
 	^ selection selectedIndex
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> getList [
 
 	^ model items
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDropListPresenter >> hasIcons [
 	"Answer whether the dropdown list will show icons"
 	
@@ -161,7 +163,7 @@ SpDropListPresenter >> hasIcons [
 			each icon notNil or: [ (self getIconFor: each) notNil ] ] ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> iconBlock [ 
 	"Answer the block that will be used to retrieve the icon to be displayed along with the 
 	 elements."
@@ -174,7 +176,7 @@ SpDropListPresenter >> iconBlock [
 	^ iconBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> iconBlock: aBlock [	
 	"Answer a block that will be used to retrieve the icon to be displayed along with the elements.
 	 `aBlock` receives one argument (an element from the list)"
@@ -187,7 +189,7 @@ SpDropListPresenter >> iconBlock: aBlock [
 	iconBlock := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDropListPresenter >> initialize [
 	super initialize.
 
@@ -198,20 +200,20 @@ SpDropListPresenter >> initialize [
 	startsWithSelection := true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpDropListPresenter >> isStartWithSelection [
 
 	^ startsWithSelection
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> items [ 
 	"Return the list used to populate the drop list"
 
 	^ self listItems
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> items: aList [
 	"Populate the drop list with a list of ui specific items"
 	"`aList` is a list of domain specific objects. If you want to specify more precisely the item actions, see `SpDropListPresenter>>#addItemLabeled:do:`"
@@ -227,21 +229,21 @@ SpDropListPresenter >> items: aList [
 	self setCollection: dropListItems
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> listItems [
 	"Return the list used to populate the drop list"
 	
 	^ self getList collect: [ :e | e model ].
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> listSize [
 	"Return the size of the list of choices"
 
 	^ self listItems size
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> model [
 	"Answer the model containing the elements to be shown in the drop down list.
 	 Tipically, the model is a collection of `SpDropListItem`."
@@ -249,13 +251,13 @@ SpDropListPresenter >> model [
 	^ model
 ]
 
-{ #category : #selection }
+{ #category : 'selection' }
 SpDropListPresenter >> resetSelection [
 	
 	self selection unselectAll 
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> selectIndex: anInteger [ 
 	"Select the element at position `anInteger` and executes the action associated with it."
 	
@@ -266,7 +268,7 @@ SpDropListPresenter >> selectIndex: anInteger [
 	self selection selectedItem value
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> selectItem: anItem [ 
 	"Select the element `anItem` if it is in the list. 
 	 It executes the action associated with the item if it is defined."
@@ -282,7 +284,7 @@ SpDropListPresenter >> selectItem: anItem [
 	realItem value
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> selectedIndex [
 	"Answer the index of selected item. 
 	 You usually do not need to use this method but `SpDropListPresenter>>#selectedItem`."
@@ -290,7 +292,7 @@ SpDropListPresenter >> selectedIndex [
 	^ self getIndex
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> selectedItem [
 	"Answer selected item"
 
@@ -298,14 +300,14 @@ SpDropListPresenter >> selectedItem [
 		ifNotNil: [ :anItem | anItem model ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> selection [
 	"Answer selection model, an instance of `SpSingleSelectionMode`."
 	
 	^ selection
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpDropListPresenter >> setCollection: items [
 
 	model collection: items.
@@ -316,35 +318,35 @@ SpDropListPresenter >> setCollection: items [
 		ifFalse: [ self resetSelection ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> sortingBlock [
 	"Answer the block used to sort the elements of the list."
 
 	^ self model sortingBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> sortingBlock: aBlock [
 	"Set the block or `SortFunction` used to sort the elements of the list."
 
 	self model sortingBlock: aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> startWithSelection [
 	"Indicate when drop list will start with an element selected."
 
 	startsWithSelection := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> startWithoutSelection [
 	"Indicate when droplist will start without an element selected."
 
 	startsWithSelection := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDropListPresenter >> updateItemsKeepingSelection: aCollection [
 	"Update list items keeping current selection. 
 	 WARNING: aCollection must includes the elements selected."
@@ -356,7 +358,7 @@ SpDropListPresenter >> updateItemsKeepingSelection: aCollection [
 		self selectItem: item ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpDropListPresenter >> whenSelectedItemChangedDo: aBlock [
 	"Inform when the selected item is changed.
 	 `aBlock` receive one optional argument: the selected item (can be nil)"
@@ -364,7 +366,7 @@ SpDropListPresenter >> whenSelectedItemChangedDo: aBlock [
 	selection whenChangedDo: [	aBlock cull: self selectedItem ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpDropListPresenter >> whenSelectionChangedDo: aBlock [
 	"Inform when the selection is changed.
 	 The method should be used only if you are interested in the fact that there was 
@@ -380,7 +382,7 @@ SpDropListPresenter >> whenSelectionChangedDo: aBlock [
 	selection whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpDropListPresenter >> whenSortingBlockChangedDo: aBlock [
 	"Inform when sorting block has changed.
 	 `aBlock` receive 3 optional arguments: 

--- a/src/Spec2-Core/SpDropListTableColumn.class.st
+++ b/src/Spec2-Core/SpDropListTableColumn.class.st
@@ -9,17 +9,19 @@ self example
 ```
 "
 Class {
-	#name : #SpDropListTableColumn,
-	#superclass : #SpTableColumn,
+	#name : 'SpDropListTableColumn',
+	#superclass : 'SpTableColumn',
 	#instVars : [
 		'display',
 		'selectedItemChangedAction',
 		'startWithSelection'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpDropListTableColumn class >> example [
 
 	^ SpTablePresenter new
@@ -33,54 +35,54 @@ SpDropListTableColumn class >> example [
 		open
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpDropListTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitDropListColumn: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> display [
 	
 	^ display
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> display: aBlock [
 
 	display := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpDropListTableColumn >> initialize [
 
 	super initialize.
 	startWithSelection := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> selectedItemChangedAction [
 		
 	^ selectedItemChangedAction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> selectedItemChangedAction: aBlock [
 
 	selectedItemChangedAction := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> shouldStartWithSelection [ 
 	^ startWithSelection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> startWithSelection [ 
 	startWithSelection := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListTableColumn >> startWithoutSelection [ 
 	startWithSelection := false
 ]

--- a/src/Spec2-Core/SpDynamicPresenter.class.st
+++ b/src/Spec2-Core/SpDynamicPresenter.class.st
@@ -27,46 +27,48 @@ todo
 - retrieveSpec:
 "
 Class {
-	#name : #SpDynamicPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpDynamicPresenter',
+	#superclass : 'SpPresenter',
 	#traits : 'SpTDynamicPresenter',
 	#classTraits : 'SpTDynamicPresenter classTrait',
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpDynamicPresenter >> assign: aPresenter to: anInstVarName [
 	self presenterAt: anInstVarName put: aPresenter.
 	aPresenter owner: self
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 SpDynamicPresenter >> doesNotUnderstand: aMessage [
 	"To make sure that we can use accessors to access the dynamically managed subcomponents."
 
 	^ self presenterAt: aMessage selector ifAbsent: [ super doesNotUnderstand: aMessage ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpDynamicPresenter >> instantiatePresenters: aCollectionOfPairs [
 	aCollectionOfPairs pairsDo: [ :k :v | self presenterAt: k asSymbol put: (self createInstanceFor: v) ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDynamicPresenter >> needFullRebuild: aBoolean [
 
 	self needRebuild: aBoolean.
 	self presentersDo: [ :w | w needRebuild: aBoolean ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDynamicPresenter >> open [
 
 	self layout ifNil: [ ^ super open ].
 	^ self asWindow openWith: self layout
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpDynamicPresenter >> openModal [
 
 	self layout ifNil: [ ^ super open ].

--- a/src/Spec2-Core/SpEditableListPresenter.class.st
+++ b/src/Spec2-Core/SpEditableListPresenter.class.st
@@ -12,8 +12,8 @@ Example:
 self example
 "
 Class {
-	#name : #SpEditableListPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpEditableListPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'title',
 		'list',
@@ -28,15 +28,17 @@ Class {
 		'label',
 		'removeItemBlock'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpEditableListPresenter class >> defaultLayout [
 	^ self layoutWithOrdering: true
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpEditableListPresenter class >> layoutWithOrdering: useOrdering [
 	| listLayout |
 	listLayout := SpBoxLayout newLeftToRight
@@ -65,33 +67,33 @@ SpEditableListPresenter class >> layoutWithOrdering: useOrdering [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpEditableListPresenter class >> new: aCollection [
 	^ self new items: aCollection.
 		
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpEditableListPresenter class >> withoutOrderingBar [
 	^ self layoutWithOrdering: false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> addButton [
 	^ addButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> addItemBlock: aBlock [
 	addItemBlock := aBlock.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> bottomButton [
 	^ bottomButton
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEditableListPresenter >> connectPresenters [
 	super connectPresenters.
 	addButton action: [ 
@@ -113,18 +115,18 @@ SpEditableListPresenter >> connectPresenters [
 		self moveElementAt: self selectedIndex to: self selectedIndex + 1 ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> display: aBlock [
 
 	list display: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> downButton [
 	^ downButton
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEditableListPresenter >> initialize [
 	super initialize.
 	title := 'Title'.
@@ -135,7 +137,7 @@ SpEditableListPresenter >> initialize [
 													self refresh. ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEditableListPresenter >> initializeDialogWindow: aWindow [
 
 	aWindow 
@@ -145,7 +147,7 @@ SpEditableListPresenter >> initializeDialogWindow: aWindow [
 			presenter close ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEditableListPresenter >> initializePresenters [
 	label := self newLabel.
 	list := self newList.
@@ -181,32 +183,32 @@ SpEditableListPresenter >> initializePresenters [
 		help: 'Move this item on the last position of the list'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEditableListPresenter >> initializeWindow: aWindowPresenter [
 	aWindowPresenter title: self title
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> items [
 	^ list model items
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpEditableListPresenter >> items: anItemList [
 	list items: anItemList.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> label: aString [
 	label label: aString 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> list [
 	^ list
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpEditableListPresenter >> moveElementAt: index to: newIndex [
 	"WARNING: this method can only be used if the model is an OrderedCollection"
 	| elementToMove |
@@ -223,7 +225,7 @@ SpEditableListPresenter >> moveElementAt: index to: newIndex [
 	self list selectIndex: newIndex
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEditableListPresenter >> newList [
 	"Default list collection is an Array.
 	As this presenter aims to add / remove items from the list, we need a growable collection"
@@ -232,86 +234,86 @@ SpEditableListPresenter >> newList [
 			yourself
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> okAction: aBlock [
 
 	okBlock := aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpEditableListPresenter >> performOkAction [
 
 	okBlock value
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> refresh [
 	self resetSelection.
 	self items: self items
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> removeButton [
 	^ removeButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> removeItem: anObject [
 	self items remove: anObject.
 	list selection unselectAll
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> removeItemBlock: aBlock [
 	removeItemBlock := aBlock.
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> resetSelection [
 	self selectIndex: 0
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> selectIndex: anIndex [
 	list selectIndex: anIndex
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> selectItem: anObject [
 	list selectItem: anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> selectedIndex [
 	^ list selection selectedIndex
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> selectedItem [
 	^ list selection selectedItem
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> title [
 	^ title
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> title: aTitle [
 	title := aTitle 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> topButton [
 	^ topButton
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenter >> upButton [
 	^ upButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpEditableListPresenter >> whenSelectionChangedDo: aBlockClosure [ 
 	list whenSelectionChangedDo: aBlockClosure
 ]

--- a/src/Spec2-Core/SpEventHandler.class.st
+++ b/src/Spec2-Core/SpEventHandler.class.st
@@ -10,16 +10,18 @@ I can listen:
 WARNING: Not all presenters will answer equally to all events. For example, presenters who can't take the keyboard focus can't respond to focus events.
 "
 Class {
-	#name : #SpEventHandler,
-	#superclass : #Object,
+	#name : 'SpEventHandler',
+	#superclass : 'Object',
 	#instVars : [
 		'presenter',
 		'events'
 	],
-	#category : #'Spec2-Core-Base-Event'
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpEventHandler class >> for: aPresenter [ 
 
 	^ self basicNew 
@@ -27,40 +29,40 @@ SpEventHandler class >> for: aPresenter [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpEventHandler class >> new [
 
 	self error: 'Use #new'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpEventHandler >> hasEvents [
 	
 	^ events notEmpty
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEventHandler >> initialize [
 	
 	super initialize.
 	events := Set new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpEventHandler >> initializePresenter: aPresenter [
 
 	presenter := aPresenter.
 	self initialize
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpEventHandler >> installAllEventsTo: anAdapter target: aWidget [
 
 	events do: [ :each |
 		each installOn: anAdapter target: aWidget ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpEventHandler >> register: anEvent [
 
 	events add: anEvent.
@@ -68,13 +70,13 @@ SpEventHandler >> register: anEvent [
 		anAdapter installEvent: anEvent  ]	
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenDoubleClickDo: aBlock [
 
 	 self register: (SpMouseDoubleClickDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenFocusLostDo: aBlock [
 	"Register on a focus lost event. 
 	 aBlock does not have parameters."
@@ -82,7 +84,7 @@ SpEventHandler >> whenFocusLostDo: aBlock [
 	 self register: (SpFocusLostEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenFocusReceivedDo: aBlock [
 	"Register on a focus received event. 
 	aBlock does not have parameters."
@@ -91,7 +93,7 @@ SpEventHandler >> whenFocusReceivedDo: aBlock [
 	 self register: (SpFocusReceivedEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenKeyDownDo: aBlock [
 	"Register on a key down event. 
 	 aBlock receives 'event' as parameter."
@@ -99,7 +101,7 @@ SpEventHandler >> whenKeyDownDo: aBlock [
 	 self register: (SpKeyDownEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenKeyUpDo: aBlock [
 	"Register on a key down event. 
 	 aBlock receives 'event' as parameter."
@@ -107,7 +109,7 @@ SpEventHandler >> whenKeyUpDo: aBlock [
 	 self register: (SpKeyUpEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenMouseDownDo: aBlock [
 	"Register on a mouse down event. 
 	 aBlock receives 'event' as parameter."
@@ -115,7 +117,7 @@ SpEventHandler >> whenMouseDownDo: aBlock [
 	 self register: (SpMouseDownEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenMouseEnterDo: aBlock [
 	"Register on a mouse enter event. 
 	 aBlock receives 'event' as parameter."
@@ -123,7 +125,7 @@ SpEventHandler >> whenMouseEnterDo: aBlock [
 	 self register: (SpMouseEnterEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenMouseLeaveDo: aBlock [
 	"Register on a mouse leave event. 
 	 aBlock receives 'event' as parameter."
@@ -131,7 +133,7 @@ SpEventHandler >> whenMouseLeaveDo: aBlock [
 	 self register: (SpMouseLeaveEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenMouseMoveDo: aBlock [
 	"Register on a mouse move event. 
 	 aBlock receives 'event' as parameter."
@@ -139,7 +141,7 @@ SpEventHandler >> whenMouseMoveDo: aBlock [
 	 self register: (SpMouseMoveEventDefinition do: aBlock)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpEventHandler >> whenMouseUpDo: aBlock [
 	"Register on a mouse up event. 
 	 aBlock receives 'event' as parameter."

--- a/src/Spec2-Core/SpFTArrayIndexColumn.class.st
+++ b/src/Spec2-Core/SpFTArrayIndexColumn.class.st
@@ -11,37 +11,39 @@ This class has and extends API of FTColumn
 	index:		<Number>
 "
 Class {
-	#name : #SpFTArrayIndexColumn,
-	#superclass : #SpFTColumn,
+	#name : 'SpFTArrayIndexColumn',
+	#superclass : 'SpFTColumn',
 	#instVars : [
 		'index'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpFTArrayIndexColumn class >> index: aNumber [
 	^ self new 
 		index: aNumber
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpFTArrayIndexColumn class >> index: aNumber width: aNumber2 [
 	^ (self index: aNumber) 
 		width: aNumber2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTArrayIndexColumn >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTArrayIndexColumn >> index: anObject [
 	index := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTArrayIndexColumn >> transform: anArray [
 	^ anArray at: self index
 ]

--- a/src/Spec2-Core/SpFTColumn.class.st
+++ b/src/Spec2-Core/SpFTColumn.class.st
@@ -2,83 +2,85 @@
 A column for Fast table
 "
 Class {
-	#name : #SpFTColumn,
-	#superclass : #Object,
+	#name : 'SpFTColumn',
+	#superclass : 'Object',
 	#instVars : [
 		'id',
 		'width',
 		'table'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpFTColumn class >> id: anObject [
 	^ self new
 		id: anObject;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn class >> undefinedColumnWidth [
 	"This is a contant that defines a column width is undefined, then the layout will try to arrange 
 	 it by itself."
 	^ 0
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpFTColumn >> acquireWidth: anOwnerWidth [
 	^ self widthOrUndefined min: anOwnerWidth
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> id [
 	^ id
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpFTColumn >> id: anObject [
 	id := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> readObject: anObject [
 
 	"Fast table presenters have a block that returns an array that is mapped by this column"
 	^ self transform: (table displayBlock value: anObject)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> table [
 	^ table
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> table: anObject [
 	table := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> title [
 	^ id
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> transform: anObject [
 	^ anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> width [
 	^ width
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> width: anObject [
 	width := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFTColumn >> widthOrUndefined [
 	^ self width ifNil: [ self class undefinedColumnWidth ]
 ]

--- a/src/Spec2-Core/SpFixedProgressBarState.class.st
+++ b/src/Spec2-Core/SpFixedProgressBarState.class.st
@@ -17,22 +17,24 @@ Internal Representation and Key Implementation Points.
 
 "
 Class {
-	#name : #SpFixedProgressBarState,
-	#superclass : #SpProgressBarState,
+	#name : 'SpFixedProgressBarState',
+	#superclass : 'SpProgressBarState',
 	#instVars : [
 		'value'
 	],
-	#category : #'Spec2-Core-Utils'
+	#category : 'Spec2-Core-Utils',
+	#package : 'Spec2-Core',
+	#tag : 'Utils'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpFixedProgressBarState class >> value: aNumber [
 	^ self new
 		value: aNumber;
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpFixedProgressBarState >> initialize [
 	
 	self class initializeSlots: self.
@@ -40,17 +42,17 @@ SpFixedProgressBarState >> initialize [
 	value := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFixedProgressBarState >> value [
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpFixedProgressBarState >> value: aNumber [
 	value := aNumber
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpFixedProgressBarState >> whenValueChangedDo: aBlock [
 	self property: #value whenChangedDo: aBlock
 ]

--- a/src/Spec2-Core/SpFocusLostEventDefinition.class.st
+++ b/src/Spec2-Core/SpFocusLostEventDefinition.class.st
@@ -3,12 +3,14 @@ I define a ""lost focus"" (focus leaved the widget) event.
 
 "
 Class {
-	#name : #SpFocusLostEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpFocusLostEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpFocusLostEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installFocusLostEvent: self to: aWidget

--- a/src/Spec2-Core/SpFocusReceivedEventDefinition.class.st
+++ b/src/Spec2-Core/SpFocusReceivedEventDefinition.class.st
@@ -3,12 +3,14 @@ I define a ""got focus"" (focus received) event.
 
 "
 Class {
-	#name : #SpFocusReceivedEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpFocusReceivedEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpFocusReceivedEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installFocusReceivedEvent: self to: aWidget

--- a/src/Spec2-Core/SpGeneratorListModel.class.st
+++ b/src/Spec2-Core/SpGeneratorListModel.class.st
@@ -6,16 +6,18 @@ See `Generator` class.
 
 "
 Class {
-	#name : #SpGeneratorListModel,
-	#superclass : #SpCollectionListModel,
+	#name : 'SpGeneratorListModel',
+	#superclass : 'SpCollectionListModel',
 	#instVars : [
 		'generator',
 		'size'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpGeneratorListModel class >> example [
 	| items generator |
 
@@ -32,7 +34,7 @@ SpGeneratorListModel class >> example [
 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpGeneratorListModel class >> on: aBlock [ 
 
 	^ self new 
@@ -40,7 +42,7 @@ SpGeneratorListModel class >> on: aBlock [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpGeneratorListModel >> at: anIndex [
 
 	^ self 
@@ -48,7 +50,7 @@ SpGeneratorListModel >> at: anIndex [
 		ifAbsent: [ self error: 'Index not found' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpGeneratorListModel >> at: anIndex ifAbsent: aBlock [
 
 	[ collection size < anIndex ] 
@@ -61,25 +63,25 @@ SpGeneratorListModel >> at: anIndex ifAbsent: aBlock [
 	^ collection at: anIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpGeneratorListModel >> generator [
 	^ generator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpGeneratorListModel >> generator: aGenerator [
 
 	generator := aGenerator.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpGeneratorListModel >> hasElementAt: index [
 
 	self at: index ifAbsent: [ ^ false ].
 	^ true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpGeneratorListModel >> initialize [
 
 	super initialize.
@@ -87,7 +89,7 @@ SpGeneratorListModel >> initialize [
 	size := 10000
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpGeneratorListModel >> size [
 
 	^ size

--- a/src/Spec2-Core/SpIconAndLabelToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpIconAndLabelToolbarDisplayMode.class.st
@@ -2,12 +2,14 @@
 Display the toolbar with icons and label only
 "
 Class {
-	#name : #SpIconAndLabelToolbarDisplayMode,
-	#superclass : #SpToolbarDisplayMode,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpIconAndLabelToolbarDisplayMode',
+	#superclass : 'SpToolbarDisplayMode',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpIconAndLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 	"ask for icon and label"
 	aButton getLabelSelector: #label.
@@ -17,18 +19,18 @@ SpIconAndLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem 
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconAndLabelToolbarDisplayMode >> extent [
 	^ (45@45) scaledByDisplayScaleFactor
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SpIconAndLabelToolbarDisplayMode >> label [
 
 	^ 'Icon and Label'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconAndLabelToolbarDisplayMode >> styleName [ 
 
 	^ 'toolBar.iconsAndLabel'

--- a/src/Spec2-Core/SpIconProvider.class.st
+++ b/src/Spec2-Core/SpIconProvider.class.st
@@ -3,12 +3,14 @@ I'm base icon provider.
 Children of `SpIconProvider` will define concrete ways to access icons.
 "
 Class {
-	#name : #SpIconProvider,
-	#superclass : #Object,
-	#category : #'Spec2-Core-IconProvider'
+	#name : 'SpIconProvider',
+	#superclass : 'Object',
+	#category : 'Spec2-Core-IconProvider',
+	#package : 'Spec2-Core',
+	#tag : 'IconProvider'
 }
 
-{ #category : #copying }
+{ #category : 'copying' }
 SpIconProvider >> , aProvider [
 
 	^ SpCompositeIconProvider new 
@@ -17,7 +19,7 @@ SpIconProvider >> , aProvider [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconProvider >> iconNamed: aName [
 
 	^ self 
@@ -25,7 +27,7 @@ SpIconProvider >> iconNamed: aName [
 		ifAbsent: [ self error: ('Icon {1} not found.' format: { aName })  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconProvider >> iconNamed: aName ifAbsent: aBlock [
 
 	self subclassResponsibility

--- a/src/Spec2-Core/SpIconToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpIconToolbarDisplayMode.class.st
@@ -2,12 +2,14 @@
 Display the toolbar with icons only
 "
 Class {
-	#name : #SpIconToolbarDisplayMode,
-	#superclass : #SpToolbarDisplayMode,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpIconToolbarDisplayMode',
+	#superclass : 'SpToolbarDisplayMode',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpIconToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 	"ask for icon (no label)"
 	aButton getIconSelector: #icon.
@@ -15,19 +17,19 @@ SpIconToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 	aButton getStateSelector: #state
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconToolbarDisplayMode >> extent [
 
 	^ (30@30) scaledByDisplayScaleFactor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconToolbarDisplayMode >> label [
 
 	^ 'Icon'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpIconToolbarDisplayMode >> styleName [ 
 
 	^ 'toolBar.icons'

--- a/src/Spec2-Core/SpImagePresenter.class.st
+++ b/src/Spec2-Core/SpImagePresenter.class.st
@@ -3,70 +3,72 @@ A presenter to display  images.
 Images need to be instances of `Form`.  
 "
 Class {
-	#name : #SpImagePresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpImagePresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#image => ObservableSlot',
 		'#action => ObservableSlot',
 		'#autoScale => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpImagePresenter class >> adapterName [
 
 	^ #ImageAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpImagePresenter class >> documentFactoryMethodSelector [
 
 	^ #newImage
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpImagePresenter >> action [
 
 	^ action
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpImagePresenter >> action: aBlock [
 	"Set the action of the image"
 
 	action := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpImagePresenter >> autoScale [
 	"Answer if image has autoscale activated."
 
 	^ autoScale
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpImagePresenter >> autoScale: aBoolean [
 	"Set whether image will autoscale or not."
 
 	autoScale := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpImagePresenter >> image [
 	"Answer the `Form` instance that will be displayed."
 
 	^ image
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpImagePresenter >> image: aForm [
 	"Set a `Form` instance to be displayed."
 	
 	image := aForm
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpImagePresenter >> initialize [
 
 	super initialize.
@@ -74,7 +76,7 @@ SpImagePresenter >> initialize [
 	autoScale := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpImagePresenter >> switchAutoscale [
 	"Toggles autoscale state."
 	
@@ -82,7 +84,7 @@ SpImagePresenter >> switchAutoscale [
 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpImagePresenter >> whenAutoScaleChangeDo: aBlockClosure [
 	"Inform when autoScale state has changed. 
 	 `aBlock` has three optional arguments: 
@@ -93,7 +95,7 @@ SpImagePresenter >> whenAutoScaleChangeDo: aBlockClosure [
 	self property: #autoScale whenChangedDo: aBlockClosure
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpImagePresenter >> whenImageChangeDo: aBlock [ 
 	"Inform when image to display has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpImageTableColumn.class.st
+++ b/src/Spec2-Core/SpImageTableColumn.class.st
@@ -11,12 +11,14 @@ SpImageTableColumn
 ```
 "
 Class {
-	#name : #SpImageTableColumn,
-	#superclass : #SpTableColumn,
-	#category : #'Spec2-Core-Widgets-Table'
+	#name : 'SpImageTableColumn',
+	#superclass : 'SpTableColumn',
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpImageTableColumn class >> example [
 
 	SpTablePresenter new
@@ -32,7 +34,7 @@ SpImageTableColumn class >> example [
 		open
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpImageTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitImageColumn: self

--- a/src/Spec2-Core/SpIndeterminatedProgressBarState.class.st
+++ b/src/Spec2-Core/SpIndeterminatedProgressBarState.class.st
@@ -10,12 +10,14 @@ Examples
 	ProgressBarIndeterminated new
 "
 Class {
-	#name : #SpIndeterminatedProgressBarState,
-	#superclass : #SpProgressBarState,
-	#category : #'Spec2-Core-Utils'
+	#name : 'SpIndeterminatedProgressBarState',
+	#superclass : 'SpProgressBarState',
+	#category : 'Spec2-Core-Utils',
+	#package : 'Spec2-Core',
+	#tag : 'Utils'
 }
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpIndeterminatedProgressBarState >> whenValueChangedDo: aBlock [
 	"Value cannot change in indeterminate state"
 ]

--- a/src/Spec2-Core/SpIndexTableColumn.class.st
+++ b/src/Spec2-Core/SpIndexTableColumn.class.st
@@ -12,12 +12,14 @@ SpIndexTableColumn title: 'My index'
 ```
 "
 Class {
-	#name : #SpIndexTableColumn,
-	#superclass : #SpTableColumn,
-	#category : #'Spec2-Core-Widgets-Table'
+	#name : 'SpIndexTableColumn',
+	#superclass : 'SpTableColumn',
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpIndexTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitIndexColumn: self

--- a/src/Spec2-Core/SpJob.class.st
+++ b/src/Spec2-Core/SpJob.class.st
@@ -19,8 +19,8 @@ job run.
 See `SpJobPresenter` for a graphical example.
 "
 Class {
-	#name : #SpJob,
-	#superclass : #Object,
+	#name : 'SpJob',
+	#superclass : 'Object',
 	#instVars : [
 		'block',
 		'currentValue',
@@ -33,17 +33,19 @@ Class {
 		'process',
 		'announcer'
 	],
-	#category : #'Spec2-Core-Job'
+	#category : 'Spec2-Core-Job',
+	#package : 'Spec2-Core',
+	#tag : 'Job'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob class >> current [
 	"Answer the current job or nil if none."
 
 	^ CurrentJob value
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpJob class >> empty [
 
 	^ self new 
@@ -52,7 +54,7 @@ SpJob class >> empty [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpJob class >> newBlock: aBlock [
 
 	^ self new
@@ -60,7 +62,7 @@ SpJob class >> newBlock: aBlock [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpJob class >> newTitle: aString block: aBlock [ 
 
 	^ self new 
@@ -69,14 +71,14 @@ SpJob class >> newTitle: aString block: aBlock [
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> addChild: aJob [
 
 	children add: aJob.
 	aJob parent: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> announce: anAnnouncementClass [
 
 	| announcement |
@@ -84,38 +86,38 @@ SpJob >> announce: anAnnouncementClass [
 	self announcer announce: announcement
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> announceChange [
 
 	isRunning ifFalse: [ ^ self ].
 	self announce: JobChange
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> announcer [
 
 	^ announcer ifNil: [ announcer := Announcer new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> block [
 	
 	^ block
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> block: aBlock [
 	
 	block := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> children [
 
 	^ children copy
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> cleanupAfterRunning [
 
 	isRunning := false.
@@ -124,44 +126,44 @@ SpJob >> cleanupAfterRunning [
 	parent ifNotNil: [ :job | job removeChild: self ]
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> current [
 
 	^ self currentValue
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> current: aNumber [
 
 	self currentValue: aNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> currentValue [
 	
 	^ currentValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> currentValue: aNumber [
 	
 	currentValue := aNumber.
 	self announceChange
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> decrement [
 
 	self currentValue: self currentValue - 1
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> increment [
 
 	self currentValue: self currentValue + 1
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpJob >> initialize [
 
 	super initialize.
@@ -173,25 +175,25 @@ SpJob >> initialize [
 	children := OrderedCollection new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpJob >> isRunning [
 
 	^ isRunning
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> label [
 
 	^ self title
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> label: aString [ 
 
 	self title: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> lookup: lookupBlock ifNone: noneBlock [
 	"Detect a job that satisfies the lookupBlock, or value noneBlock if none satisfies. 
 	The lookup starts at myself, following recursevely through my parent."
@@ -203,19 +205,19 @@ SpJob >> lookup: lookupBlock ifNone: noneBlock [
 		ifNotNil: [ parent lookup: lookupBlock ifNone: noneBlock ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> max [
 	
 	^ max
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> max: aNumber [
 
 	self migrateProgressWhileUpdatingBounds: [ max := aNumber ].
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> migrateProgressWhileUpdatingBounds: aBlockChangingBounds [
 	"Keep the progress value consistent while we change min / max"
 	| progress |
@@ -224,32 +226,32 @@ SpJob >> migrateProgressWhileUpdatingBounds: aBlockChangingBounds [
 	self progress: progress.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> min [
 	
 	^ min
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> min: aNumber [
 
 	self migrateProgressWhileUpdatingBounds: [ min := aNumber ].
 	self announceChange
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> parent [
 
 	^ parent
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> parent: aJob [ 
 
 	parent := aJob.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> prepareForRunning [
 
 	isRunning := true.
@@ -257,7 +259,7 @@ SpJob >> prepareForRunning [
 	self announce: JobStart
 ]
 
-{ #category : #progress }
+{ #category : 'progress' }
 SpJob >> progress [
 	"Avoid negative progress and divideByZero."
 
@@ -266,7 +268,7 @@ SpJob >> progress [
 		ifFalse: [ (currentValue - min) / (max - min) ]
 ]
 
-{ #category : #progress }
+{ #category : 'progress' }
 SpJob >> progress: aNormalizedFloat [
 	"Set the progress: 0.0 - 1.0"
 
@@ -274,19 +276,19 @@ SpJob >> progress: aNormalizedFloat [
 	self announceChange
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> progressPercent: aNumber [ 
 	
 	self currentValue: aNumber
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJob >> removeChild: aJob [ 
 
 	children remove: aJob.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpJob >> run [
 
 	[ 
@@ -295,44 +297,44 @@ SpJob >> run [
 	ensure: [ self cleanupAfterRunning ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> title [
 	
 	^ title
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpJob >> title: anObject [
 	
 	title := anObject.
 	self announceChange
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> value [
 
 	^ self currentValue
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 SpJob >> value: aNumber [
 
 	self currentValue: aNumber
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpJob >> whenChangedDo: aBlock [
 
 	self announcer when: JobChange do: aBlock
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpJob >> whenEndDo: aBlock [
 
 	self announcer when: JobEnd do: aBlock
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpJob >> whenStartDo: aBlock [
 
 	self announcer when: JobStart do: aBlock

--- a/src/Spec2-Core/SpJobListPresenter.class.st
+++ b/src/Spec2-Core/SpJobListPresenter.class.st
@@ -2,15 +2,17 @@
 A presenter to stack jobs.
 "
 Class {
-	#name : #SpJobListPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpJobListPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'refreshRateInMs'
 	],
-	#category : #'Spec2-Core-Job'
+	#category : 'Spec2-Core-Job',
+	#package : 'Spec2-Core',
+	#tag : 'Job'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpJobListPresenter class >> example [ 
 	| jobList |
 	
@@ -33,7 +35,7 @@ SpJobListPresenter class >> example [
 	^ nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobListPresenter >> addJobPresenter: aJob [
 	| presenter |
 	
@@ -48,13 +50,13 @@ SpJobListPresenter >> addJobPresenter: aJob [
 		window resize: 500@(layout children size *  self jobPresenterHeight) ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpJobListPresenter >> initializePresenters [
 
 	self layout: SpBoxLayout newTopToBottom
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpJobListPresenter >> initializeWindow: aWindowPresenter [ 
 
 	aWindowPresenter 
@@ -64,13 +66,13 @@ SpJobListPresenter >> initializeWindow: aWindowPresenter [
 		centered
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobListPresenter >> jobPresenterHeight [
 
 	^ 70
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpJobListPresenter >> pushJob: aJob [
 
 	aJob whenStartDo: [ :ann | self addJobPresenter: ann job ].
@@ -79,12 +81,12 @@ SpJobListPresenter >> pushJob: aJob [
 	aJob run	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpJobListPresenter >> refreshRateInMs: anInteger [ 
 	refreshRateInMs := anInteger.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobListPresenter >> removeJobPresenter: aJob [
 	| presenter |
 	

--- a/src/Spec2-Core/SpJobPresenter.class.st
+++ b/src/Spec2-Core/SpJobPresenter.class.st
@@ -15,18 +15,20 @@ SpJobPresenter new
 ```
 "
 Class {
-	#name : #SpJobPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpJobPresenter',
+	#superclass : 'SpPresenter',
 	#traits : 'SpTModel',
 	#classTraits : 'SpTModel classTrait',
 	#instVars : [
 		'progressBar',
 		'progressLabel'
 	],
-	#category : #'Spec2-Core-Job'
+	#category : 'Spec2-Core-Job',
+	#package : 'Spec2-Core',
+	#tag : 'Job'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 SpJobPresenter class >> example [
 	| job |
 
@@ -43,7 +45,7 @@ SpJobPresenter class >> example [
 		run
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpJobPresenter >> initializePresenters [
 
 	self layout: (SpBoxLayout newTopToBottom
@@ -54,7 +56,7 @@ SpJobPresenter >> initializePresenters [
 		yourself)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpJobPresenter >> initializeWindow: aWindowPresenter [ 
 
 	aWindowPresenter 
@@ -64,25 +66,25 @@ SpJobPresenter >> initializeWindow: aWindowPresenter [
 		centered
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobPresenter >> jobChanged: ann [ 
 
 	self updatePresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobPresenter >> jobEnd: ann [ 
 
 	self updatePresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobPresenter >> jobStart: ann [ 
 
 	self updatePresenter
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpJobPresenter >> model: aModel [
 
 	model := aModel.
@@ -90,13 +92,13 @@ SpJobPresenter >> model: aModel [
 	self updatePresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobPresenter >> refreshRateInMs: anInteger [
 
 	progressBar withAdapterDo: [ :progressAdapter | progressAdapter refreshRateInMs: anInteger ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpJobPresenter >> run [
 
 	self open.
@@ -104,14 +106,14 @@ SpJobPresenter >> run [
 	self withWindowDo: [ :window | window close ]
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpJobPresenter >> setModelBeforeInitialization: aModel [
 
 	model := aModel.
 	self updateSubscriptions
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpJobPresenter >> updatePresenter [
 	| currentJob |
 
@@ -121,7 +123,7 @@ SpJobPresenter >> updatePresenter [
 	progressBar fixedAt: model progress
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpJobPresenter >> updateSubscriptions [
 	
 	model announcer weak 

--- a/src/Spec2-Core/SpKeyDownEventDefinition.class.st
+++ b/src/Spec2-Core/SpKeyDownEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a key down event
 "
 Class {
-	#name : #SpKeyDownEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpKeyDownEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpKeyDownEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installKeyDownEvent: self to: aWidget

--- a/src/Spec2-Core/SpKeyUpEventDefinition.class.st
+++ b/src/Spec2-Core/SpKeyUpEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a key up event
 "
 Class {
-	#name : #SpKeyUpEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpKeyUpEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpKeyUpEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installKeyUpEvent: self to: aWidget

--- a/src/Spec2-Core/SpLabelPresenter.class.st
+++ b/src/Spec2-Core/SpLabelPresenter.class.st
@@ -4,48 +4,50 @@ A label presenter displays smalls (or medium) amounts of text.
 _NOTE: In the future, it should be possible to attach another widget to a label, but for now it is not implemented._
 "
 Class {
-	#name : #SpLabelPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpLabelPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#traits : 'SpTDecoratedText',
 	#classTraits : 'SpTDecoratedText classTrait',
 	#instVars : [
 		'#label => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpLabelPresenter class >> adapterName [
 
 	^ #LabelAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpLabelPresenter class >> documentFactoryMethodSelector [
 
 	^ #newLabel
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpLabelPresenter class >> title [
 
 	^ 'Label presenter'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpLabelPresenter >> canTakeKeyboardFocus [
 
 	^ false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpLabelPresenter >> defaultColor [
 
 	self flag: #TOREMOVE. "This needs to be removed"
 	^ self theme textColor
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpLabelPresenter >> initialize [
 	super initialize.
 
@@ -53,21 +55,21 @@ SpLabelPresenter >> initialize [
 	self whenLabelChangedDo: [ self changed: #getText ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpLabelPresenter >> label [
 	"Answer the label to be displayed."
 
 	^ label
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpLabelPresenter >> label: aString [
 	"Set the label to be displayed"
 
 	label := aString
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpLabelPresenter >> localeChanged [
 
 	super localeChanged.
@@ -75,7 +77,7 @@ SpLabelPresenter >> localeChanged [
 		
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpLabelPresenter >> whenLabelChangedDo: aBlock [
 	"Inform when label property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpLabelToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpLabelToolbarDisplayMode.class.st
@@ -2,12 +2,14 @@
 Display the toolbar with labels only
 "
 Class {
-	#name : #SpLabelToolbarDisplayMode,
-	#superclass : #SpToolbarDisplayMode,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpLabelToolbarDisplayMode',
+	#superclass : 'SpToolbarDisplayMode',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 	"ask for label (no icon)"
 	aButton getLabelSelector: #label.
@@ -15,18 +17,18 @@ SpLabelToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 	aButton getStateSelector: #state	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabelToolbarDisplayMode >> extent [
 	^ (45@25) scaledByDisplayScaleFactor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabelToolbarDisplayMode >> label [
 
 	^ 'Label'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabelToolbarDisplayMode >> styleName [
 
 	^ 'toolBar.label'

--- a/src/Spec2-Core/SpLabeledPresenter.class.st
+++ b/src/Spec2-Core/SpLabeledPresenter.class.st
@@ -9,17 +9,19 @@ Example:
 	self instantiate: (LabelledPresenter label: 'Email' input: self newTextInput description: 'Email adress to use to send activation and informations emails.')
 "
 Class {
-	#name : #SpLabeledPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpLabeledPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'input',
 		'descriptionPresenter',
 		'labelPresenter'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpLabeledPresenter class >> defaultLayout [
 	^ SpBoxLayout newLeftToRight
 		add: #labelPresenter withConstraints: [ :constraints | constraints width: self labelWidth ];
@@ -30,12 +32,12 @@ SpLabeledPresenter class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpLabeledPresenter class >> label: aString input: aPresenter [
 	^ self label: aString input: aPresenter description: nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpLabeledPresenter class >> label: aString input: aPresenter description: anotherString [
 	^ self new
 		label: aString;
@@ -44,7 +46,7 @@ SpLabeledPresenter class >> label: aString input: aPresenter description: anothe
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> description: aString [
 	aString ifNil: [ ^ self ].
 	
@@ -54,44 +56,44 @@ SpLabeledPresenter >> description: aString [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> descriptionPresenter [
 	^ descriptionPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> descriptionPresenter: anObject [
 	descriptionPresenter := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpLabeledPresenter >> initializePresenters [
 	labelPresenter := self newLabel.
 	descriptionPresenter :=  self newNullPresenter. "By default it is null"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> input [
 	^ input
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> input: anObject [
 	input := anObject.
 	self focusOrder add: input
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> label: aString [
 	labelPresenter label: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> labelPresenter [
 	^ labelPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabeledPresenter >> labelPresenter: anObject [
 	labelPresenter := anObject
 ]

--- a/src/Spec2-Core/SpLinkTableColumn.class.st
+++ b/src/Spec2-Core/SpLinkTableColumn.class.st
@@ -10,16 +10,18 @@ SpIndexTableColumn
 ```
 "
 Class {
-	#name : #SpLinkTableColumn,
-	#superclass : #SpTableColumn,
+	#name : 'SpLinkTableColumn',
+	#superclass : 'SpTableColumn',
 	#instVars : [
 		'action',
 		'url'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpLinkTableColumn class >> title: aString evaluated: aBlock action: actionBlock [
 
 	^ self new 
@@ -29,7 +31,7 @@ SpLinkTableColumn class >> title: aString evaluated: aBlock action: actionBlock 
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpLinkTableColumn class >> title: aString evaluated: aBlock url: urlBlock [
 
 	^ self new 
@@ -39,28 +41,28 @@ SpLinkTableColumn class >> title: aString evaluated: aBlock url: urlBlock [
 		yourself
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpLinkTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitLinkColumn: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLinkTableColumn >> action [
 	^ action
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLinkTableColumn >> action: aBlock [
 	action := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLinkTableColumn >> url [
 	^ url
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLinkTableColumn >> url: anObject [
 	url := anObject
 ]

--- a/src/Spec2-Core/SpListPresenter.class.st
+++ b/src/Spec2-Core/SpListPresenter.class.st
@@ -11,8 +11,8 @@ It means many fonctionality related to the selection (selected items, multiple i
 A list presenter does not offer the possibility to add one item in isolation instead you should use the `items:` setter to set the full list domain object. The responsibility to manage the items displayed by a list presenter is not the one of that list presenter but its users e.g, the presenter you will write and that instantiates and uses the list presenter. This is normal since there is no way that the list presenter could track changes into the domain object representing the list items.
 "
 Class {
-	#name : #SpListPresenter,
-	#superclass : #SpAbstractListPresenter,
+	#name : 'SpListPresenter',
+	#superclass : 'SpAbstractListPresenter',
 	#traits : 'SpTSearchable + SpTDecoratedText',
 	#classTraits : 'SpTSearchable classTrait + SpTDecoratedText classTrait',
 	#instVars : [
@@ -22,22 +22,24 @@ Class {
 		'#display => ObservableSlot',
 		'#icon => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpListPresenter class >> adapterName [
 
 	^ #ListAdapter
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpListPresenter class >> title [
 
 	^ 'List'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> clickOnSelectedItem [
 
 	| item |
@@ -45,7 +47,7 @@ SpListPresenter >> clickOnSelectedItem [
 	^ item notNil and: [ (item respondsTo: #click) and: [ item click ] ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> display [
 	"Answer the display block that will transform the objects from `SpAbstractListPresenter>>#model` into a
 	 displayable string."
@@ -53,7 +55,7 @@ SpListPresenter >> display [
 	^ display
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> display: aBlock [
 	"Set the block that will be applied on each of the list items. 
 	 The result of the block will be used to display the item on the screen.
@@ -70,14 +72,14 @@ SpListPresenter >> display: aBlock [
 	display := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> displayIcon [
 	"Return the block used to return an icon that will be displayed in the list"
 
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> displayIcon: aBlock [
 	"Set a block which takes an item as argument and returns the icon to display in the list. 
 	 `aBlock` receives one argument"
@@ -85,7 +87,7 @@ SpListPresenter >> displayIcon: aBlock [
 	icon := aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> displayValueAt: anIndex [
 	"Return the effective string that is displayed on the list. 
 	Note that it is different from the item, because often an item is an object whose only a facette (e.g., name) is displayed. In such case displayValueAt: return the string of the displayed facette"
@@ -93,48 +95,48 @@ SpListPresenter >> displayValueAt: anIndex [
 	^ self displayValueFor: (model at: anIndex)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> displayValueFor: anObject [
 
 	^ self display value: anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpListPresenter >> hasHeaderTitle [
 	"Answer true if the list has a title (See `SpListPresenter>>#headerTitle:`)."
 
 	^ headerTitle isEmptyOrNil not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpListPresenter >> hasIcons [
 	"Answer true if the list has an icon provider (See `SpListPresenter>>#icons:`)."
 
 	^ self displayIcon notNil
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> headerTitle [
 	"Answer the header title."
 
 	^ headerTitle
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> headerTitle: aString [
 	"Set the header title."
 
 	headerTitle := aString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> hideHeaderTitle [
 	"Hide list header."
 
 	headerTitle := nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> iconFor: anItem [
 
 	^ self displayIcon
@@ -142,7 +144,7 @@ SpListPresenter >> iconFor: anItem [
 		cull: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpListPresenter >> initialize [
 
 	super initialize.
@@ -152,12 +154,12 @@ SpListPresenter >> initialize [
 	display := [ :object | object asStringOrText ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> prepareForFilteredDataSourceWith: items [
 	model := items
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> registerEvents [
 	super registerEvents.
 	"Do not use whenAutoDeselectChangedDo: to avoid the deprecation warning."
@@ -172,19 +174,19 @@ SpListPresenter >> registerEvents [
 			self withAdapterDo: [ :anAdapter | anAdapter refreshWidgetHeaderTitle ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpListPresenter >> resetListSelection [
 	self selectIndex: 0
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpListPresenter >> resetSortingBlock [
 	"Reset the sortering block with the default value which consists in not sorting"
 
 	self model sortingBlock: nil
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpListPresenter >> updateList [
 	"Update the list re taking the list defined in `SpAbstractListPresenter>>#model` and filling the list with 
 	 them (this is useful when the list contained changed internally (like adding element to a collection, etc.). 
@@ -194,7 +196,7 @@ SpListPresenter >> updateList [
 	self unselectAll
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpListPresenter >> whenDisplayChangedDo: aBlock [
 	"Inform when the display block has changed.
  	 `aBlock` has three optional arguments: 
@@ -205,7 +207,7 @@ SpListPresenter >> whenDisplayChangedDo: aBlock [
 	self property: #display whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpListPresenter >> whenIconsChangedDo: aBlock [
 	"Inform when the icons block has changed.
  	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpLocationIconProvider.class.st
+++ b/src/Spec2-Core/SpLocationIconProvider.class.st
@@ -5,16 +5,18 @@ It receive locations (directory references) where to find them.
 Alternatively, it can also look for gtk theme icons (stored by name in the gtk theme).
 "
 Class {
-	#name : #SpLocationIconProvider,
-	#superclass : #SpIconProvider,
+	#name : 'SpLocationIconProvider',
+	#superclass : 'SpIconProvider',
 	#instVars : [
 		'icons',
 		'locations'
 	],
-	#category : #'Spec2-Core-IconProvider'
+	#category : 'Spec2-Core-IconProvider',
+	#package : 'Spec2-Core',
+	#tag : 'IconProvider'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpLocationIconProvider class >> newLocation: aLocation [
 
 	^ self new 
@@ -22,13 +24,13 @@ SpLocationIconProvider class >> newLocation: aLocation [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLocationIconProvider >> addLocation: aReference [
 
 	locations := locations copyWith: aReference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLocationIconProvider >> iconNamed: aName ifAbsent: aBlock [
 	| icon |
 	
@@ -42,13 +44,13 @@ SpLocationIconProvider >> iconNamed: aName ifAbsent: aBlock [
 	^ icon
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLocationIconProvider >> icons [
 
 	^ icons
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpLocationIconProvider >> initialize [
 
 	super initialize.
@@ -57,13 +59,13 @@ SpLocationIconProvider >> initialize [
 	self initializeBlankIcon
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpLocationIconProvider >> initializeBlankIcon [
 
 	self setBlankIcon: (Form extent: 16@16 depth: 8)
 ]
 
-{ #category : #inspecting }
+{ #category : 'inspecting' }
 SpLocationIconProvider >> inspectionIcons [
 	<inspectorPresentationOrder: 0 title: 'Icons'> 
 
@@ -74,7 +76,7 @@ SpLocationIconProvider >> inspectionIcons [
 		yourself
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SpLocationIconProvider >> loadAllIcons [
 
 	self locations do: [ :eachLocation |
@@ -84,7 +86,7 @@ SpLocationIconProvider >> loadAllIcons [
 				put: (self loadIcon: each) ] ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SpLocationIconProvider >> loadIcon: fileReference [
 
 	fileReference exists ifFalse: [ 
@@ -94,7 +96,7 @@ SpLocationIconProvider >> loadIcon: fileReference [
 		 Form fromBinaryStream: stream ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SpLocationIconProvider >> loadIconNamed: aSymbol [
 
 	self locations do: [ :each | | ref |
@@ -104,19 +106,19 @@ SpLocationIconProvider >> loadIconNamed: aSymbol [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLocationIconProvider >> locations [
 
 	^ locations
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLocationIconProvider >> menuIconNamed: aName [ 
 
 	^ self iconNamed: aName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLocationIconProvider >> setBlankIcon: aForm [
 	"To be able to specify the form that represents a missing icon."
 	

--- a/src/Spec2-Core/SpMenuBarPresenter.class.st
+++ b/src/Spec2-Core/SpMenuBarPresenter.class.st
@@ -8,29 +8,31 @@ I'm different from a simple menu in:
 Tipically, this menu will be presented at the top of a window.
 "
 Class {
-	#name : #SpMenuBarPresenter,
-	#superclass : #SpMenuPresenter,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpMenuBarPresenter',
+	#superclass : 'SpMenuPresenter',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuBarPresenter class >> adapterName [
 
 	^ #MenuBarAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuBarPresenter class >> addDocumentExtraSections: aBuilder [
 	"It does not applies here"
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuBarPresenter class >> documentExampleCodeSelector [
 
 	^ #example
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuBarPresenter class >> documentFactoryMethodSelector [
 
 	^ #newMenuBar

--- a/src/Spec2-Core/SpMenuButtonPresenter.class.st
+++ b/src/Spec2-Core/SpMenuButtonPresenter.class.st
@@ -3,45 +3,47 @@ A presenter to create a menu button (a button who exposes a menu instead having 
 
 "
 Class {
-	#name : #SpMenuButtonPresenter,
-	#superclass : #SpAbstractButtonPresenter,
+	#name : 'SpMenuButtonPresenter',
+	#superclass : 'SpAbstractButtonPresenter',
 	#instVars : [
 		'#menu => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuButtonPresenter class >> adapterName [
 
 	^ #MenuButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newMenuButton
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuButtonPresenter class >> title [
 
 	^ 'MenuButton'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMenuButtonPresenter >> initialize [
 	super initialize.
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuButtonPresenter >> menu [
 	"Answer the menu (an instance of `SpMenuPresenter` or a block) to show."
 
 	^ menu
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuButtonPresenter >> menu: aValuable [
 	"Set the menu to show. 
 	 `aValuable` can be an instance of `SpMenuPresenter` or a block to allow dynamic behavior."
@@ -49,7 +51,7 @@ SpMenuButtonPresenter >> menu: aValuable [
 	menu := aValuable
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMenuButtonPresenter >> whenMenuChangedDo: aBlock [
 	"Inform when menu  property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpMenuGroupPresenter.class.st
+++ b/src/Spec2-Core/SpMenuGroupPresenter.class.st
@@ -3,28 +3,30 @@ A presenter for grouping menu items.
 A group is always part of a menu (See `SpMenuPresenter`), and it groups items (See `SpMenuItemPresenter`).
 "
 Class {
-	#name : #SpMenuGroupPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpMenuGroupPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#items',
 		'#autoRefresh => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuGroupPresenter class >> adapterName [
 
 	^ #MenuGroupAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuGroupPresenter class >> documentExampleCodeSelector [
 
 	^ #exampleMenuGroup
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuGroupPresenter >> add: aName target: targetObject selector: aSelector [
 	
 	self flag: #TODO. "This is for compatibility with the old menu builder and needs to be removed!"
@@ -35,7 +37,7 @@ SpMenuGroupPresenter >> add: aName target: targetObject selector: aSelector [
 	^ self menuItems last
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuGroupPresenter >> addItem: aBlock [
 	| item |
 	
@@ -44,24 +46,24 @@ SpMenuGroupPresenter >> addItem: aBlock [
 	self addMenuItem: item
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuGroupPresenter >> addMenuItem: aMenuItem [
 
 	aMenuItem owner: self.
 	items add: aMenuItem
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuGroupPresenter >> autoRefresh [
 	^ autoRefresh
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuGroupPresenter >> autoRefresh: aBoolean [
 	autoRefresh := aBoolean
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuGroupPresenter >> buildWithLayout: aSpecLayout [
 	"Build the widget using the spec name provided as argument"
 	| widget|
@@ -71,39 +73,39 @@ SpMenuGroupPresenter >> buildWithLayout: aSpecLayout [
 	^ widget
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMenuGroupPresenter >> canTakeKeyboardFocus [
 	"Answer when the presenter can take keyboard focus."
 
 	^ false
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuGroupPresenter >> fromSpec: aSpec [
 	self addItem: [ :item | item fromSpec: aSpec ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMenuGroupPresenter >> initialize [
 	super initialize.
 
 	items := OrderedCollection new asValueHolder
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMenuGroupPresenter >> isEmpty [
 	"Answer true if the group is empty"
 
 	^ items isEmpty
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuGroupPresenter >> menuItems [
 
 	^ items value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuGroupPresenter >> rootMenu [
 
 	^ self owner rootMenu

--- a/src/Spec2-Core/SpMenuItemPresenter.class.st
+++ b/src/Spec2-Core/SpMenuItemPresenter.class.st
@@ -7,8 +7,8 @@ A menu item can have: an action (See `SpMenuItemPresenter>>#action:`) **OR** it 
 Tipically, you do not call directly `SpMenuItemPresenter`. Instead, you use the builder method provided when building a `SpMenuPresenter` (See example below).
 "
 Class {
-	#name : #SpMenuItemPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpMenuItemPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#name => ObservableSlot',
 		'#icon => ObservableSlot',
@@ -18,29 +18,31 @@ Class {
 		'#subMenu',
 		'#state'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuItemPresenter class >> adapterName [
 
 	^ #MenuItemAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuItemPresenter class >> documentExampleCodeSelector [
 
 	^ #exampleShowAtPointer
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> action [
 	"Answer the action to be executed when the menu item is selected."
 
 	^ action
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> action: aBlock [
 	"Set the action to be executed when the menu item is selected.
 	 `aBlock` receives zero arguments."
@@ -48,14 +50,14 @@ SpMenuItemPresenter >> action: aBlock [
 	action := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> description [
 	"Answer the description for the menu item."
 
 	^ description
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> description: aString [
 	"Set a description for the menu item. In some platforms (like Morphic), it can be shown as a 
 	 tooltip text."
@@ -63,33 +65,33 @@ SpMenuItemPresenter >> description: aString [
 	description := aString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMenuItemPresenter >> hasShortcut [
 
 	^ self shortcut notNil
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> icon [
 	"Answer the icon to be shown with the menu item."
 
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> icon: anIcon [
 	"Set an icon (an instance of `Form`) to be shown with the menu item."
 
 	icon := anIcon
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuItemPresenter >> iconName: aString [ 
 	
 	self icon: (self iconNamed: aString)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMenuItemPresenter >> initialize [
 	super initialize.
 
@@ -97,13 +99,13 @@ SpMenuItemPresenter >> initialize [
 	name := ''
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMenuItemPresenter >> isMenuPresenter [
 
 	^ true
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpMenuItemPresenter >> localeChanged [
 
 	super localeChanged.
@@ -111,14 +113,14 @@ SpMenuItemPresenter >> localeChanged [
 	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> name [
 	"Answer the name of the menu item. This will be displayed as label."
 
 	^ name
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> name: aString [
 	"The label of the menu item. 
 	 In certain backends (Gtk), we allow this label to contain mnemonics using an underscore ($_)
@@ -130,7 +132,7 @@ SpMenuItemPresenter >> name: aString [
 	name := aString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuItemPresenter >> performMenuActionWith: aMenuItem [
 	| en |
 
@@ -141,18 +143,18 @@ SpMenuItemPresenter >> performMenuActionWith: aMenuItem [
 	self action cull: aMenuItem
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuItemPresenter >> rootMenu [ 
 	
 	^ self owner rootMenu
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> shortcut [
 	^ shortcut
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> shortcut: aShortcut [
 	"Set a shortcut (an instance of `KMKeyCombination`) that be shown with the menu item. 
 	 **IMPORTANT:** Since most menus are added dinamically to its presenters (as part of a 
@@ -163,26 +165,26 @@ SpMenuItemPresenter >> shortcut: aShortcut [
 	shortcut := aShortcut
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuItemPresenter >> state [
 	^ state
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuItemPresenter >> state: aBoolean [
 
 	self flag: #REVIEW. "Maybe not removed but implemented correctly?"
 	state := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> subMenu [
 	"Answer the submenu that will be displayed with this menu if any, or nil."
 
 	^ subMenu
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuItemPresenter >> subMenu: aMenuPresenter [
 	"Set the submenu that will be displayed with this menu.
 	 If a submenu is shown, defined action (See `SpMenuItemPresenter>>#action:`) will be ignored."
@@ -192,7 +194,7 @@ SpMenuItemPresenter >> subMenu: aMenuPresenter [
 	subMenu := aMenuPresenter
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMenuItemPresenter >> whenDescriptionChangedDo: aBlock [ 
 	"Inform when description has changed. 
 	 `aBlock` has three optional arguments: 
@@ -203,7 +205,7 @@ SpMenuItemPresenter >> whenDescriptionChangedDo: aBlock [
 	self property: #description whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMenuItemPresenter >> whenIconChangedDo: aBlock [ 
 	"Inform when icon has changed. 
 	 `aBlock` has three optional arguments: 
@@ -214,7 +216,7 @@ SpMenuItemPresenter >> whenIconChangedDo: aBlock [
 	self property: #icon whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMenuItemPresenter >> whenNameChangedDo: aBlock [ 
 	"Inform when name  has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpMenuPresenter.class.st
+++ b/src/Spec2-Core/SpMenuPresenter.class.st
@@ -4,8 +4,8 @@ A menu presenter contains groups of menu items (having one unique group by defau
 A menu presenter is included in presenters that implement the `#contextMenu:` (See below) method, but it can also be invoked by calling `SpMenuPresenter>>#openWithSpecAt:`
 "
 Class {
-	#name : #SpMenuPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpMenuPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#groups',
 		'#title => ObservableSlot',
@@ -14,16 +14,18 @@ Class {
 		'#shortcutGroup',
 		'#defaultGroup'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuPresenter class >> adapterName [
 
 	^ #MenuAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuPresenter class >> addDocumentExtraSections: aBuilder [
 
 	aBuilder newLine.
@@ -34,19 +36,19 @@ SpMenuPresenter class >> addDocumentExtraSections: aBuilder [
 				aBuilder monospace: eachType name ] ] ]	
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuPresenter class >> documentExampleCodeSelector [
 
 	^ #exampleShowAtPointer
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpMenuPresenter class >> documentFactoryMethodSelector [
 
 	^ #newMenu
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpMenuPresenter class >> popup [
 	<spec>
 	
@@ -54,7 +56,7 @@ SpMenuPresenter class >> popup [
 		adaptAsPopup: #(presenter))
 ]
 
-{ #category : #'api - building' }
+{ #category : 'api - building' }
 SpMenuPresenter >> addAllFromPragma: pragma target: target [
 
 	self fromSpec: (PragmaMenuBuilder 
@@ -62,7 +64,7 @@ SpMenuPresenter >> addAllFromPragma: pragma target: target [
 		model: target) menuSpec
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> addGroup: aBlock [
 	"Add a group of items. 
 	 If you do not want a multiple-group menu, you can use `SpMenuPresenter>>#addItem:` instead."
@@ -73,7 +75,7 @@ SpMenuPresenter >> addGroup: aBlock [
 	self addMenuGroup: group
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> addItem: aBlock [
 	"Add an item to the menu. When the menu group has not been specified previously, add the 
 	 item in a default group.
@@ -82,43 +84,43 @@ SpMenuPresenter >> addItem: aBlock [
 	self defaultGroup addItem: aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> addKeybindingsTo: aPresenter [
 	"bind keybindings (shortcuts) defined in this menu to aPresenter"
 
 	aPresenter applyKeyBindingsFromMenu: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMenuPresenter >> addMenuGroup: aMenuGroup [
 
 	aMenuGroup owner: self.
 	groups add: aMenuGroup
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuPresenter >> autoRefresh [
 	^ autoRefresh
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuPresenter >> autoRefresh: aBoolean [
 	autoRefresh := aBoolean
 ]
 
-{ #category : #'api - building' }
+{ #category : 'api - building' }
 SpMenuPresenter >> buildWithSpecAsPopup [
 
 	^ self build
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMenuPresenter >> canTakeKeyboardFocus [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuPresenter >> defaultGroup [
 
 	^ defaultGroup ifNil: [ 
@@ -127,7 +129,7 @@ SpMenuPresenter >> defaultGroup [
 		defaultGroup ]
 ]
 
-{ #category : #'api - building' }
+{ #category : 'api - building' }
 SpMenuPresenter >> fromSpec: aSpec [
 	| grps subgroup |
 	
@@ -148,35 +150,35 @@ SpMenuPresenter >> fromSpec: aSpec [
 			group addItem: [ :item | item fromSpec: spec ] ] ] ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> icon [
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> icon: anIcon [
 	icon := anIcon
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpMenuPresenter >> iconName: aSymbol [
 	self icon: (self iconNamed: aSymbol)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMenuPresenter >> initialize [
 
 	super initialize.
 	groups := OrderedCollection new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMenuPresenter >> isMenuPresenter [
 
 	^ true
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpMenuPresenter >> localeChanged [
 
 	super localeChanged.
@@ -184,12 +186,12 @@ SpMenuPresenter >> localeChanged [
 	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> menuGroups [
 	^ groups
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> openWithSpecAt: aPosition [
 	"Open this menu at `aPosition`. 
 	 `aPosition` os a instance of `Point`"
@@ -198,7 +200,7 @@ SpMenuPresenter >> openWithSpecAt: aPosition [
 	self withAdapterDo: [ :anAdapter | anAdapter openAt: aPosition ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> openWithSpecAtPointer [
 	"Open this menu at cursor position"
 
@@ -206,7 +208,7 @@ SpMenuPresenter >> openWithSpecAtPointer [
 	self withAdapterDo: [ :anAdapter | anAdapter openAtPointer ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SpMenuPresenter >> printOn: aStream [
 	super printOn: aStream.
 	self title value
@@ -217,7 +219,7 @@ SpMenuPresenter >> printOn: aStream [
 				nextPutAll: '''' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuPresenter >> rootMenu [
 
 	^ self owner isMenuPresenter 
@@ -226,7 +228,7 @@ SpMenuPresenter >> rootMenu [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuPresenter >> shortcutGroup [
 	"Some platforms use acceleration groups to store shortcut keys. 
 	 if that's the case, we use this property to access it later (and store 
@@ -235,18 +237,18 @@ SpMenuPresenter >> shortcutGroup [
 	^ shortcutGroup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuPresenter >> shortcutGroup: aKeyGroup [
 	
 	shortcutGroup := aKeyGroup
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> title [
 	^ title
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMenuPresenter >> title: aString [
 	title := aString
 ]

--- a/src/Spec2-Core/SpMillerActivation.class.st
+++ b/src/Spec2-Core/SpMillerActivation.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SpMillerActivation,
-	#superclass : #Object,
+	#name : 'SpMillerActivation',
+	#superclass : 'Object',
 	#instVars : [
 		'value'
 	],
-	#category : #'Spec2-Core-Miller'
+	#category : 'Spec2-Core-Miller',
+	#package : 'Spec2-Core',
+	#tag : 'Miller'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpMillerActivation class >> on: anInteger [ 
 	
 	^ self new
@@ -15,13 +17,13 @@ SpMillerActivation class >> on: anInteger [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMillerActivation >> selectedItem [
 	
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMillerActivation >> value: anInteger [ 
 	value := anInteger
 ]

--- a/src/Spec2-Core/SpMillerColumnPresenter.class.st
+++ b/src/Spec2-Core/SpMillerColumnPresenter.class.st
@@ -13,18 +13,20 @@ You have to set me:
 All presenters inside this one should be polymorphic, defining: `whenActivatedDo:`, an event that will invoke a valuable with a selection object (understanding the message `selectedObject`).
 "
 Class {
-	#name : #SpMillerColumnPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpMillerColumnPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'#newPresenterBlock',
 		'#columnsWillChangeBlock',
 		'#horizontalScrollBar => ObservableSlot',
 		'#columnsChangedBlock'
 	],
-	#category : #'Spec2-Core-Miller'
+	#category : 'Spec2-Core-Miller',
+	#package : 'Spec2-Core',
+	#tag : 'Miller'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> addPresenter: newSubPresenter [
 
 	newSubPresenter whenActivatedDo: [ :selection |
@@ -33,21 +35,21 @@ SpMillerColumnPresenter >> addPresenter: newSubPresenter [
 	layout add: newSubPresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerColumnPresenter >> announceColumnsChanged: index [
 
 	columnsChangedBlock ifNil: [ ^ self ]. 
 	columnsChangedBlock cull: index
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerColumnPresenter >> announceColumnsWillChange: index [
 
 	columnsWillChangeBlock ifNil: [ ^ self ]. 
 	columnsWillChangeBlock cull: index
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerColumnPresenter >> changeSelection: selection from: aPresenter [
 	| selectedPresenterIndex |
 
@@ -58,13 +60,13 @@ SpMillerColumnPresenter >> changeSelection: selection from: aPresenter [
 	self announceColumnsChanged: selectedPresenterIndex
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMillerColumnPresenter >> hasHorizontalScrollBar [
 
 	^ horizontalScrollBar
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMillerColumnPresenter >> initialize [
 
 	super initialize.
@@ -72,43 +74,43 @@ SpMillerColumnPresenter >> initialize [
 	self withHorizontalScrollBar
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMillerColumnPresenter >> initializePresenters [
 	
 	layout := SpMillerLayout newHorizontal
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerColumnPresenter >> newPresenterFor: aModel [
 
 	^ newPresenterBlock value: aModel
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> pages [
 	
 	^ layout presenters
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> presenterBlock: aBlock [ 
 	
 	newPresenterBlock := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> presenters [
 
 	^ layout presenters
 ]
 
-{ #category : #model }
+{ #category : 'model' }
 SpMillerColumnPresenter >> pushModel: aModel [
 
 	self addPresenter: (self newPresenterFor: aModel)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> removeAllFrom: aPage [
 	"remove all columns starting by this page."
 	| index |
@@ -118,7 +120,7 @@ SpMillerColumnPresenter >> removeAllFrom: aPage [
 	self selectPage: index
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerColumnPresenter >> resetTo: anIndex [
 	"Remove all presenters up to anIndex.
 	0 means to remove all elements."
@@ -126,46 +128,46 @@ SpMillerColumnPresenter >> resetTo: anIndex [
 		index <= anIndex ifFalse: [ layout remove: presenter ] ]
 ]
 
-{ #category : #paginator }
+{ #category : 'paginator' }
 SpMillerColumnPresenter >> scrollByDeltaPercent: percent [
 	
 	self withAdapterDo: [ :anAdapter | 
 		anAdapter scrollByDeltaPercent: percent ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> selectPage: aNumber [
 
 	self withAdapterDo: [ :anAdapter |
 		anAdapter selectPage: aNumber ]
 ]
 
-{ #category : #model }
+{ #category : 'model' }
 SpMillerColumnPresenter >> setRootModel: aModel [
 
 	self resetTo: 0.
 	self pushModel: aModel
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> size [
 
 	^ self presenters size
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> spacing [
 
 	^ layout spacing
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> spacing: aNumber [
 
 	layout spacing: aNumber
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpMillerColumnPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	self pages do: [ :each | 
@@ -174,43 +176,43 @@ SpMillerColumnPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 			excluding: excludes ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> visiblePages [
 
 	^ layout visiblePages
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> visiblePages: aNumber [ 
 
 	layout visiblePages: aNumber
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMillerColumnPresenter >> whenColumnsChangedDo: aBlock [
 
 	columnsChangedBlock := aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMillerColumnPresenter >> whenColumnsWillChangeDo: aBlock [
 
 	columnsWillChangeBlock := aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMillerColumnPresenter >> whenHorizontalScrollBarChangedDo: aBlock [
 
 	self property: #horizontalScrollBar whenChangedDo: aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> withHorizontalScrollBar [
 
 	horizontalScrollBar := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerColumnPresenter >> withoutHorizontalScrollBar [
 
 	horizontalScrollBar := false

--- a/src/Spec2-Core/SpMillerPaginatorPresenter.class.st
+++ b/src/Spec2-Core/SpMillerPaginatorPresenter.class.st
@@ -3,23 +3,25 @@ A presenter that chains a miller list (`SpMillerColumnPresenter`) along with a p
 This is the most common usage of paginator, and there are several places where we want to use a miller list with pagination and this common presenter will be provifing basic functionality pre-made for consumption.
 "
 Class {
-	#name : #SpMillerPaginatorPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpMillerPaginatorPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'millerList',
 		'paginator',
 		'paginatorContainerLayout'
 	],
-	#category : #'Spec2-Core-Widgets-Advanced'
+	#category : 'Spec2-Core-Widgets-Advanced',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Advanced'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> addPresenter: aPresenter [
 
 	self millerListPresenter addPresenter: aPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMillerPaginatorPresenter >> initializePresenters [
 
 	self layout: (SpBoxLayout newTopToBottom
@@ -35,50 +37,50 @@ SpMillerPaginatorPresenter >> initializePresenters [
 	self updatePaginator: 1
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> millerListPresenter [
 
 	^ millerList
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerPaginatorPresenter >> newPaginator [
 		
 	^ self instantiate: SpPaginatorPresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> pages [
 
 	^ millerList pages
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> paginatorPresenter [
 
 	^ paginator
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> removeAllFrom: aPresenter [
 
 	millerList removeAllFrom: aPresenter.
 	self updatePaginator: ((millerList pages size - millerList visiblePages + 1) max: 1)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> selectPage: aNumber [ 
 
 	self millerListPresenter selectPage: aNumber
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> spacing: aNumber [
 
 	self millerListPresenter spacing: aNumber
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMillerPaginatorPresenter >> updatePaginator: pageSelected [
 
 	millerList pages size > 1 
@@ -97,7 +99,7 @@ SpMillerPaginatorPresenter >> updatePaginator: pageSelected [
 			paginator := nil ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpMillerPaginatorPresenter >> visiblePages: aNumber [
 
 	self millerListPresenter visiblePages: 1.

--- a/src/Spec2-Core/SpMillerPresenter.class.st
+++ b/src/Spec2-Core/SpMillerPresenter.class.st
@@ -2,12 +2,14 @@
 I'm a kind of API that a `SpMillerPresenter` should implement: basically one single method `whenActivedDo:`.
 "
 Class {
-	#name : #SpMillerPresenter,
-	#superclass : #SpPresenter,
-	#category : #'Spec2-Core-Miller'
+	#name : 'SpMillerPresenter',
+	#superclass : 'SpPresenter',
+	#category : 'Spec2-Core-Miller',
+	#package : 'Spec2-Core',
+	#tag : 'Miller'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMillerPresenter >> whenActivatedDo: aBlock [
 
 	self subclassResponsibility

--- a/src/Spec2-Core/SpModalWindowPresenter.class.st
+++ b/src/Spec2-Core/SpModalWindowPresenter.class.st
@@ -30,21 +30,23 @@ SomePresenter >> initializeDialogWindow: aDialogPresenter
 ```
 "
 Class {
-	#name : #SpModalWindowPresenter,
-	#superclass : #SpDialogWindowPresenter,
+	#name : 'SpModalWindowPresenter',
+	#superclass : 'SpDialogWindowPresenter',
 	#instVars : [
 		'#closeOnBackdropClick => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpModalWindowPresenter class >> adapterName [
 
 	^ #ModalWindowAdapter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpModalWindowPresenter >> closeOnBackdropClick [
 	"Answer if the user will be able to click on the backdrop to close the modal 
 	 launching the cancel action."
@@ -52,7 +54,7 @@ SpModalWindowPresenter >> closeOnBackdropClick [
 	^ closeOnBackdropClick
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpModalWindowPresenter >> closeOnBackdropClick: aBoolean [
 	"Set when the user will be able to click on the backdrop to close the modal 
 	 launching the cancel action."
@@ -60,7 +62,7 @@ SpModalWindowPresenter >> closeOnBackdropClick: aBoolean [
 	closeOnBackdropClick := aBoolean
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpModalWindowPresenter >> initialize [
 
 	super initialize.

--- a/src/Spec2-Core/SpMouseDoubleClickDefinition.class.st
+++ b/src/Spec2-Core/SpMouseDoubleClickDefinition.class.st
@@ -2,12 +2,14 @@
 I define a double click event
 "
 Class {
-	#name : #SpMouseDoubleClickDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpMouseDoubleClickDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpMouseDoubleClickDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installMouseDoubleClickEvent: self to: aWidget

--- a/src/Spec2-Core/SpMouseDownEventDefinition.class.st
+++ b/src/Spec2-Core/SpMouseDownEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a mouse down event
 "
 Class {
-	#name : #SpMouseDownEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpMouseDownEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpMouseDownEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installMouseDownEvent: self to: aWidget

--- a/src/Spec2-Core/SpMouseEnterEventDefinition.class.st
+++ b/src/Spec2-Core/SpMouseEnterEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a mouse enter event
 "
 Class {
-	#name : #SpMouseEnterEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpMouseEnterEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpMouseEnterEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installMouseEnterEvent: self to: aWidget

--- a/src/Spec2-Core/SpMouseLeaveEventDefinition.class.st
+++ b/src/Spec2-Core/SpMouseLeaveEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a key down event
 "
 Class {
-	#name : #SpMouseLeaveEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpMouseLeaveEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpMouseLeaveEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installMouseLeaveEvent: self to: aWidget

--- a/src/Spec2-Core/SpMouseMoveEventDefinition.class.st
+++ b/src/Spec2-Core/SpMouseMoveEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a mouse move event
 "
 Class {
-	#name : #SpMouseMoveEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpMouseMoveEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpMouseMoveEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installMouseMoveEvent: self to: aWidget

--- a/src/Spec2-Core/SpMouseUpEventDefinition.class.st
+++ b/src/Spec2-Core/SpMouseUpEventDefinition.class.st
@@ -2,12 +2,14 @@
 I define a mouse up event
 "
 Class {
-	#name : #SpMouseUpEventDefinition,
-	#superclass : #SpBaseEventDefinition,
-	#category : #'Spec2-Core-Base-Event'
+	#name : 'SpMouseUpEventDefinition',
+	#superclass : 'SpBaseEventDefinition',
+	#category : 'Spec2-Core-Base-Event',
+	#package : 'Spec2-Core',
+	#tag : 'Base-Event'
 }
 
-{ #category : #installing }
+{ #category : 'installing' }
 SpMouseUpEventDefinition >> installOn: anAdapter target: aWidget [
 
 	anAdapter installMouseUpEvent: self to: aWidget

--- a/src/Spec2-Core/SpMultipleSelectionMode.class.st
+++ b/src/Spec2-Core/SpMultipleSelectionMode.class.st
@@ -2,15 +2,17 @@
 Implement multiple selection mode (Users can select multiple element of list or table)
 "
 Class {
-	#name : #SpMultipleSelectionMode,
-	#superclass : #SpAbstractSelectionMode,
+	#name : 'SpMultipleSelectionMode',
+	#superclass : 'SpAbstractSelectionMode',
 	#instVars : [
 		'#selectedIndexes => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 SpMultipleSelectionMode >> basicSelectIndex: indexToSelect [
 
 	"Adding to the selection an out of range should not change selection"
@@ -19,54 +21,54 @@ SpMultipleSelectionMode >> basicSelectIndex: indexToSelect [
 	self selectIndexes: (self selectedIndexes copyWith: indexToSelect)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMultipleSelectionMode >> includesIndex: anIndex [
 
 	^ self selectedIndexes includes: anIndex
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMultipleSelectionMode >> includesIndexes: aCollection [
 	^ aCollection allSatisfy: [ :anIndex | self selectedIndexes includes: anIndex ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMultipleSelectionMode >> includesItem: anItem [
 
 	^ self selectedItems includes: anItem
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMultipleSelectionMode >> includesItems: aCollection [
 	^ aCollection allSatisfy: [ :anItem | self selectedItems includes: anItem ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMultipleSelectionMode >> initialize [
 	super initialize.
 	selectedIndexes := OrderedCollection new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMultipleSelectionMode >> isEmpty [
 	
 	^ self selectedIndexes isEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpMultipleSelectionMode >> isMultipleSelection [
 	
 	^ true
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectAll [
 	"Select all items."
 	
 	self selectIndexes: (1 to: self model size)
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectIndexes: aCollectionOfIndexes [
 	"Select items at positions included in `aCollectionOfIndexes`."
 	| indexes |
@@ -83,14 +85,14 @@ SpMultipleSelectionMode >> selectIndexes: aCollectionOfIndexes [
 	^ selectedIndexes := indexes
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectItems: aCollection [
 	"Select items included in `aCollection` if they are included in model list."
 
 	self selectIndexes: (aCollection collect: [ :anItem | self indexOfItem: anItem ])
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectedIndex [
 	"Answer the first selected index."
 
@@ -99,14 +101,14 @@ SpMultipleSelectionMode >> selectedIndex [
 		ifEmpty: [ 0 ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectedIndexes [
 	"Answer a collection with indexes of all selected items."
 
 	^ selectedIndexes
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectedItem [
 	"Answer first selected item."
 
@@ -115,39 +117,39 @@ SpMultipleSelectionMode >> selectedItem [
 		ifEmpty: [ nil ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> selectedItems [
 	"Answer a collection with all selected items."
 
 	^ self widget itemsAt: self selectedIndexes
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMultipleSelectionMode >> selectedItemsSortedByIndex [
 
 	^ self widget itemsAt: self selectedIndexes sort
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMultipleSelectionMode >> selectionHolder [
 	^ self observablePropertyNamed: #selectedIndexes
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> unselectAll [
 	"Remove all selections."
 	
 	self selectIndexes: #()
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpMultipleSelectionMode >> unselectIndex: anIndex [
 	"Unselect item at position `anInteger`."
 
 	self selectIndexes: (self selectedIndexes copyWithout: anIndex)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpMultipleSelectionMode >> whenChangedDo: aBlock [
 	"Inform when selection has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpNotebookPage.class.st
+++ b/src/Spec2-Core/SpNotebookPage.class.st
@@ -5,8 +5,8 @@ A page can have a title, an icon and some other interesting properties.
 An important member is `SpNotebookPage>>#presenterProvider`, which contains a block to retrieve the content of the page, which can be resolved lazily.
 "
 Class {
-	#name : #SpNotebookPage,
-	#superclass : #Object,
+	#name : 'SpNotebookPage',
+	#superclass : 'Object',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
 	#instVars : [
@@ -19,14 +19,16 @@ Class {
 		'#activePresenter => WeakSlot',
 		'#labelPresenter'
 	],
-	#category : #'Spec2-Core-Widgets-Tab'
+	#category : 'Spec2-Core-Widgets-Tab',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tab'
 }
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpNotebookPage class >> addDocumentExtraSections: aBuilder [
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpNotebookPage class >> addDocumentSectionFactoryMethod: aBuilder [
 	| selector |
 
@@ -43,13 +45,13 @@ SpNotebookPage class >> addDocumentSectionFactoryMethod: aBuilder [
 	aBuilder text: '.'
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpNotebookPage class >> documentFactoryMethodSelector [
 
 	^ #newNotebookPage
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpNotebookPage class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -61,7 +63,7 @@ SpNotebookPage class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpNotebookPage class >> title: aString icon: anIcon provider: aBlock [
 
 	^ self new 
@@ -71,7 +73,7 @@ SpNotebookPage class >> title: aString icon: anIcon provider: aBlock [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpNotebookPage class >> title: aString provider: aBlock [
 
 	^ self new 
@@ -80,35 +82,35 @@ SpNotebookPage class >> title: aString provider: aBlock [
 		yourself
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> activePresenter [
 	"Answer current active presenter fot this page (it may be nil, if page has not been displayed yet)"
 	
 	^ activePresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> beCloseable [
 	"Set the page as closeable, make a closing button to appear with the title."
 
 	closeable := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> icon [
 	"Answer the icon (an instance of `Form`) to show with title"
 
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> icon: anIcon [
 	"Set the icon (an instance of `Form`) to show with title"
 
 	icon := anIcon
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNotebookPage >> initialize [
 	
 	self class initializeSlots: self.
@@ -116,14 +118,14 @@ SpNotebookPage >> initialize [
 	closeable := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpNotebookPage >> isCloseable [
 	"Answer when the page is closeable or not"
 
 	^ closeable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNotebookPage >> labelPresenterFor: ownerPresenter [
 	"There is one, and *just one* active label presenter for each page.
 	 The only case I can think that can be changed is if owner changed (if we move the page from 
@@ -137,7 +139,7 @@ SpNotebookPage >> labelPresenterFor: ownerPresenter [
 	^ labelPresenter
 ]
 
-{ #category : #'private - factory' }
+{ #category : 'private - factory' }
 SpNotebookPage >> newLabelPresenterFor: ownerPresenter [
 	"override this to implement custom labels"
 
@@ -146,33 +148,33 @@ SpNotebookPage >> newLabelPresenterFor: ownerPresenter [
 		on: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNotebookPage >> owner [
 
 	^ owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNotebookPage >> owner: anObject [
 
 	owner := anObject
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPage >> pageTitleChanged [
 
 	self owner ifNil: [ ^ self ].
 	self owner pageTitleChanged: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> presenterProvider [
 	"Answer the presenter provider (tipically a block, but any valuable could work)."
 
 	^ presenterProvider
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> presenterProvider: aBlock [
 	"Set the presenter provider (tipically a block, but any valuable could work).
 	 The block will be executed before showing the page contents."
@@ -180,21 +182,21 @@ SpNotebookPage >> presenterProvider: aBlock [
 	presenterProvider := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> removeFromNotebook [
 	"Remove this page from the notebook."
 
 	owner removePage: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> resetContent [
 	"force a redraw of contents of this page (next time it is selected)"
 	
 	self owner updatePageContent: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPage >> retrievePresenter [
 	"refresh all the time, because content may have change"
 
@@ -204,21 +206,21 @@ SpNotebookPage >> retrievePresenter [
 	^ activePresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> title [
 	"Answer the title to show in the notebook"
 
 	^ title
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPage >> title: aString [
 	"Set the title to show in the notebook"
 
 	title := aString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPage >> unsubscribe: anObject [
 	| observableSlots |
 	
@@ -231,13 +233,13 @@ SpNotebookPage >> unsubscribe: anObject [
 				slotValue unsubscribe: anObject ] ].
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPage >> whenIconChangedDo: aBlock [
 
 	self property: #icon whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPage >> whenRetrievedDo: aBlock [ 
 	"Inform when a page has been retrived, allowing extra settings.
 	 `aBlock` is a block with one orgument (the presenter retrieved)"
@@ -245,7 +247,7 @@ SpNotebookPage >> whenRetrievedDo: aBlock [
 	retrievedBlock := aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPage >> whenTitleChangedDo: aBlock [
 
 	self property: #title whenChangedDo: aBlock

--- a/src/Spec2-Core/SpNotebookPageLabelPresenter.class.st
+++ b/src/Spec2-Core/SpNotebookPageLabelPresenter.class.st
@@ -3,18 +3,20 @@ A presenter that acts as tab label for the notebook page.
 It is possible to put any widget in as label, this is just the ""default"" implementation.
 "
 Class {
-	#name : #SpNotebookPageLabelPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpNotebookPageLabelPresenter',
+	#superclass : 'SpPresenter',
 	#traits : 'SpTModel',
 	#classTraits : 'SpTModel classTrait',
 	#instVars : [
 		'labelPresenter',
 		'iconPresenter'
 	],
-	#category : #'Spec2-Core-Widgets-Tab'
+	#category : 'Spec2-Core-Widgets-Tab',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tab'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNotebookPageLabelPresenter >> initializePresenters [
 
 	self layout: (SpBoxLayout newLeftToRight
@@ -46,13 +48,13 @@ SpNotebookPageLabelPresenter >> initializePresenters [
 	"self eventHandler whenDoubleClickDo: [ :event | 'ok' crTrace  ]."
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNotebookPageLabelPresenter >> label [
 
 	^ labelPresenter label
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpNotebookPageLabelPresenter >> model: aModel [
 
 	(model notNil 
@@ -63,19 +65,19 @@ SpNotebookPageLabelPresenter >> model: aModel [
 	self updatePresenter
 ]
 
-{ #category : #subscription }
+{ #category : 'subscription' }
 SpNotebookPageLabelPresenter >> unsubscribePage: aPage [
 
 	aPage unsubscribe: self
 ]
 
-{ #category : #'private - updating' }
+{ #category : 'private - updating' }
 SpNotebookPageLabelPresenter >> updateIcon [
 
 	iconPresenter image: self model icon
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNotebookPageLabelPresenter >> updatePresenter [
 
 	self model 
@@ -83,7 +85,7 @@ SpNotebookPageLabelPresenter >> updatePresenter [
 		whenIconChangedDo: [ self updateIcon ]
 ]
 
-{ #category : #'private - updating' }
+{ #category : 'private - updating' }
 SpNotebookPageLabelPresenter >> updateTitle [
 
 	labelPresenter label: self model title

--- a/src/Spec2-Core/SpNotebookPresenter.class.st
+++ b/src/Spec2-Core/SpNotebookPresenter.class.st
@@ -3,28 +3,30 @@ I'm a presenter for a tabbed notebook container.
 This is a container whos children are pages (instances of `SpNotebookPage`), which have a title and a content.
 "
 Class {
-	#name : #SpNotebookPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpNotebookPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#pagesHolder',
 		'#selectedPage => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Tab'
+	#category : 'Spec2-Core-Widgets-Tab',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tab'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpNotebookPresenter class >> adapterName [
 
 	^ #NotebookAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpNotebookPresenter class >> documentFactoryMethodSelector [
 
 	^ #newNotebook
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> addPage: aPage [
 	"Add a page (an instance of `SpNotebookPage`) to the notebook."
 
@@ -32,14 +34,14 @@ SpNotebookPresenter >> addPage: aPage [
 	pagesHolder add: aPage
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> addPageTitle: aString provider: aBlock [ 
 	"A convenience method to directly add a page with a provider."
 	
 	^ self addPage: (SpNotebookPage title: aString provider: aBlock)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNotebookPresenter >> initialize [
 
 	super initialize.
@@ -47,26 +49,26 @@ SpNotebookPresenter >> initialize [
 	pagesHolder whenChangedDo: [ self pagesChanged ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPresenter >> pageAt: index [
 
 	^ self pages at: index
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPresenter >> pageTitleChanged: aPage [ 
 
 	self changed: #updatePageTitle: with: { aPage }
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> pages [ 
 	"Answer all pages in the notebook."
 
 	^ pagesHolder value
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> pages: aCollection [
 	"Set all pages of the notebook.
 	 `aCollection` contains instances of `SpNotebookPage`."
@@ -76,13 +78,13 @@ SpNotebookPresenter >> pages: aCollection [
 	pagesHolder valueChanged: nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPresenter >> pagesChanged [
 
 	self changed: #updatePages
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> removeAll [
 	"Remove all pages in notebook"
 	
@@ -90,28 +92,28 @@ SpNotebookPresenter >> removeAll [
 	pagesHolder removeAll
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> removePage: aPage [
 	"Remove the page `aPage` from the notebook."
 	
 	pagesHolder remove: aPage
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> removePageAt: anIndex [
 	"Remove the page at index `anIndex`."
 
 	pagesHolder removeAt: anIndex
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> resetAllPageContents [
 	"Resets all page contents, forcing a refresh next time a page is selected."
 
 	self pages do: [ :each | each resetContent ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> selectPage: aPage [
 	"Selects the page `aPage` from the notebook, switching to show it."
 
@@ -119,21 +121,21 @@ SpNotebookPresenter >> selectPage: aPage [
 	selectedPage := aPage
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> selectPageIndex: aNumber [
 	"Select the page with the index `aNumber`."
 
 	self selectPage: (self pages at: aNumber)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> selectedPage [
 	"Answer current selected page."
 
 	^ selectedPage
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNotebookPresenter >> selectedPageIndex [
 	"Answer the index of selected page"
 	| page |
@@ -144,7 +146,7 @@ SpNotebookPresenter >> selectedPageIndex [
 	^ self pages indexOf: page
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpNotebookPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	excludes add: self.
@@ -156,14 +158,14 @@ SpNotebookPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 		excluding: excludes
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNotebookPresenter >> updatePageContent: aPage [
 
 	self withAdapterDo: [ :anAdapter | 
 		anAdapter updatePageContent: aPage ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPresenter >> whenPageAddedDo: aBlock [
 	"Inform when a page has been added.
 	 `aBlock` receives one argument (the added page)"
@@ -171,7 +173,7 @@ SpNotebookPresenter >> whenPageAddedDo: aBlock [
 	pagesHolder whenAddedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPresenter >> whenPageRemovedDo: aBlock [
 	"Inform when a page has been removed.
 	 `aBlock` receives one argument (the removed page)"
@@ -179,7 +181,7 @@ SpNotebookPresenter >> whenPageRemovedDo: aBlock [
 	pagesHolder whenRemovedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPresenter >> whenPagesChangedDo: aBlock [
 	"Inform when pages has been changed.
 	 `aBlock` has three optional arguments: 
@@ -190,7 +192,7 @@ SpNotebookPresenter >> whenPagesChangedDo: aBlock [
 	pagesHolder whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNotebookPresenter >> whenSelectedPageChangedDo: aBlock [
 	"Inform when selected page has changed.
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpNullApplication.class.st
+++ b/src/Spec2-Core/SpNullApplication.class.st
@@ -3,12 +3,14 @@ I'm a default application for the case where no application is defined.
 I'm meant to provide backwards compatibility and I SHOULD NOT BE USED REGULARLY.
 "
 Class {
-	#name : #SpNullApplication,
-	#superclass : #SpApplication,
-	#category : #'Spec2-Core-Base'
+	#name : 'SpNullApplication',
+	#superclass : 'SpApplication',
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 SpNullApplication class >> reset [
 	<script>
 	

--- a/src/Spec2-Core/SpNullMillerPresenter.class.st
+++ b/src/Spec2-Core/SpNullMillerPresenter.class.st
@@ -3,15 +3,17 @@ I'm a basic miller presenter that wraps a non-miller presenter and does nothing 
 Useful to wrap elements that do not need to flow to the right.
 "
 Class {
-	#name : #SpNullMillerPresenter,
-	#superclass : #SpMillerPresenter,
+	#name : 'SpNullMillerPresenter',
+	#superclass : 'SpMillerPresenter',
 	#instVars : [
 		'wrappedPresenter'
 	],
-	#category : #'Spec2-Core-Miller'
+	#category : 'Spec2-Core-Miller',
+	#package : 'Spec2-Core',
+	#tag : 'Miller'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpNullMillerPresenter class >> defaultLayout [
 	
 	^ SpBoxLayout newLeftToRight
@@ -19,19 +21,19 @@ SpNullMillerPresenter class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNullMillerPresenter >> setModelBeforeInitialization: aModel [
 
 	wrappedPresenter := aModel.
 	wrappedPresenter owner: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNullMillerPresenter >> whenActivatedDo: aBlock [
 	"Do nothing"
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNullMillerPresenter >> wrappedPresenter [
 
 	^ wrappedPresenter

--- a/src/Spec2-Core/SpNullPresenter.class.st
+++ b/src/Spec2-Core/SpNullPresenter.class.st
@@ -3,12 +3,14 @@ A null presenter that contains nothing.
 Used by DynamicPresentersListBuilder to fill empty space when required for the layout.
 "
 Class {
-	#name : #SpNullPresenter,
-	#superclass : #SpPresenter,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpNullPresenter',
+	#superclass : 'SpPresenter',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpNullPresenter class >> defaultLayout [
 	"Returns empty layout. That's the point of null presenter."
 

--- a/src/Spec2-Core/SpNumberInputFieldPresenter.class.st
+++ b/src/Spec2-Core/SpNumberInputFieldPresenter.class.st
@@ -4,8 +4,8 @@ A presenter  for a  text field specialised on numbers.
 
 "
 Class {
-	#name : #SpNumberInputFieldPresenter,
-	#superclass : #SpTextInputFieldPresenter,
+	#name : 'SpNumberInputFieldPresenter',
+	#superclass : 'SpTextInputFieldPresenter',
 	#instVars : [
 		'#numberType => ObservableSlot',
 		'#minimum => ObservableSlot',
@@ -13,76 +13,78 @@ Class {
 		'#climbRate => ObservableSlot',
 		'#digits => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpNumberInputFieldPresenter class >> adapterName [
 
 	^ #NumberInputFieldAdapter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNumberInputFieldPresenter class >> defaultClimbRate [
 
 	^ 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNumberInputFieldPresenter class >> defaultDigits [
 
 	^ 2
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpNumberInputFieldPresenter class >> documentFactoryMethodSelector [
 
 	^ #newNumberInput
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> beFloat [
 	"Set the presenter to display float numbers"
 
 	self numberType: Float
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> beInteger [
 	"Set the presenter to display integer numbers"
 
 	self numberType: Integer
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> climbRate [
 	"Answer the jump rate when a spin is present."
 
 	^ climbRate
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> climbRate: aNumber [
 	"Set the jump rate when a spin is present."
 
 	climbRate := aNumber
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> digits [
 	"Answer digits to show when we have a float number"
 
 	^ digits
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> digits: aNumber [
 	"Set digits to show when we have a float number"
 
 	digits := aNumber
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpNumberInputFieldPresenter >> initialize [
 
 	super initialize.
@@ -91,49 +93,49 @@ SpNumberInputFieldPresenter >> initialize [
 	self climbRate: self class defaultClimbRate.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpNumberInputFieldPresenter >> isFloat [ 
 	"Answer if the number type is a float."
 
 	^ self numberType = Float
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpNumberInputFieldPresenter >> isInteger [ 
 	"Answer if the number type is an integer."
 
 	^ self numberType = Integer
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> maximum [
 	"Answer the maximum number to accept (it can be nil, if not maximum is set)"
 
 	^ maximum
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> maximum: aNumber [
 	"Set the maximum number to accept"
 
 	maximum := aNumber
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> minimum [
 	"Answer the minimum number to accept (it can be nil, if not minimum is set)"
 
 	^ minimum
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> minimum: aNumber [
 	"Answer the minimum number to accept."
 
 	minimum := aNumber
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> number [
 	"Answer the number ingressed."
 
@@ -142,7 +144,7 @@ SpNumberInputFieldPresenter >> number [
 		ifEmpty: [ 0 ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> number: aNumber [
 	"Set the number to display."
 
@@ -150,21 +152,21 @@ SpNumberInputFieldPresenter >> number: aNumber [
 
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> numberType [
 	"Answer the type of number the input field will show (Integer or Float)"
 
 	^ numberType
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpNumberInputFieldPresenter >> numberType: aClass [
 	"This can be Integer or Float, no more"
 
 	numberType := aClass
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpNumberInputFieldPresenter >> rangeMinimum: minNumber maximum: maxNumber [ 
 	"A convenience method to set the maximum and minimum values to accept."
 
@@ -172,7 +174,7 @@ SpNumberInputFieldPresenter >> rangeMinimum: minNumber maximum: maxNumber [
 	self maximum: maxNumber
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNumberInputFieldPresenter >> whenClimbRateChangedDo: aBlock [
 	"Inform when climbRate property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -183,7 +185,7 @@ SpNumberInputFieldPresenter >> whenClimbRateChangedDo: aBlock [
 	self property: #climbRate whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNumberInputFieldPresenter >> whenDigitsChangedDo: aBlock [
 	"Inform when digits property state has changed. 
 	 `aBlock` has three optional arguments: 
@@ -194,7 +196,7 @@ SpNumberInputFieldPresenter >> whenDigitsChangedDo: aBlock [
 	self property: #digits whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNumberInputFieldPresenter >> whenMaximumChangedDo: aBlock [
 	"Inform when maximum property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -205,7 +207,7 @@ SpNumberInputFieldPresenter >> whenMaximumChangedDo: aBlock [
 	self property: #maximum whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNumberInputFieldPresenter >> whenMinimumChangedDo: aBlock [
 	"Inform when minimum property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -216,7 +218,7 @@ SpNumberInputFieldPresenter >> whenMinimumChangedDo: aBlock [
 	self property: #minimum whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNumberInputFieldPresenter >> whenNumberChangedDo: aBlock [
 	"Inform when number property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -227,7 +229,7 @@ SpNumberInputFieldPresenter >> whenNumberChangedDo: aBlock [
 	self whenTextChangedDo: [ :txt | aBlock value: self number ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpNumberInputFieldPresenter >> whenNumberTypeChangedDo: aBlock [
 	"Inform when numberType property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpPharoThemeIconProvider.class.st
+++ b/src/Spec2-Core/SpPharoThemeIconProvider.class.st
@@ -2,12 +2,14 @@
 I'm a provider that redirects to the default Pharo icon provider.
 "
 Class {
-	#name : #SpPharoThemeIconProvider,
-	#superclass : #SpIconProvider,
-	#category : #'Spec2-Core-IconProvider'
+	#name : 'SpPharoThemeIconProvider',
+	#superclass : 'SpIconProvider',
+	#category : 'Spec2-Core-IconProvider',
+	#package : 'Spec2-Core',
+	#tag : 'IconProvider'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPharoThemeIconProvider >> iconNamed: aName [ 
 
 	^ self 
@@ -15,7 +17,7 @@ SpPharoThemeIconProvider >> iconNamed: aName [
 		ifAbsent: [ self noIcon ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPharoThemeIconProvider >> iconNamed: aName ifAbsent: aBlock [
 
 	aName ifNil: [ ^ aBlock value ].
@@ -25,7 +27,7 @@ SpPharoThemeIconProvider >> iconNamed: aName ifAbsent: aBlock [
 		ifNone: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPharoThemeIconProvider >> noIcon [
 
 	^ ThemeIcons current blankIcon

--- a/src/Spec2-Core/SpPopoverBottomPosition.class.st
+++ b/src/Spec2-Core/SpPopoverBottomPosition.class.st
@@ -2,12 +2,14 @@
 I define a popover needs to be shown at the bottom of its owner.
 "
 Class {
-	#name : #SpPopoverBottomPosition,
-	#superclass : #SpPopoverPosition,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpPopoverBottomPosition',
+	#superclass : 'SpPopoverPosition',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SpPopoverBottomPosition >> applyTo: aWidget [
 
 	aWidget bePositionBottom

--- a/src/Spec2-Core/SpPopoverContentPresenter.class.st
+++ b/src/Spec2-Core/SpPopoverContentPresenter.class.st
@@ -3,12 +3,14 @@ A popover content presenter.
 All popovers contents need to extent this presenter (to get some functionalies).
 "
 Class {
-	#name : #SpPopoverContentPresenter,
-	#superclass : #SpPresenter,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpPopoverContentPresenter',
+	#superclass : 'SpPresenter',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverContentPresenter >> dismiss [
 
 	^ self owner dismiss

--- a/src/Spec2-Core/SpPopoverLeftPosition.class.st
+++ b/src/Spec2-Core/SpPopoverLeftPosition.class.st
@@ -2,12 +2,14 @@
 I define a popover needs to be shown at the left of its owner.
 "
 Class {
-	#name : #SpPopoverLeftPosition,
-	#superclass : #SpPopoverPosition,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpPopoverLeftPosition',
+	#superclass : 'SpPopoverPosition',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SpPopoverLeftPosition >> applyTo: aWidget [
 
 	aWidget bePositionLeft

--- a/src/Spec2-Core/SpPopoverPosition.class.st
+++ b/src/Spec2-Core/SpPopoverPosition.class.st
@@ -3,45 +3,47 @@ I represent the position of a popover in relation to its owner.
 I am an abstract class and my children will define: top, left, bottom or right position.
 "
 Class {
-	#name : #SpPopoverPosition,
-	#superclass : #Object,
+	#name : 'SpPopoverPosition',
+	#superclass : 'Object',
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPopoverPosition class >> bottom [
 
 	^ SpPopoverBottomPosition uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPopoverPosition class >> left [
 
 	^ SpPopoverLeftPosition uniqueInstance
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPopoverPosition class >> new [
 
 	self error: 'Use #uniqueInstance'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPopoverPosition class >> right [
 
 	^ SpPopoverRightPosition uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPopoverPosition class >> top [
 
 	^ SpPopoverTopPosition uniqueInstance
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPopoverPosition class >> uniqueInstance [
 
 	self = SpPopoverPosition 
@@ -49,7 +51,7 @@ SpPopoverPosition class >> uniqueInstance [
 	^ uniqueInstance ifNil: [ uniqueInstance := self basicNew initialize ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SpPopoverPosition >> applyTo: aWidget [
 
 	self subclassResponsibility

--- a/src/Spec2-Core/SpPopoverPresenter.class.st
+++ b/src/Spec2-Core/SpPopoverPresenter.class.st
@@ -6,29 +6,31 @@ Also, it can be show at the top, left, bottom or right of the owner or rectangle
 The presenter placed on a popover needs to extend `SpPopoverContentPresenter` (or implement its API) to gain all properties.
 "
 Class {
-	#name : #SpPopoverPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpPopoverPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#presenter => ObservableSlot',
 		'#position',
 		'#relativeTo'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpPopoverPresenter class >> adapterName [
 
 	^ #PopoverAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpPopoverPresenter class >> documentFactoryMethodSelector [
 
 	^ #newPopover
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> bePositionBottom [
 	"Set the popover to appear at the bottom of the owner (or the presenter set 
 	 by `SpPopoverPresenter>>#relativeTo:`). 
@@ -37,7 +39,7 @@ SpPopoverPresenter >> bePositionBottom [
 	self position: SpPopoverPosition bottom
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> bePositionLeft [
 	"Set the popover to appear at the left of the owner (or the presenter set 
 	 by `SpPopoverPresenter>>#relativeTo:`)
@@ -46,7 +48,7 @@ SpPopoverPresenter >> bePositionLeft [
 	self position: SpPopoverPosition left
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> bePositionRight [
 	"Set the popover to appear at the right of the owner (or the presenter set 
 	 by `SpPopoverPresenter>>#relativeTo:`)
@@ -55,7 +57,7 @@ SpPopoverPresenter >> bePositionRight [
 	self position: SpPopoverPosition right
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> bePositionTop [
 	"Set the popover to appear at the top of the owner (or the presenter set 
 	 by `SpPopoverPresenter>>#relativeTo:`)
@@ -64,27 +66,27 @@ SpPopoverPresenter >> bePositionTop [
 	self position: SpPopoverPosition top
 ]
 
-{ #category : #'api - focus' }
+{ #category : 'api - focus' }
 SpPopoverPresenter >> defaultKeyboardFocus [
 
 	^ self presenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> dismiss [ 
 	"Dismiss this popover"
 
 	^ self withAdapterDo: [ :anAdapter | anAdapter dismiss ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPopoverPresenter >> initialize [
 
 	super initialize.
 	self bePositionBottom
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> popup [
 
 	"Shows the popover, relative to `SpPopoverPresenter>>#relativeTo`."
@@ -93,7 +95,7 @@ SpPopoverPresenter >> popup [
 	self withAdapterDo: [ :anAdapter | anAdapter popup ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> popupPointingTo: aRectangle [
 	"Shows the popover, relative to `SpPopoverPresenter>>#relativeTo`, and 
 	 pointing to `aRectangle`"
@@ -103,28 +105,28 @@ SpPopoverPresenter >> popupPointingTo: aRectangle [
 		anAdapter popupPointingTo: aRectangle ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> position [
 	"Answer the position (top, left, bottom, right) of the presenter."
 
 	^ position
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> position: aPosition [
 	"Set the position (top, left, bottom, right) of the presenter."
 
 	position := aPosition
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> presenter [
 	"Answer the presenter that will be shown by the popover."
 
 	^ presenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> presenter: aPresenter [
 	"Set the presenter that will be shown by the popover."
 
@@ -132,21 +134,21 @@ SpPopoverPresenter >> presenter: aPresenter [
 	presenter := aPresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> relativeTo [
 	"Answer the presenter that will show the popover (and the popover will be shown relative to it)."
 
 	^ relativeTo ifNil: [ self owner ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPopoverPresenter >> relativeTo: aPresenter [
 	"Set the presenter that will show the popover (and the popover will be shown relative to it)."
 
 	relativeTo := aPresenter
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpPopoverPresenter >> whenPresenterChangedDo: aBlock [
 	"Inform when content presenter has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpPopoverRightPosition.class.st
+++ b/src/Spec2-Core/SpPopoverRightPosition.class.st
@@ -2,12 +2,14 @@
 I define a popover needs to be shown at the right of its owner.
 "
 Class {
-	#name : #SpPopoverRightPosition,
-	#superclass : #SpPopoverPosition,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpPopoverRightPosition',
+	#superclass : 'SpPopoverPosition',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SpPopoverRightPosition >> applyTo: aWidget [
 
 	aWidget bePositionRight

--- a/src/Spec2-Core/SpPopoverTopPosition.class.st
+++ b/src/Spec2-Core/SpPopoverTopPosition.class.st
@@ -2,12 +2,14 @@
 I define a popover needs to be shown at the top of its owner.
 "
 Class {
-	#name : #SpPopoverTopPosition,
-	#superclass : #SpPopoverPosition,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpPopoverTopPosition',
+	#superclass : 'SpPopoverPosition',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SpPopoverTopPosition >> applyTo: aWidget [
 
 	aWidget bePositionTop

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -82,8 +82,8 @@ SpMyPresenter >> initializeLayout
 
 "
 Class {
-	#name : #SpPresenter,
-	#superclass : #SpAbstractPresenter,
+	#name : 'SpPresenter',
+	#superclass : 'SpAbstractPresenter',
 	#traits : 'SpTPresenterBuilder',
 	#classTraits : 'SpTPresenterBuilder classTrait',
 	#instVars : [
@@ -100,31 +100,33 @@ Class {
 		'#extent => ObservableSlot',
 		'#styles'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter class >> currentApplication [ 
 
 	^ SpApplication defaultApplication
 ]
 
-{ #category : #'labeled-presenters' }
+{ #category : 'labeled-presenters' }
 SpPresenter class >> iconWidth [
 	^ 24
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPresenter class >> isAbstract [
 	^ self = SpPresenter
 ]
 
-{ #category : #'labeled-presenters' }
+{ #category : 'labeled-presenters' }
 SpPresenter class >> labelWidth [
 	^ 100
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter class >> newApplication: anApplication [
 
 	^ self basicNew
@@ -133,7 +135,7 @@ SpPresenter class >> newApplication: anApplication [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter class >> newApplication: anApplication model: aModel [
 
 	^ self basicNew
@@ -143,7 +145,7 @@ SpPresenter class >> newApplication: anApplication model: aModel [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter class >> newApplication: anApplication owner: anOwningPresenter [
 
 	^ self basicNew
@@ -153,7 +155,7 @@ SpPresenter class >> newApplication: anApplication owner: anOwningPresenter [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter class >> newApplication: anApplication owner: anOwningPresenter model: aDomainObject [
 
 	^ self basicNew
@@ -164,7 +166,7 @@ SpPresenter class >> newApplication: anApplication owner: anOwningPresenter mode
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter class >> on: aDomainObject [
 
 	^ self 
@@ -172,7 +174,7 @@ SpPresenter class >> on: aDomainObject [
 		model: aDomainObject 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter class >> owner: anOwningPresenter on: aDomainObject [
 
 	^ self basicNew
@@ -182,13 +184,13 @@ SpPresenter class >> owner: anOwningPresenter on: aDomainObject [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpPresenter class >> title [
 	
 	^ 'Untitled window'
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> aboutText [
 	"DO NOT USE
 	With Spec 2, SpPresenter was refactored to move all window management to WindowPresenter.
@@ -201,7 +203,7 @@ SpPresenter >> aboutText [
 	^ aboutText
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> addAll: aWindow withSpecLayout: aSpec [
 
 	aWindow
@@ -209,7 +211,7 @@ SpPresenter >> addAll: aWindow withSpecLayout: aSpec [
 		frame: (0@0 corner: 1@1).
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenter >> addStyle: aName [
 	"Add a style-class to a presenter. Styles are defined in the application stylesheet and will 
 	 affect presenters by applying the properties the user adds to the class.
@@ -227,7 +229,7 @@ SpPresenter >> addStyle: aName [
 	self withAdapterDo: [ :anAdapter | anAdapter addStyle: aName ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> additionalSubpresentersMap [
 
 	"additionalSubpresentersMap serves for storing of sub-presenters that are not
@@ -237,14 +239,14 @@ SpPresenter >> additionalSubpresentersMap [
 	^ additionalSubpresentersMap ifNil: [ additionalSubpresentersMap := Dictionary new ]
 ]
 
-{ #category : #'simple dialog helpers' }
+{ #category : 'simple dialog helpers' }
 SpPresenter >> alert: aString [
 	"Displays a simple inform dialog, for more configurable version please use `self application newInform title: ....`."
 
 	^ self application alert: aString
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> allPresenters [
 	"This answers ALL presenters included in this presenter, the ones that are in the layout 
 	 BUT ALSO the presenters in other embeded presenters
@@ -262,7 +264,7 @@ SpPresenter >> allPresenters [
 			stream << each ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> allPresentersInFocusOrder [
 	"This answers ALL presenters included in this presenter, the ones that are in the layout 
 	 BUT ALSO the presenters in other embeded presenters. 
@@ -274,13 +276,13 @@ SpPresenter >> allPresentersInFocusOrder [
 			stream << each  ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> announce: anAnnouncement [
 
 	self announcer announce: anAnnouncement
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> announceDisplayed [
 	"When using a VersatileDialogPresenter the adapter is nil.
 	We do not know if that is a correct behaviour"
@@ -293,7 +295,7 @@ SpPresenter >> announceDisplayed [
 				yourself)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> application [
 
 	^ self hasOwner 
@@ -307,13 +309,13 @@ SpPresenter >> application [
 				application := SpApplication defaultApplication ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> application: anApplication [
 
 	application := anApplication
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> applyKeyBindingsFromMenu: aMenuPresenter [
 	"traverses aMenuPresenter and bind shortcuts associated "
 
@@ -326,21 +328,21 @@ SpPresenter >> applyKeyBindingsFromMenu: aMenuPresenter [
 			item subMenu ifNotNil: [ :subMenu | subMenu addKeybindingsTo: self	] ] ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 SpPresenter >> asPresenter [
 	"This allows to use presenter instances inside layouts directly"
 
 	^ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 SpPresenter >> asPresenterOn: aPresenter [
 	"This allows to use presenter instances inside layouts directly"
 
 	^ self
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> askOkToClose [
 	"DO NOT USE
 	With Spec 2, SpPresenter was refactored to move all window management to WindowPresenter.
@@ -353,14 +355,14 @@ SpPresenter >> askOkToClose [
 	^ askOkToClose
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpPresenter >> basicBuildAdapterWithLayout: aSpecLayout [
 
 	layout == aSpecLayout ifFalse: [ layout := aSpecLayout ].
 	^ super basicBuildAdapterWithLayout: aSpecLayout
 ]
 
-{ #category : #'api - shortcuts' }
+{ #category : 'api - shortcuts' }
 SpPresenter >> bindKeyCombination: aShortcut toAction: aBlock [
 	"Adds a single shortcut to the list of `SpPresenter>>#contextKeyBindings`. Action `aBlock` 
 	 will be executed when presenter the key combination is presseed.
@@ -375,27 +377,27 @@ SpPresenter >> bindKeyCombination: aShortcut toAction: aBlock [
 		anAdapter bindKeyCombination: aShortcut toAction: aBlock ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPresenter >> canTakeKeyboardFocus [
 	"Answer when the presenter can take keyboard focus."
 
 	^ true
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> cancelled [
 	self flag: #TODO. "just for dialogs... I wonder if we need it here?"
 
 	self withWindowDo: #cancelled
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> centered [
 
 	self withWindowDo: #centered
 ]
 
-{ #category : #'simple dialog helpers' }
+{ #category : 'simple dialog helpers' }
 SpPresenter >> confirm: aString [
 	"Displays a simple confirm dialog, for more configurable version please use `self application newConfirm title: ....`."
 
@@ -403,12 +405,12 @@ SpPresenter >> confirm: aString [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenter >> connectPresenters [
 	"The method connectPresenters defines the interactions between the different widgets. By connecting the behaviors of the different widgets it specifies the overall presentation, i.e., how the overall UI responds to interactions by the user. Usually this method consists of specifications of actions to perform when a certain event is received by a widget. The whole interaction flow of the UI then emerges from the propagation of those events."
 ]
 
-{ #category : #'api - shortcuts' }
+{ #category : 'api - shortcuts' }
 SpPresenter >> contextKeyBindings [
 	"Answer contextKeyBindings stores a KMCategory with keybindings for this presenter. 
 	 Note that not all presenters can have key bindings, just the ones that can take the 
@@ -418,7 +420,7 @@ SpPresenter >> contextKeyBindings [
 	^ contextKeyBindings
 ]
 
-{ #category : #'api - shortcuts' }
+{ #category : 'api - shortcuts' }
 SpPresenter >> contextKeyBindings: aKMCategory [
 	"Set the context keybindings for this presenter."
 	
@@ -427,7 +429,7 @@ SpPresenter >> contextKeyBindings: aKMCategory [
 		ifNil: [ aKMCategory ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> createInstanceFor: aClassSymbol [
 	"Retrieve the class corresponding to aClassSymbol using the bindings, then create a new instance of this class"
 
@@ -436,7 +438,7 @@ SpPresenter >> createInstanceFor: aClassSymbol [
 	^ self instantiate: class.
 ]
 
-{ #category : #'api - focus' }
+{ #category : 'api - focus' }
 SpPresenter >> defaultKeyboardFocus [
 	"Answer the presentar that will act as default responder when showing this presenter or 
 	 receive the `SpPresenter>>#takeKeyboardFocus` message. By default, this answers self, 
@@ -445,47 +447,47 @@ SpPresenter >> defaultKeyboardFocus [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> defer: aBlock [
 
 	self application defer: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> delete [
 
 	self withWindowDo: #delete
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> enabled: aBoolean [
 
 	self presentersDo: [ :each | 
 		each enabled: aBoolean ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> extent [
 	^ extent
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> extent: aPoint [
 	^ extent := aPoint
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> focusOrder [
 
 	^ focusOrder ifNil: [ focusOrder := OrderedCollection new ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> focusOrder: anObject [
 	^ focusOrder := anObject
 ]
 
-{ #category : #'api - focus' }
+{ #category : 'api - focus' }
 SpPresenter >> focusedPresenter [
 	"Answer the focused presenter if any (nil if no presenter is focused)"
 
@@ -494,7 +496,7 @@ SpPresenter >> focusedPresenter [
 		ifNone: [ nil ]
 ]
 
-{ #category : #'api - focus' }
+{ #category : 'api - focus' }
 SpPresenter >> hasKeyboardFocus [
 	"Answer true if this presenter has the active keyboard focus."
 
@@ -503,27 +505,27 @@ SpPresenter >> hasKeyboardFocus [
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenter >> hide [
 	"hide current presenter making it invisible for the user"
 
 	visible := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> iconNamed: aSymbol [
 
 	^ self application iconNamed: aSymbol
 ]
 
-{ #category : #'simple dialog helpers' }
+{ #category : 'simple dialog helpers' }
 SpPresenter >> inform: aString [
 	"Displays a simple inform dialog, for more configurable version please use `self application newInform title: ....`."
 
 	^ self application inform: aString
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> initialExtent [
 	
 	"DO NOT USE
@@ -536,7 +538,7 @@ SpPresenter >> initialExtent [
 	^ nil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenter >> initialize [
 
 	super initialize.
@@ -550,7 +552,7 @@ SpPresenter >> initialize [
 	self initializePrivateAnnouncements
 ]
 
-{ #category : #'initialization - deprecated' }
+{ #category : 'initialization - deprecated' }
 SpPresenter >> initializePresenter [
 	"Now, presenters should implement #connectPresenters instead."
 	"Obsolete. Do not use me, use connectPresenters"
@@ -562,7 +564,7 @@ SpPresenter >> initializePresenter [
 					ifTrue: [ widget extent: ex ] ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenter >> initializePresenters [
 	"The method initializePresenters instantiates, saves in instance vari- ables, and partially configures the different widgets that will be part of the UI.
 	In general the initializePresenters method should follow the pattern:
@@ -573,7 +575,7 @@ SpPresenter >> initializePresenters [
 	"self subclassResponsibility"
 ]
 
-{ #category : #'private - initialization' }
+{ #category : 'private - initialization' }
 SpPresenter >> initializePrivateAnnouncements [
 
 	self 
@@ -584,13 +586,13 @@ SpPresenter >> initializePrivateAnnouncements [
 		whenChangedDo: [ :newLayout | self replaceLayoutWith: newLayout ]
 ]
 
-{ #category : #'private - initialization' }
+{ #category : 'private - initialization' }
 SpPresenter >> initializePrivateAnnouncer [
 
   announcer := Announcer new
 ]
 
-{ #category : #'private - initialization' }
+{ #category : 'private - initialization' }
 SpPresenter >> initializePrivateHooks [
 	self flag: #todo. "We should remove later #initializeWidgets and #initializePresenter."
 	self initializeWidgets.
@@ -601,19 +603,19 @@ SpPresenter >> initializePrivateHooks [
 
 ]
 
-{ #category : #'private - initialization' }
+{ #category : 'private - initialization' }
 SpPresenter >> initializePrivateValueHolders [
 
 	askOkToClose := false.
 	titleHolder := self class title
 ]
 
-{ #category : #'initialization - deprecated' }
+{ #category : 'initialization - deprecated' }
 SpPresenter >> initializeWidgets [
 	"Now, presenters should implement #initializePresenters instead."
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenter >> initializeWindow: aWindowPresenter [
 	"override this to set window values before opening. 
 	 You may want to add a menu, a toolbar or a statusbar"
@@ -628,7 +630,7 @@ SpPresenter >> initializeWindow: aWindowPresenter [
 		windowIcon: self windowIcon
 ]
 
-{ #category : #'inspector-extensions' }
+{ #category : 'inspector-extensions' }
 SpPresenter >> inspectionSubPresenters [
 	<inspectorPresentationOrder: 910 title: 'Subpresenters'>
 	
@@ -639,13 +641,13 @@ SpPresenter >> inspectionSubPresenters [
 		yourself
 ]
 
-{ #category : #'inspector-extensions' }
+{ #category : 'inspector-extensions' }
 SpPresenter >> inspectionSubPresentersContext: aContext [
 	
 	aContext active: self presenters notEmpty
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenter >> instantiatePresenters: aCollectionOfPairs [
 	"instantiatePresenters: is legacy code in SpPresenter and must not be used. It will be deprecated and removed."
 
@@ -662,21 +664,21 @@ SpPresenter >> instantiatePresenters: aCollectionOfPairs [
 				pairsDo: [ :k :v | self instVarNamed: k asString put: (self createInstanceFor: v) ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPresenter >> isBuilt [
 	"Answer if this presenter has been built."
 
 	^ self isDisplayed
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPresenter >> isDisplayed [
 	"Answer if the widget is currently displayed on screen"
 
 	^ self hasWindow and: [ self root isDisplayed ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPresenter >> isRoot [
 	"Answer if this presenter is the root of the presenter hierarchy.
 	 To be root, the presenter has to be contained in a window"
@@ -687,7 +689,7 @@ SpPresenter >> isRoot [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPresenter >> isVisible [
 	"Answer when the presenter is visible. 
 	 See `SpPresenter>>#show` and `SpPresenter>>#hide`."
@@ -695,13 +697,13 @@ SpPresenter >> isVisible [
 	^ visible value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> layout [
 
 	^ layout ifNil: [ self layout: self defaultLayout ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenter >> layout: aLayout [
 	"Set the layout for current presenter. 
 	 See `SpExecutableLayout` hierarchy for details on what can be set as layout."
@@ -710,7 +712,7 @@ SpPresenter >> layout: aLayout [
 	^ layout
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> layoutPresenters [
 
 	layout ifNil: [ ^ self presenters ].
@@ -723,20 +725,20 @@ SpPresenter >> layoutPresenters [
 				ifFalse:[ self presenterAt: each ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> locale [ 
 
 	^ self application locale
 ]
 
-{ #category : #localization }
+{ #category : 'localization' }
 SpPresenter >> localeChanged [
 
 	"do nothing here. Override me in subclasses to update strings presented to the users"
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> okToChange [
 
 	^ self hasWindow
@@ -744,7 +746,7 @@ SpPresenter >> okToChange [
 		ifFalse: [ true ] 
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> on: anAnnouncement send: aSelector to: aTarget [
 
 	self announcer
@@ -753,14 +755,14 @@ SpPresenter >> on: anAnnouncement send: aSelector to: aTarget [
 		to: aTarget
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> presenterAt: aName [
 	"Retrieves a subpresenter of this composed presenter."
 
 	^ self readSlotNamed: aName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenter >> presenterAt: aName ifAbsent: aBlock [
 	"Retrieves a subpresenter of this composed presenter."
 
@@ -769,7 +771,7 @@ SpPresenter >> presenterAt: aName ifAbsent: aBlock [
 		do: aBlock
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> presenters [
 	"This answers ALL presenters included in this layout (including nested layouts). 
 	 BUT IT DOES NOT INCLUDES presenters of embeded presenters.
@@ -786,7 +788,7 @@ SpPresenter >> presenters [
 			stream << each ] ]
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> presentersDo: aBlock [
 
 	self layout ifNil: [ ^ self ].
@@ -794,7 +796,7 @@ SpPresenter >> presentersDo: aBlock [
 		aBlock value: (each asPresenterOn: self) ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> presentersInFocusOrder [
 
 	^ focusOrder ifNil: [ 
@@ -802,13 +804,13 @@ SpPresenter >> presentersInFocusOrder [
 			select: [ :each | each isVisible and: [ each canTakeKeyboardFocus ] ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> rebuildLayout [
 
 	self replaceLayoutWith: self layout
 ]
 
-{ #category : #'api - shortcuts' }
+{ #category : 'api - shortcuts' }
 SpPresenter >> removeKeyCombination: aShortcut [
 	"Remove the action associated to `aShortcut`"
 
@@ -817,7 +819,7 @@ SpPresenter >> removeKeyCombination: aShortcut [
 		anAdapter removeKeyCombination: aShortcut ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenter >> removeStyle: aName [
 	"Remove style from presenter.
 	 See `SpPresenter>>#removeStyle:`"
@@ -827,14 +829,14 @@ SpPresenter >> removeStyle: aName [
 	self withAdapterDo: [ :anAdapter | anAdapter removeStyle: aName ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> replaceLayoutWith: aLayout [
 
 	self withAdapterDo: [ :anAdapter |
 		anAdapter replaceLayoutWith: aLayout ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> requestWindowClose [
 
 	"returns <true> if the user is allowed to close the window. Useful if you want to ask user if he wants to save the changed content etc."
@@ -842,45 +844,45 @@ SpPresenter >> requestWindowClose [
 	^ true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpPresenter >> resolveSymbol: aSymbol [
 
 	^ Smalltalk at: aSymbol
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpPresenter >> retrieveLayout: aSelector [
 
 	^ layout ifNil: [ super retrieveLayout: aSelector ]
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpPresenter >> setModel: aDomainObject [
 
 
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpPresenter >> setModelBeforeInitialization: aDomainObject [
 
 
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenter >> show [
 	"show current presenter making it visible for the user"
 
 	visible := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenter >> styles [ 
 	"Answer the collection of styles to be applied to this presenter"
 
 	^ styles
 ]
 
-{ #category : #'api - focus' }
+{ #category : 'api - focus' }
 SpPresenter >> takeKeyboardFocus [
 	"Causes this presenter to have the keyboard focus for the window it's inside. The presenter must 
 	 be focusable (it has to answer true to `SpPresenter>>#canTakeKeyboardFocus`."
@@ -893,7 +895,7 @@ SpPresenter >> takeKeyboardFocus [
 		anAdapter takeKeyboardFocus ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> title [
 	"DO NOT USE
 	With Spec 2, SpPresenter was refactored to move all window management to WindowPresenter.
@@ -906,13 +908,13 @@ SpPresenter >> title [
 	^ titleHolder
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> toolName [
 
 	^ self class toolName
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> traverseInFocusOrderDo: aBlock [
 
 	self 
@@ -920,7 +922,7 @@ SpPresenter >> traverseInFocusOrderDo: aBlock [
 		excluding: Set new
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	"(excludes includes: self) ifTrue: [ ^ self ]. 
@@ -930,7 +932,7 @@ SpPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 		each traverseInFocusOrderDo: aBlock excluding: excludes ]
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> traversePresentersDo: aBlock [
 
 	self 
@@ -938,7 +940,7 @@ SpPresenter >> traversePresentersDo: aBlock [
 		excluding: Set new
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpPresenter >> traversePresentersDo: aBlock excluding: excludes [
 
 	(excludes includes: self) ifTrue: [ ^ self ]. 
@@ -951,7 +953,7 @@ SpPresenter >> traversePresentersDo: aBlock excluding: excludes [
 		var traversePresentersDo: aBlock excluding: excludes ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> update [
 
 	"self deprecated: 'This method is a remaining from ancient times and should not be used, 
@@ -962,17 +964,17 @@ SpPresenter >> update [
 	self build
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenter >> updatePresenter [
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> visibleIf: aValuable [
 
 	visible := aValuable
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpPresenter >> whenContextKeyBindingsChangedDo: aBlock [
 	"Inform when context keybindings have been changed (See `SpPresenter>>#contextKeyBindings:`).
 	 `aBlock` receives two optional arguments 
@@ -982,7 +984,7 @@ SpPresenter >> whenContextKeyBindingsChangedDo: aBlock [
 	self property: #contextKeyBindings whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpPresenter >> whenDisplayDo: aBlock [
 	"Inform when presenter has been displayed.
 	 `aBlock` receives one argument 
@@ -994,7 +996,7 @@ SpPresenter >> whenDisplayDo: aBlock [
 		for: aBlock receiver
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpPresenter >> whenVisibleChangedDo: aBlock [
 	"Inform when visible property have been changed (See `SpPresenter>>#show` and `SpPresenter>>#hide`).
 	 `aBlock` receives two optional arguments 
@@ -1004,7 +1006,7 @@ SpPresenter >> whenVisibleChangedDo: aBlock [
 	self property: #visible whenChangedDo: aBlock
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> whenWindowChanged: aBlock [
 
 	self flag: #TODO. "This is here for backwards compatibility (you can have same 
@@ -1015,7 +1017,7 @@ SpPresenter >> whenWindowChanged: aBlock [
 		for: self
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpPresenter >> windowIcon [
 	"DO NOT USE
 	With Spec 2, SpPresenter was refactored to move all window management to WindowPresenter.

--- a/src/Spec2-Core/SpPresenterBuilder.class.st
+++ b/src/Spec2-Core/SpPresenterBuilder.class.st
@@ -10,21 +10,23 @@ list := self newList.
 ```
 "
 Class {
-	#name : #SpPresenterBuilder,
-	#superclass : #Object,
+	#name : 'SpPresenterBuilder',
+	#superclass : 'Object',
 	#traits : 'SpTPresenterBuilder',
 	#classTraits : 'SpTPresenterBuilder classTrait',
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenterBuilder >> instantiate: aPresenterClass [
 	"Instantiate a SpPresenter subclass and set its instance owner"
 	
 	^ aPresenterClass new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpPresenterBuilder >> instantiate: aPresenterClass on: aModel [
 	"Instantiate a SpPresenter subclass and set its instance owner and model"
 

--- a/src/Spec2-Core/SpPresenterSelectorPresenter.class.st
+++ b/src/Spec2-Core/SpPresenterSelectorPresenter.class.st
@@ -11,23 +11,25 @@ choose := self newPresenterSelector
 ```
 "
 Class {
-	#name : #SpPresenterSelectorPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpPresenterSelectorPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'model',
 		'cases',
 		'default'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #transmission }
+{ #category : 'transmission' }
 SpPresenterSelectorPresenter >> defaultInputPort [
 
 	^ self inputModelPort
 ]
 
-{ #category : #'api - focus' }
+{ #category : 'api - focus' }
 SpPresenterSelectorPresenter >> defaultKeyboardFocus [
 
 	^ layout children 
@@ -35,45 +37,45 @@ SpPresenterSelectorPresenter >> defaultKeyboardFocus [
 		ifEmpty: [ super defaultKeyboardFocus ]
 ]
 
-{ #category : #'defining conditions' }
+{ #category : 'defining conditions' }
 SpPresenterSelectorPresenter >> defaultShow: aPresenterOrBlock [
 
 	default := aPresenterOrBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenterSelectorPresenter >> initialize [
 
 	cases := SmallDictionary new.
 	super initialize.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenterSelectorPresenter >> initializePresenters [
 
 	layout := SpBoxLayout newTopToBottom
 ]
 
-{ #category : #transmission }
+{ #category : 'transmission' }
 SpPresenterSelectorPresenter >> inputModelPort [
 
 	^ SpModelPort newPresenter: self
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpPresenterSelectorPresenter >> setModel: anObject [
 
 	model := anObject.
 	self updatePresenter
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpPresenterSelectorPresenter >> setModelBeforeInitialization: anObject [
 
 	model := anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpPresenterSelectorPresenter >> showingPresenter [
 
 	^ self layout children
@@ -81,7 +83,7 @@ SpPresenterSelectorPresenter >> showingPresenter [
 		ifEmpty: [ nil ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenterSelectorPresenter >> updatePresenter [
 
 	layout removeAll.
@@ -95,7 +97,7 @@ SpPresenterSelectorPresenter >> updatePresenter [
 		layout add: (default cull: model) ]
 ]
 
-{ #category : #'defining conditions' }
+{ #category : 'defining conditions' }
 SpPresenterSelectorPresenter >> when: conditionBlock show: aPresenterOrBlock [
 
 	cases 

--- a/src/Spec2-Core/SpPresenterWithModel.class.st
+++ b/src/Spec2-Core/SpPresenterWithModel.class.st
@@ -7,27 +7,29 @@ You should implement the method `modelChanged` in my subclasses.
 
 "
 Class {
-	#name : #SpPresenterWithModel,
-	#superclass : #SpPresenter,
+	#name : 'SpPresenterWithModel',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'announcingObject'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'accessing - private' }
+{ #category : 'accessing - private' }
 SpPresenterWithModel >> announcingObject [
 
 	^ announcingObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenterWithModel >> model [
 
 	 ^ self announcingObject value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPresenterWithModel >> model: aDomainObject [
 	"aDomainObject can be regular object, a value holder or an instance of Model"
 	
@@ -37,13 +39,13 @@ SpPresenterWithModel >> model: aDomainObject [
 	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenterWithModel >> modelChanged [
 
 	"subclass responsibility (optional)"
 ]
 
-{ #category : #'accessing - private' }
+{ #category : 'accessing - private' }
 SpPresenterWithModel >> setAnnouncingObject: aDomainObject [
 
 	announcingObject := aDomainObject isSpAnnouncingObject ifFalse: [ aDomainObject asValueHolder ] ifTrue: [ aDomainObject ].
@@ -51,20 +53,20 @@ SpPresenterWithModel >> setAnnouncingObject: aDomainObject [
 	
 ]
 
-{ #category : #transmission }
+{ #category : 'transmission' }
 SpPresenterWithModel >> setModel: aDomainObject [
 
 	^	self model: aDomainObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPresenterWithModel >> setModelBeforeInitialization: aDomainObject [
 
 	self setAnnouncingObject: aDomainObject.
 
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 SpPresenterWithModel >> updatePresenter [
 
 	self modelChanged 

--- a/src/Spec2-Core/SpProgressBarPresenter.class.st
+++ b/src/Spec2-Core/SpProgressBarPresenter.class.st
@@ -4,27 +4,29 @@ A presenter used to define a progress bar.
 `SpProgressBarPresenter` uses a strategy to define the kind of progress ba (It can be fixed at a value, indetermineted or progressing).
 "
 Class {
-	#name : #SpProgressBarPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpProgressBarPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#state => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpProgressBarPresenter class >> adapterName [
 
 	^ #ProgressBarAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpProgressBarPresenter class >> documentFactoryMethodSelector [
 
 	^ #newProgressBar
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpProgressBarPresenter >> fixedAt: aNumber [
 	"Declare that the progress bar will be fixed at a certain value. 
 	 The value should be the completed ratio between 0 and 1."
@@ -32,7 +34,7 @@ SpProgressBarPresenter >> fixedAt: aNumber [
 	self state: (SpFixedProgressBarState value: aNumber)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpProgressBarPresenter >> fixedPercentage: aNumber [
 	"Declare that the progress bar will be fixed at a certain value. 
 	 The value should be in percent"
@@ -40,7 +42,7 @@ SpProgressBarPresenter >> fixedPercentage: aNumber [
 	self fixedAt: aNumber percent
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpProgressBarPresenter >> indeterminate [
 	"If selected, the progress bar will go back and forth without any clear progression. 
 	 Use it do show a progress bar with indeterminate progression."
@@ -48,14 +50,14 @@ SpProgressBarPresenter >> indeterminate [
 	self state: SpIndeterminatedProgressBarState new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpProgressBarPresenter >> initialize [
 
 	super initialize.
 	self fixedAt: 0
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpProgressBarPresenter >> progress: aBlock [
 	"Using this option, the progress bar will increase with time. 
 	 The progression block should return the progression between 0 and 1."
@@ -63,7 +65,7 @@ SpProgressBarPresenter >> progress: aBlock [
 	self progress: aBlock every: 0.2 second
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpProgressBarPresenter >> progress: aBlock every: aDelay [
 	"Using this option, the progress bar will increase with time. 
 	 The progression block should return the progression between 0 and 1 and 
@@ -72,26 +74,26 @@ SpProgressBarPresenter >> progress: aBlock every: aDelay [
 	self state: (SpProgressingProgressBarState progression: aBlock every: aDelay)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpProgressBarPresenter >> state [
 
 	^ state
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpProgressBarPresenter >> state: aState [
 
 	state := aState.
 	self withAdapterPerformOrDefer: [ :anAdapter | anAdapter updateState ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpProgressBarPresenter >> value [
 
 	^ self state value
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpProgressBarPresenter >> whenValueChangedDo: aBlock [
 	"Inform when progress value has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpProgressBarState.class.st
+++ b/src/Spec2-Core/SpProgressBarState.class.st
@@ -8,14 +8,16 @@ My subclasses are used by the ProgressBarPresenter.
 
 "
 Class {
-	#name : #SpProgressBarState,
-	#superclass : #Object,
+	#name : 'SpProgressBarState',
+	#superclass : 'Object',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
-	#category : #'Spec2-Core-Utils'
+	#category : 'Spec2-Core-Utils',
+	#package : 'Spec2-Core',
+	#tag : 'Utils'
 }
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpProgressBarState >> whenValueChangedDo: aBlock [
 	"My subclasses should fire the block when the current value changes."
 

--- a/src/Spec2-Core/SpProgressingProgressBarState.class.st
+++ b/src/Spec2-Core/SpProgressingProgressBarState.class.st
@@ -21,17 +21,19 @@ Internal Representation and Key Implementation Points.
 
 "
 Class {
-	#name : #SpProgressingProgressBarState,
-	#superclass : #SpProgressBarState,
+	#name : 'SpProgressingProgressBarState',
+	#superclass : 'SpProgressBarState',
 	#instVars : [
 		'refreshDelay',
 		'progression',
 		'currentValue'
 	],
-	#category : #'Spec2-Core-Utils'
+	#category : 'Spec2-Core-Utils',
+	#package : 'Spec2-Core',
+	#tag : 'Utils'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpProgressingProgressBarState class >> progression: aBlock every: aDelay [
 	^ self new
 		progression: aBlock;
@@ -39,39 +41,39 @@ SpProgressingProgressBarState class >> progression: aBlock every: aDelay [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpProgressingProgressBarState >> currentValue [
 	^ currentValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpProgressingProgressBarState >> currentValue: aNumber [
 	currentValue := aNumber
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpProgressingProgressBarState >> initialize [
 	self class initializeSlots: self.
 	super initialize.
 	currentValue := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpProgressingProgressBarState >> progression [
 	^ progression
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpProgressingProgressBarState >> progression: aValuable [
 	progression := aValuable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpProgressingProgressBarState >> refreshDelay [
 	^ refreshDelay
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpProgressingProgressBarState >> refreshDelay: aDelay [
 	refreshDelay := aDelay
 ]

--- a/src/Spec2-Core/SpRadioButtonPresenter.class.st
+++ b/src/Spec2-Core/SpRadioButtonPresenter.class.st
@@ -2,34 +2,36 @@
 A presenter for Radio Buttons.
 "
 Class {
-	#name : #SpRadioButtonPresenter,
-	#superclass : #SpAbstractFormButtonPresenter,
+	#name : 'SpRadioButtonPresenter',
+	#superclass : 'SpAbstractFormButtonPresenter',
 	#instVars : [
 		'associatedRadioButtons',
 		'initialStateSet'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpRadioButtonPresenter class >> adapterName [
 
 	^ #RadioButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpRadioButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newRadioButton
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpRadioButtonPresenter class >> title [
 
 	^ 'Radio Button'
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpRadioButtonPresenter >> associatedRadioButtons [
 	"Answer the collection of radio buttons associated (grouped) to this one.
 	 See also `SpRadioButtonPresenter>>#associatedRadioButtons:`"
@@ -37,7 +39,7 @@ SpRadioButtonPresenter >> associatedRadioButtons [
 	^ associatedRadioButtons
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpRadioButtonPresenter >> associatedRadioButtons: aCollection [ 
 	"Set the list of radio buttons associated with this one.
 	 By using this, you will be grouping together this radio button along with the ones contained 
@@ -54,13 +56,13 @@ SpRadioButtonPresenter >> associatedRadioButtons: aCollection [
 	aCollection do: [ :each | each state: false ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpRadioButtonPresenter >> basicAssociatedRadioButtons: aCollection [ 
 	
 	associatedRadioButtons := aCollection copyWithout: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpRadioButtonPresenter >> initialStateNotSet [
 	"Setting this value to the first radio button will cause the entire group to be unset 
 	 on first display. This will be ignored if sent to other than the own containing the 
@@ -69,7 +71,7 @@ SpRadioButtonPresenter >> initialStateNotSet [
 	initialStateSet := false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpRadioButtonPresenter >> initialize [
 
 	super initialize.
@@ -78,7 +80,7 @@ SpRadioButtonPresenter >> initialize [
 	associatedRadioButtons := #()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpRadioButtonPresenter >> isInitialStateSet [
 	"Answer if the radio button and its associates start the display with one of the buttons 
 	 set. This is often used when you do not have a default option and you need to require the 
@@ -87,7 +89,7 @@ SpRadioButtonPresenter >> isInitialStateSet [
 	^ initialStateSet
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpRadioButtonPresenter >> state: aValue [
 	"Set the state `aBoolean` of current radio button. 
 	 Changing the state affect other associated radio buttons by toggling also their state.

--- a/src/Spec2-Core/SpSearchInputFieldPresenter.class.st
+++ b/src/Spec2-Core/SpSearchInputFieldPresenter.class.st
@@ -4,12 +4,14 @@ It displays an additional ""clear"" icon.
 
 "
 Class {
-	#name : #SpSearchInputFieldPresenter,
-	#superclass : #SpTextInputFieldPresenter,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpSearchInputFieldPresenter',
+	#superclass : 'SpTextInputFieldPresenter',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSearchInputFieldPresenter class >> adapterName [
 
 	^ #SearchInputFieldAdapter

--- a/src/Spec2-Core/SpSingleSelectionMode.class.st
+++ b/src/Spec2-Core/SpSingleSelectionMode.class.st
@@ -2,48 +2,50 @@
 I implement single selection mode (my users can select just one element of list or table)
 "
 Class {
-	#name : #SpSingleSelectionMode,
-	#superclass : #SpAbstractSelectionMode,
+	#name : 'SpSingleSelectionMode',
+	#superclass : 'SpAbstractSelectionMode',
 	#instVars : [
 		'#selectedIndex => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 SpSingleSelectionMode >> basicSelectIndex: indexToSelect [
 	selectedIndex := indexToSelect
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSingleSelectionMode >> includesIndex: anIndex [
 	^ self selectedIndex = anIndex
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSingleSelectionMode >> includesItem: anItem [
 
 	^ self selectedItem = anItem
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSingleSelectionMode >> initialize [
 	super initialize.
 	selectedIndex := 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSingleSelectionMode >> isEmpty [
 	
 	^ self selectedIndex = 0
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectAll [
 	"Do nothing, since single selection mode wont allow for selecting all elements."
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectIndexes: aCollectionOfIndexes [
 	"Take first index from `aCollectionOfIndexes` and selects it. Ignore all the rest."
 
@@ -51,7 +53,7 @@ SpSingleSelectionMode >> selectIndexes: aCollectionOfIndexes [
 	self selectIndex: aCollectionOfIndexes first.
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectItems: aCollection [
 	"Take first element from `aCollection` and selects it. Ignore all the rest."
 
@@ -59,14 +61,14 @@ SpSingleSelectionMode >> selectItems: aCollection [
 	self selectItem: aCollection first.
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectedIndex [
 	"Answer index of current selected element"
 
 	^ selectedIndex
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectedIndexes [
 	"Answer an array with a single element containing current selected element index."
 		
@@ -75,7 +77,7 @@ SpSingleSelectionMode >> selectedIndexes [
 		ifFalse: [ { self selectedIndex } ]
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectedItem [
 	"Answer selected item"
 
@@ -85,7 +87,7 @@ SpSingleSelectionMode >> selectedItem [
 	^ self model at: self selectedIndex
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> selectedItems [
 	"Answer an array with a single element, the selected item"
 	
@@ -94,32 +96,32 @@ SpSingleSelectionMode >> selectedItems [
 		ifNil: [ #() ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpSingleSelectionMode >> selectionHolder [
 	^ self observablePropertyNamed: #selectedIndex
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> unselectAll [
 	"Unselect current selected element."
 	
 	self selectIndex: 0
 ]
 
-{ #category : #'api - selection' }
+{ #category : 'api - selection' }
 SpSingleSelectionMode >> unselectIndex: anInteger [
 	"Unselect element at index `anInteger`"
 
 	self selectedIndex = anInteger ifTrue: [ self basicSelectIndex: 0 ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSingleSelectionMode >> whenChangedDo: aBlock [
 
 	self whenSelectedIndexChangedDo: [ aBlock cull: self ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSingleSelectionMode >> whenSelectedIndexChangedDo: aBlock [
 
 	self property: #selectedIndex whenChangedDo: aBlock

--- a/src/Spec2-Core/SpSliderInputPresenter.class.st
+++ b/src/Spec2-Core/SpSliderInputPresenter.class.st
@@ -11,21 +11,23 @@ Note
 - if autoAccept is true, the character '-' could create problems
 "
 Class {
-	#name : #SpSliderInputPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpSliderInputPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'slider',
 		'input'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpSliderInputPresenter class >> defaultLayout [
 	^ self sliderLeft
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSliderInputPresenter class >> sliderBottom [
 
 	^ SpBoxLayout newTopToBottom
@@ -34,7 +36,7 @@ SpSliderInputPresenter class >> sliderBottom [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSliderInputPresenter class >> sliderLeft [
 
 	^ SpPanedLayout newLeftToRight
@@ -44,7 +46,7 @@ SpSliderInputPresenter class >> sliderLeft [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSliderInputPresenter class >> sliderRight [
 
 	^ SpPanedLayout newLeftToRight
@@ -54,7 +56,7 @@ SpSliderInputPresenter class >> sliderRight [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSliderInputPresenter class >> sliderTop [
 
 	^ SpBoxLayout newTopToBottom
@@ -63,7 +65,7 @@ SpSliderInputPresenter class >> sliderTop [
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderInputPresenter >> connectPresenters [
 
 	slider whenValueChangedDo: [ :sliderValue | 
@@ -74,7 +76,7 @@ SpSliderInputPresenter >> connectPresenters [
 			slider value: text asNumber ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderInputPresenter >> initializePresenters [
 
 	slider := self newSlider.
@@ -82,48 +84,48 @@ SpSliderInputPresenter >> initializePresenters [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> input [
 	^ input
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> label [
 	^ slider label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> label: aString [
 	slider label: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> max: aNumber [
 	slider max: aNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> min: aNumber [
 	slider min: aNumber.
 	input text: aNumber asString 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> slider [
 	^ slider
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> value [
 	^ slider value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenter >> value: aNumber [
 	slider value: aNumber 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderInputPresenter >> whenValueChangedDo: aBlock [
 	slider whenValueChangedDo: aBlock
 ]

--- a/src/Spec2-Core/SpSliderMark.class.st
+++ b/src/Spec2-Core/SpSliderMark.class.st
@@ -1,29 +1,31 @@
 Class {
-	#name : #SpSliderMark,
-	#superclass : #Object,
+	#name : 'SpSliderMark',
+	#superclass : 'Object',
 	#instVars : [
 		'value',
 		'text'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderMark >> text [
 	^ text
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderMark >> text: aText [
 	text := aText
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderMark >> value [
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderMark >> value: aValue [
 	value := aValue
 ]

--- a/src/Spec2-Core/SpSliderPresenter.class.st
+++ b/src/Spec2-Core/SpSliderPresenter.class.st
@@ -3,8 +3,8 @@ A presenter that show a slider.
 
 "
 Class {
-	#name : #SpSliderPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpSliderPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#max => ObservableSlot',
 		'#min => ObservableSlot',
@@ -15,41 +15,43 @@ Class {
 		'#label => ObservableSlot',
 		'#marks => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSliderPresenter class >> adapterName [
 
 	^ #SliderAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpSliderPresenter class >> documentFactoryMethodSelector [
 
 	^ #newSlider
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> absoluteValue [
 	"Return the position of the slider in a scale between 0 and 1 despite of the min and max value"
 
 	^ absoluteValue
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> absoluteValue: aFloat [
 	"Set the position of the slider in a scale between 0 and 1 despite of the min and max value"
 
 	absoluteValue := aFloat
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderPresenter >> absoluteValueToValue: v [
 	^ self min + (v * (self max - self min)) roundTo: self quantum
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> addMark: aString at: aValue [
 	"Add the mark `aString` at `aValue` ."
 	
@@ -61,24 +63,24 @@ SpSliderPresenter >> addMark: aString at: aValue [
 		yourself)
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> beHorizontal [
 	isHorizontal := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> beVertical [
 	isHorizontal := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> color: aColor [
 
 	"Hack because during the interpretation, the state is slightly inconistent"
 	self widget ifNotNil: [:w | w == self ifFalse: [ super color: aColor ]]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderPresenter >> initialize [
 	| isChanging |
 	super initialize.
@@ -114,102 +116,102 @@ SpSliderPresenter >> initialize [
 	self whenLabelChangedDo: [ :v | self changed: #label ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSliderPresenter >> isHorizontal [
 	^ isHorizontal
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSliderPresenter >> isVertical [
 	^ self isHorizontal not
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> label [
 	"Return the label of the slider"
 
 	^ label
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> label: aString [
 	"Set the label of the slider"
 
 	label := aString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> marks [
 	^ marks
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> marks: anObject [
 	marks := anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> max [
 	"Return the maximun value"
 
 	^ max
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> max: anObject [
 	"Set the maximun value"
 
 	max := anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> min [
 	"Return the minimum value"
 
 	^ min
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> min: anObject [
 	"Set the minimum value"
 
 	min := anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> quantum [
 	"Return the quantum betwen values"
 
 	^ quantum
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> quantum: aNumber [
 	"Set the quantum betwen values"
 
 	quantum := aNumber
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderPresenter >> reset [
 	"Reset the cursor to the minimum value"
 	
 	self value: self min
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderPresenter >> scaleValue: v [
 	^ ((v - self min) / (self max - self min)) asFloat
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> value [
 	"Return the current value in a range between min and max"
 
 	^ value
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpSliderPresenter >> value: aNumber [
 	"Set the value in a range between min and max"
 
@@ -217,12 +219,12 @@ SpSliderPresenter >> value: aNumber [
 	value := aNumber
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderPresenter >> valueToAbsoluteValue: v [
 	^ ((v - self min) / (self max - self min)) asFloat
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenAbsoluteValueChangedDo: aBlock [
 	"Inform when absolute value has changed. 
 	 `aBlock` has three optional arguments: 
@@ -233,7 +235,7 @@ SpSliderPresenter >> whenAbsoluteValueChangedDo: aBlock [
 	self property: #absoluteValue whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenLabelChangedDo: aBlock [
 	"Inform when label has changed. 
 	 `aBlock` has three optional arguments: 
@@ -244,7 +246,7 @@ SpSliderPresenter >> whenLabelChangedDo: aBlock [
 	self property: #label whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenMarksChangedDo: aBlock [
 	"Inform when marks property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -255,7 +257,7 @@ SpSliderPresenter >> whenMarksChangedDo: aBlock [
 	self property: #marks whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenMaxChangedDo: aBlock [ 
 	"Inform when maximum property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -266,7 +268,7 @@ SpSliderPresenter >> whenMaxChangedDo: aBlock [
 	self property: #max whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenMinChangedDo: aBlock [ 
 	"Inform when minimum property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -277,14 +279,14 @@ SpSliderPresenter >> whenMinChangedDo: aBlock [
 	self property: #min whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenQuantumChangedDo: aBlock [ 
 	"Block performed when the quantum value changed"
 
 	self property: #quantum whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpSliderPresenter >> whenValueChangedDo: aBlock [ 
 	"Block performed when the value changed"
 

--- a/src/Spec2-Core/SpSpinnerPresenter.class.st
+++ b/src/Spec2-Core/SpSpinnerPresenter.class.st
@@ -2,18 +2,20 @@
 A simple spinner.
 "
 Class {
-	#name : #SpSpinnerPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpSpinnerPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpSpinnerPresenter class >> adapterName [
 	
 	^ #SpinnerAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpSpinnerPresenter class >> documentFactoryMethodSelector [
 
 	^ #newSpinner

--- a/src/Spec2-Core/SpStatusBarPresenter.class.st
+++ b/src/Spec2-Core/SpStatusBarPresenter.class.st
@@ -7,27 +7,29 @@ A status bar acts as a stack of messages that will be shown to the user.
 The messages can be pushed (See `SpStatusBarPresenter>>#pushMessage:`) and then popped (See `SpStatusBarPresenter>>#popMessage`). 
 "
 Class {
-	#name : #SpStatusBarPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpStatusBarPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'message'
 	],
-	#category : #'Spec2-Core-Widgets-Toolbar'
+	#category : 'Spec2-Core-Widgets-Toolbar',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Toolbar'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpStatusBarPresenter class >> adapterName [
 
 	^ #StatusBarAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpStatusBarPresenter class >> documentFactoryMethodSelector [
 
 	^ #newStatusBar
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpStatusBarPresenter >> canTakeKeyboardFocus [
 	"Answer whether the presenter can be focused or not. 
 	 In case of `SpStatusBarPresenter`, this message will answer always false."
@@ -35,19 +37,19 @@ SpStatusBarPresenter >> canTakeKeyboardFocus [
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStatusBarPresenter >> message [
 	"Answer current shown message."
 
 	^ message
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpStatusBarPresenter >> message: aString [
 	message := aString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStatusBarPresenter >> popMessage [ 
 	"Pop current message (it will dismiss current message and restore previous one)"
 	
@@ -55,7 +57,7 @@ SpStatusBarPresenter >> popMessage [
 	self changed: #popMessage
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStatusBarPresenter >> pushMessage: aString [ 
 	"Push a new message to the stack (replacing current message with a new one)."
 	

--- a/src/Spec2-Core/SpStringTableColumn.class.st
+++ b/src/Spec2-Core/SpStringTableColumn.class.st
@@ -12,8 +12,8 @@ SpStringTableColumn
 ```
 "
 Class {
-	#name : #SpStringTableColumn,
-	#superclass : #SpTableColumn,
+	#name : 'SpStringTableColumn',
+	#superclass : 'SpTableColumn',
 	#traits : 'SpTDecoratedText',
 	#classTraits : 'SpTDecoratedText classTrait',
 	#instVars : [
@@ -21,53 +21,55 @@ Class {
 		'acceptAction',
 		'sortable'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> acceptAction [
 	"Answer the action (set by `SpStringTablePresenter>>#onAcceptEdition:`) to execute when accepting an edition."
 	
 	^ acceptAction
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpStringTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ aBuilder visitStringColumn: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> alignment [
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> beEditable [ 
 	"Set the cell as editable."
 
 	editable := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> beNotEditable [ 
 	"Set the cell as not editable (this is the default)."
 
 	editable := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> beNotSortable [
 
 	self isSortable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> beSortable [
 
 	self isSortable: true
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SpStringTableColumn >> compareFunction: aBlock [
 	"sets the sorting of this column to use the two argument aBlock for comparing (aBlock should return a boolean). 
 	it is often simpler to use a boolean compare than the threeway compare required by sortFunction: "
@@ -85,7 +87,7 @@ SpStringTableColumn >> compareFunction: aBlock [
 	self isSortable: true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpStringTableColumn >> initialize [ 
 
 	super initialize.
@@ -93,26 +95,26 @@ SpStringTableColumn >> initialize [
 	sortable := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpStringTableColumn >> isEditable [ 
 	"Answer true if column has editable cells"
 	
 	^ editable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpStringTableColumn >> isSortable [
 
 	^ sortable
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpStringTableColumn >> isSortable: aBoolean [ 
 
 	sortable := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> onAcceptEdition: aBlock [
 	"Set the block to execute when cell edition is accepted.
 	 `aBlock` receives two arguments: 
@@ -122,13 +124,13 @@ SpStringTableColumn >> onAcceptEdition: aBlock [
 	acceptAction := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> sortFunction [
 
 	^ super sortFunction ifNil: [ self evaluation ascending ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> sortFunction: aBlockOrSortFunction [
 	"Set the THREEWAY sort function to apply to the values of this column in order to sort elements.
 	 `aBlockOrSortFunction` is a block that receives two arguments to compare or an instace of 

--- a/src/Spec2-Core/SpTAlignableColumn.trait.st
+++ b/src/Spec2-Core/SpTAlignableColumn.trait.st
@@ -1,19 +1,21 @@
 Trait {
-	#name : #SpTAlignableColumn,
+	#name : 'SpTAlignableColumn',
 	#instVars : [
 		'alignmentAction'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpTAlignableColumn >> displayAlignment [
 	"aBlock must return an instance of `SpColumnAlignment`"
 
 	^ alignmentAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTAlignableColumn >> displayAlignment: aBlock [
 	"aBlock must return an instance of `SpColumnAlignment`"
 

--- a/src/Spec2-Core/SpTContextMenu.trait.st
+++ b/src/Spec2-Core/SpTContextMenu.trait.st
@@ -4,14 +4,16 @@ Note that I just add some behaviour at presenter level, the right implementation
 to be solved in the backend adaptor.
 "
 Trait {
-	#name : #SpTContextMenu,
+	#name : 'SpTContextMenu',
 	#instVars : [
 		'#contextMenu => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpTContextMenu >> contextMenu [
 	"Answer context menu or nil if there is none defined.
 	 Context menu can be an instace of `SpMenuPresenter` or a block (that will answer eventually an 
@@ -22,7 +24,7 @@ SpTContextMenu >> contextMenu [
 	^ contextMenu
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTContextMenu >> contextMenu: aValuableOrMenuPresenter [
 	"Set the context menu.
 	 Context menu can be an instace of `SpMenuPresenter` or a block (that will answer eventually an 
@@ -33,14 +35,14 @@ SpTContextMenu >> contextMenu: aValuableOrMenuPresenter [
 	contextMenu := aValuableOrMenuPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTContextMenu >> initialize [
 	
 	self class initializeSlots: self.
 	super initialize.
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTContextMenu >> whenMenuChangedDo: aBlock [
 	"Inform when menu definition changed. 
 	 `aBlock` receives zero arguments."

--- a/src/Spec2-Core/SpTDecoratedText.trait.st
+++ b/src/Spec2-Core/SpTDecoratedText.trait.st
@@ -5,7 +5,7 @@ A column can be decorated with certain attributes (see selectors defined) that r
 The valuable is always in the form [ :anItem | aResult ], but result may vary depending on the decoration (explained in messages).
 "
 Trait {
-	#name : #SpTDecoratedText,
+	#name : 'SpTDecoratedText',
 	#instVars : [
 		'colorAction',
 		'backgroundColorAction',
@@ -13,16 +13,18 @@ Trait {
 		'boldAction',
 		'underlineAction'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayBackgroundColor [
 
 	^ backgroundColorAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayBackgroundColor: aBlock [
 	"Changes the background color of cells of the column. 
 	 `aBlock` receives an argument (the model element) and should answer an instance of Color. 
@@ -31,13 +33,13 @@ SpTDecoratedText >> displayBackgroundColor: aBlock [
 	backgroundColorAction := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayBold [
 
 	^ boldAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayBold: aBlock [
 	"If `aBlock` answer true, the cell will be displayed in bold.
 	 `aBlock` receives one argument (the model element)."
@@ -45,13 +47,13 @@ SpTDecoratedText >> displayBold: aBlock [
 	boldAction := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayColor [
 
 	^ colorAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayColor: aBlock [
 	"Changes the font color of cells of the column. 
 	 `aBlock` receives an argument (the model element) and should answer an instance of Color."
@@ -59,13 +61,13 @@ SpTDecoratedText >> displayColor: aBlock [
 	colorAction := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayItalic [
 
 	^ italicAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayItalic: aBlock [
 	"If `aBlock` answer true, the cell will be displayed in italic.
 	 `aBlock` receives one argument (the model element)."
@@ -73,13 +75,13 @@ SpTDecoratedText >> displayItalic: aBlock [
 	italicAction := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayUnderline [
 
 	^ underlineAction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTDecoratedText >> displayUnderline: aBlock [
 	"If `aBlock` answer true, the cell will be displayed underlined.
 	 `aBlock` receives one argument (the model element)."

--- a/src/Spec2-Core/SpTDynamicPresenter.trait.st
+++ b/src/Spec2-Core/SpTDynamicPresenter.trait.st
@@ -5,26 +5,28 @@ I can be used to create components that may have variable number of children.
 DEPRECATED: This trait should not be used, since all presenters are dynamic now.
 "
 Trait {
-	#name : #SpTDynamicPresenter,
+	#name : 'SpTDynamicPresenter',
 	#instVars : [
 		'presenters'
 	],
-	#category : #'Spec2-Core-Base'
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTDynamicPresenter classSide >> isDeprecated [
 
 	^ true
 ]
 
-{ #category : #'private - accessing' }
+{ #category : 'private - accessing' }
 SpTDynamicPresenter >> basicPresenters [
 
 	^ presenters ifNil: [ presenters := OrderedDictionary new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTDynamicPresenter >> presenterAt: aName [
 
 	^ self basicPresenters 
@@ -32,7 +34,7 @@ SpTDynamicPresenter >> presenterAt: aName [
 		ifAbsent: [ self readSlotNamed: aName  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTDynamicPresenter >> presenterAt: aName ifAbsent: aBlock [
 	^ self basicPresenters
 		at: aName
@@ -41,7 +43,7 @@ SpTDynamicPresenter >> presenterAt: aName ifAbsent: aBlock [
 				do: aBlock ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTDynamicPresenter >> presenterAt: aName put: aPresenter [
 
 	^ self basicPresenters 
@@ -49,13 +51,13 @@ SpTDynamicPresenter >> presenterAt: aName put: aPresenter [
 		put: aPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTDynamicPresenter >> presenters [
 
 	^ self basicPresenters values
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 SpTDynamicPresenter >> presentersDo: aBlock [
 
 	self basicPresenters valuesDo: aBlock

--- a/src/Spec2-Core/SpTHaveWrappingScrollBars.trait.st
+++ b/src/Spec2-Core/SpTHaveWrappingScrollBars.trait.st
@@ -9,17 +9,19 @@ if your backend of choice supports it.
 THIS CANNOT BE CHANGED ONCE THE WIDGET IS CREATED.
 "
 Trait {
-	#name : #SpTHaveWrappingScrollBars,
+	#name : 'SpTHaveWrappingScrollBars',
 	#instVars : [
 		'wrapScrollBars',
 		'propagateNaturalHeight',
 		'propagateNaturalWidth',
 		'scrollBarStyles'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> addScrollBarStyle: aStyle [
 	"Add a style for the scrollbar component. 
 	 In platforms that do not support separation from component and scrollbar (like Morphic), the 
@@ -30,7 +32,7 @@ SpTHaveWrappingScrollBars >> addScrollBarStyle: aStyle [
 	scrollBarStyles := scrollBarStyles copyWith: aStyle
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTHaveWrappingScrollBars >> hasScrollBars [
 	"Some backends like Morphic forces the scrollbars in their Tables and Lists. 
 	 But some others like Gtk3 don't. This option allows you to configure the precence 
@@ -42,7 +44,7 @@ SpTHaveWrappingScrollBars >> hasScrollBars [
 	^ wrapScrollBars
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTHaveWrappingScrollBars >> initializeTHaveWrappingScrollBars [
 
 	scrollBarStyles := #().
@@ -50,7 +52,7 @@ SpTHaveWrappingScrollBars >> initializeTHaveWrappingScrollBars [
 	self propagateNaturalHeight: false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTHaveWrappingScrollBars >> isPropagateNaturalHeight [
 	"Indicate if component propagates natural heigth.
 	 See `SpTHaveWrappingScrollBars>>#propagateNaturalHeight:`"
@@ -58,7 +60,7 @@ SpTHaveWrappingScrollBars >> isPropagateNaturalHeight [
 	^ propagateNaturalHeight ifNil: [ false ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTHaveWrappingScrollBars >> isPropagateNaturalWidth [
 	"Indicate if component propagates natural width.
 	 See `SpTHaveWrappingScrollBars>>#propagateNaturalWidth:`"
@@ -66,7 +68,7 @@ SpTHaveWrappingScrollBars >> isPropagateNaturalWidth [
 	^ propagateNaturalWidth ifNil: [ false ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> propagateNaturalHeight: aBoolean [
 	"Indicate when component propagates natural heigth.
 	 Natural height propagation means that the height of the presenter containing both scrollbars and 
@@ -75,7 +77,7 @@ SpTHaveWrappingScrollBars >> propagateNaturalHeight: aBoolean [
 	propagateNaturalHeight := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> propagateNaturalWidth: aBoolean [
 	"Indicate when component propagates natural width.
 	 Natural width propagation means that the width of the presenter containing both scrollbars and 
@@ -86,7 +88,7 @@ SpTHaveWrappingScrollBars >> propagateNaturalWidth: aBoolean [
 	propagateNaturalWidth := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> removeScrollBarStyle: aStyle [
 	"Remove `aStyle` from the list of scrollbar styles.
 	 See SpTHaveWrappingScrollBars>>#scrollBarStyles"
@@ -94,7 +96,7 @@ SpTHaveWrappingScrollBars >> removeScrollBarStyle: aStyle [
 	scrollBarStyles := scrollBarStyles copyWithout: aStyle
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> scrollBarStyles [
 	"Answer styles defined for the scrollbar component. 
 	 In platforms that do not support separation from component and scrollbar (like Morphic), the 
@@ -105,7 +107,7 @@ SpTHaveWrappingScrollBars >> scrollBarStyles [
 	^ scrollBarStyles ifNil: [ #() ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> withScrollBars [
 	"Some backends like Morphic forces the scrollbars in their Tables and Lists. 
 	 But some others like Gtk3 don't. This option allows you to configure the precence 
@@ -117,7 +119,7 @@ SpTHaveWrappingScrollBars >> withScrollBars [
 	wrapScrollBars := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTHaveWrappingScrollBars >> withoutScrollBars [
 	"Some backends like Morphic forces the scrollbars in their Tables and Lists. 
 	 But some others like Gtk3 don't. This option allows you to configure the precence 

--- a/src/Spec2-Core/SpTModel.trait.st
+++ b/src/Spec2-Core/SpTModel.trait.st
@@ -2,45 +2,47 @@
 A trait to add ""model"" behavior to a presenter.
 "
 Trait {
-	#name : #SpTModel,
+	#name : 'SpTModel',
 	#instVars : [
 		'model'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #transmission }
+{ #category : 'transmission' }
 SpTModel >> defaultInputPort [
 
 	^ self inputModelPort
 ]
 
-{ #category : #transmission }
+{ #category : 'transmission' }
 SpTModel >> inputModelPort [
 
 	^ SpModelPort newPresenter: self
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpTModel >> model [
 
 	^ model
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpTModel >> model: aModel [
 
 	model := aModel.
 	self updatePresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTModel >> setModel: aModel [
 
 	self model: aModel
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 SpTModel >> setModelBeforeInitialization: aModel [
 
 	model := aModel

--- a/src/Spec2-Core/SpTPresenterBuilder.trait.st
+++ b/src/Spec2-Core/SpTPresenterBuilder.trait.st
@@ -10,80 +10,82 @@ list := self newList.
 ```
 "
 Trait {
-	#name : #SpTPresenterBuilder,
-	#category : #'Spec2-Core-Base'
+	#name : 'SpTPresenterBuilder',
+	#category : 'Spec2-Core-Base',
+	#package : 'Spec2-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTPresenterBuilder >> instantiate: aPresenterClass [
 	"Instantiate a SpPresenter subclass and set its instance owner"
 
 	^ aPresenterClass owner: self
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTPresenterBuilder >> instantiate: aPresenterClass on: aModel [
 	"Instantiate a SpPresenter subclass and set its instance owner and model"
 
 	^ aPresenterClass owner: self on: aModel
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newActionBar [
 
 	^ self instantiate: SpActionBarPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newAthens [
 
 	^ self instantiate: SpAthensPresenter
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newBoxLayoutLeftToRight [
 
 	^ SpBoxLayout newLeftToRight
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newBoxLayoutTopToBottom [
 
 	^ SpBoxLayout newTopToBottom
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newButton [
 	^ self instantiate: SpButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newButtonBar [
 
 	^ self instantiate: SpButtonBarPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newCheckBox [
 	^ self instantiate: SpCheckBoxPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newComponentList [
 	^ self instantiate: SpComponentListPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newDiff [
 	^ self instantiate: SpDiffPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newDropList [
 	^ self instantiate: SpDropListPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newDynamicPresentersListIn: accessorSymbol usingBuilder: aDynamicPresentersListBuilder [
 	|mutatorSymbol newDynamicPresenter |
 	mutatorSymbol := (accessorSymbol , ':') asSymbol.
@@ -99,103 +101,103 @@ SpTPresenterBuilder >> newDynamicPresentersListIn: accessorSymbol usingBuilder: 
 	self build
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newGridLayout [
 
 	^ SpGridLayout new
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newImage [
 	^ self instantiate: SpImagePresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newLabel [
 	^ self instantiate: SpLabelPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newList [
 	^ self instantiate: SpListPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newMenu [
 	^ self instantiate: SpMenuPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newMenuBar [
 	^ self instantiate: SpMenuBarPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newMenuButton [
 
 	^ self instantiate: SpMenuButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newNotebook [
 
 	^ self instantiate: SpNotebookPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newNotebookPage [
 
 	self flag: #TODO. "NotebookPage needs to be a Presenter?"
 	^ SpNotebookPage new
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newNullPresenter [
 	^ self instantiate: SpNullPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newNumberInput [
 	^ self instantiate: SpNumberInputFieldPresenter
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newOverlayLayout [
 
 	^ SpOverlayLayout new
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newPanedLayoutLeftToRight [
 
 	^ SpPanedLayout newLeftToRight
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newPanedLayoutTopToBottom [
 
 	^ SpPanedLayout newTopToBottom
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newPopover [
 
 	^ self instantiate: SpPopoverPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newPresenter [
 
 	^ self instantiate: SpPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newPresenterSelector [
 
 	^ self instantiate: SpPresenterSelectorPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newPresenterWith: aBlock [
 	| presenter |
 
@@ -205,104 +207,104 @@ SpTPresenterBuilder >> newPresenterWith: aBlock [
 	^ presenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newProgressBar [
 	^ self instantiate: SpProgressBarPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newRadioButton [
 	^ self instantiate: SpRadioButtonPresenter
 ]
 
-{ #category : #'scripting - layouts' }
+{ #category : 'scripting - layouts' }
 SpTPresenterBuilder >> newScrollableLayout [
 
 	^ SpScrollableLayout new
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newSearchInput [
 
 	^ self instantiate: SpSearchInputFieldPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newSlider [
 	^ self instantiate: SpSliderPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newSpinner [
 
 	^ self instantiate: SpSpinnerPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newStatusBar [
 
 	^ self instantiate: SpStatusBarPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newTable [
 
 	^ self instantiate: SpTablePresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newText [
 	^ self instantiate: SpTextPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newTextInput [
 	^ self instantiate: SpTextInputFieldPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newToggleButton [
 
 	^ self instantiate: SpToggleButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newToolbar [
 
 	^ self instantiate: SpToolbarPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newToolbarButton [
 
 	^ self instantiate: SpToolbarButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newToolbarMenuButton [
 
 	^ self instantiate: SpToolbarMenuButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newToolbarPopoverButton [
 
 	^ self instantiate: SpToolbarPopoverButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newToolbarToggleButton [
 
 	^ self instantiate: SpToolbarToggleButtonPresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newTree [
 
 	^ self instantiate: SpTreePresenter
 ]
 
-{ #category : #'scripting - widgets' }
+{ #category : 'scripting - widgets' }
 SpTPresenterBuilder >> newTreeTable [
 
 	^ self instantiate: SpTreeTablePresenter

--- a/src/Spec2-Core/SpTSearchable.trait.st
+++ b/src/Spec2-Core/SpTSearchable.trait.st
@@ -3,36 +3,38 @@ I add search capability to lists/tables and trees.
 I implement basic common API but real implementation (as always) needs to be done in the backend adapters. 
 "
 Trait {
-	#name : #SpTSearchable,
+	#name : 'SpTSearchable',
 	#instVars : [
 		'#searchEnabled => ObservableSlot',
 		'#searchBlock'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 SpTSearchable >> disableSearch [
 	"Disable searching"
 
 	searchEnabled := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTSearchable >> enableSearch [
 	"Enable searching"
 
 	searchEnabled := true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTSearchable >> hasCustomSearch [
 	"Answer true if the list has a custom search defined (See `SpListPresenter>>#searchMatching:`"
 
 	^ searchBlock notNil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTSearchable >> initialize [
 	
 	self class initializeSlots: self.
@@ -40,21 +42,21 @@ SpTSearchable >> initialize [
 	self initializeTSearchable
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTSearchable >> initializeTSearchable [
 	
 	self searchMatching: [ :item :pattern | 
 		self performDefaultSearch: item matching: pattern ].
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTSearchable >> isSearchEnabled [
 	"Answer true if search is enabled (See `SpTSearchable>>#enableSearch`)"
 
 	^ searchEnabled
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTSearchable >> performDefaultSearch: item matching: pattern [
 	| text |
 	
@@ -62,7 +64,7 @@ SpTSearchable >> performDefaultSearch: item matching: pattern [
 	^ text beginsWith: pattern
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTSearchable >> performSearch: item matching: pattern [
 
 	^ searchBlock 
@@ -70,7 +72,7 @@ SpTSearchable >> performSearch: item matching: pattern [
 		value: pattern
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTSearchable >> searchMatching: aBlock [
 	"Enables search and defines a block to perform a search on the model objects. 
 	 The block receives two parameters: 
@@ -81,13 +83,13 @@ SpTSearchable >> searchMatching: aBlock [
 	self enableSearch
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTSearchable >> searchValueOf: item [ 
 
 	^ self displayValueFor: item
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTSearchable >> whenSearchEnabledChangedDo: aBlock [
 	"Inform when search enabled/disabled has changed.
  	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpTableColumn.class.st
+++ b/src/Spec2-Core/SpTableColumn.class.st
@@ -3,8 +3,8 @@ A base definition for table columns.
 A `SpTableColumn` define the common behavior of a column.
 "
 Class {
-	#name : #SpTableColumn,
-	#superclass : #Object,
+	#name : 'SpTableColumn',
+	#superclass : 'Object',
 	#traits : 'SpTAlignableColumn',
 	#classTraits : 'SpTAlignableColumn classTrait',
 	#instVars : [
@@ -14,10 +14,12 @@ Class {
 		'sortFunction',
 		'width'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 SpTableColumn class >> addDocumentSectionHierarchy: aBuilder [
 	
 	aBuilder newLine.
@@ -29,7 +31,7 @@ SpTableColumn class >> addDocumentSectionHierarchy: aBuilder [
 		buildFor: self
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTableColumn class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -39,7 +41,7 @@ SpTableColumn class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #testing ]) }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTableColumn class >> evaluated: aValuable [
 
 	^ self new 
@@ -47,7 +49,7 @@ SpTableColumn class >> evaluated: aValuable [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTableColumn class >> title: aString [
 
 	^ self new 
@@ -55,7 +57,7 @@ SpTableColumn class >> title: aString [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTableColumn class >> title: aString evaluated: aValuable [
 
 	^ self new 
@@ -64,13 +66,13 @@ SpTableColumn class >> title: aString evaluated: aValuable [
 		yourself
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SpTableColumn >> acceptColumnVisitor: aBuilder [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> beExpandable [
 	"Indicate that this column may be expanded if requested by the rendering.
 	 This will cause the column to take as much width as it is given.
@@ -79,7 +81,7 @@ SpTableColumn >> beExpandable [
 	expandable := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> beNotExpandable [
 	"Indicate that this column will not be expanded when requested by the rendering.
 	 This will cause the column to have a fixed width (often calculated by the width of its 
@@ -88,7 +90,7 @@ SpTableColumn >> beNotExpandable [
 	expandable := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> evaluated: aBlock [
 	"Define how the column will evaluate the element of the table/tree model 
 	 (See `SpAbstractListPresenter>>#items:) to get the value to display in this 
@@ -99,7 +101,7 @@ SpTableColumn >> evaluated: aBlock [
 	evaluation := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> evaluation [
 	"Answer the evaluation block to transform the table element (See `SpAbstractListPresenter>>#items:`)
 	 into a value to display in this column"
@@ -107,48 +109,48 @@ SpTableColumn >> evaluation [
 	^ evaluation
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTableColumn >> initialize [
 
 	super initialize.
 	self beExpandable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTableColumn >> isComposite [
 	"Answer if this is a composite column"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTableColumn >> isEditable [
 	"Answer if this column is editable"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTableColumn >> isExpandable [
 	"Answer if this column is expandable"
 
 	^ expandable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTableColumn >> isSortable [
 	"Answer if this column is sortable"
 
 	^ self sortFunction notNil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTableColumn >> readObject: anObject [ 
 
 	^ self evaluation cull: anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> sortFunction [
 	"Answer the a sort function to apply to the values of this column in order to sort elements. 
 	 If not defined, most table column types will not allow the table sorting capabilities. 
@@ -158,7 +160,7 @@ SpTableColumn >> sortFunction [
 	^ sortFunction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> sortFunction: aBlockOrSortFunction [
 	"Set the sort function to apply to the values of this column in order to sort elements.
 	 `aBlockOrSortFunction` is a block that receives two arguments to compare or an instace of 
@@ -167,21 +169,21 @@ SpTableColumn >> sortFunction: aBlockOrSortFunction [
 	sortFunction := aBlockOrSortFunction
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> title [
 	"Answer the header title of this column."
 
 	^ title
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> title: aString [
 	"Set the header title of this column."
 
 	title := aString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> width [
 	"Answer the fixed width of this column (or nil if column is expandable, 
 	 see `SpTableColumn>>#beExpandable`)"
@@ -189,7 +191,7 @@ SpTableColumn >> width [
 	^ width
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTableColumn >> width: aNumber [
 	"Set the width of a column to `aNumber`. 
 	 Note that setting width to a value will NOT make this column not expandable. 

--- a/src/Spec2-Core/SpTablePresenter.class.st
+++ b/src/Spec2-Core/SpTablePresenter.class.st
@@ -6,8 +6,8 @@ A table has columns with a type (See column types section).
 
 "
 Class {
-	#name : #SpTablePresenter,
-	#superclass : #SpAbstractListPresenter,
+	#name : 'SpTablePresenter',
+	#superclass : 'SpAbstractListPresenter',
 	#traits : 'SpTSearchable',
 	#classTraits : 'SpTSearchable classTrait',
 	#instVars : [
@@ -15,16 +15,18 @@ Class {
 		'#showColumnHeaders => ObservableSlot',
 		'#isResizable => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTablePresenter class >> adapterName [
 
 	^ #TableAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTablePresenter class >> addDocumentExtraSections: aBuilder [
 
 	aBuilder newLine.
@@ -35,20 +37,20 @@ SpTablePresenter class >> addDocumentExtraSections: aBuilder [
 				aBuilder monospace: eachType name ] ] ]
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTablePresenter class >> documentFactoryMethodSelector [
 
 	^ #newTable
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> addColumn: aColumn [
 	"Add a column to the table. A column should be an instance of `SpTableColumn`"
 
 	columns := columns copyWith: aColumn
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> addColumns: aCollection [
 	"Add a list of columns.
 	 `aCollection` is a list of instances of `SpTableColumn`"
@@ -56,13 +58,13 @@ SpTablePresenter >> addColumns: aCollection [
 	aCollection do: [ :each | self addColumn: each ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> alternateRowsColor [
 	" Will alternate Rows color for a better reading: one row lighter, the next row darker"
 	self withAdapterPerformOrDefer: [ :tableAdapter | tableAdapter alternateRowsColor ].
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> beNotResizable [
 	"Mark the table as 'not resizable', which means there will be not possibility to resize the 
 	 columns of it."
@@ -70,26 +72,26 @@ SpTablePresenter >> beNotResizable [
 	self isResizable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> beResizable [
 	"Mark the table as 'resizable', which means there will be a slider to resize the columns."
 
 	self isResizable: true
 ]
 
-{ #category : #emulating }
+{ #category : 'emulating' }
 SpTablePresenter >> clickOnColumnHeaderAt: anIndex [
 	self withAdapterDo: [ :tableAdapter | tableAdapter clickOnColumnHeaderAt: anIndex ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> columns [
 	"Answer the columns composing this table."
 
 	^ columns
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> columns: aCollection [
 	"Set all columns at once. 
 	 `aCollection` is a list of instances of `SpTableColumn`"
@@ -97,14 +99,14 @@ SpTablePresenter >> columns: aCollection [
 	columns := aCollection
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> hideColumnHeaders [
 	"Hide the column headers"
 
 	showColumnHeaders := false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTablePresenter >> initialize [ 
 
 	super initialize.
@@ -114,52 +116,52 @@ SpTablePresenter >> initialize [
 	isResizable := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTablePresenter >> isResizable [
 	"Answer true if table allows resizing of its columns."
 
 	^ isResizable
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTablePresenter >> isResizable: aBoolean [
 	isResizable := aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTablePresenter >> isShowingColumnHeaders [
 	"Answer true if the table is configured to show column headers."
 
 	^ showColumnHeaders
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> removeColumn: aColumn [
 	"Remove a column from the table. A column should be an instance of `SpTableColumn`"
 
 	columns := columns copyWithout: aColumn
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTablePresenter >> searchValueOf: anObject [
 	
 	^ anObject asString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTablePresenter >> showColumnHeaders [
 	"Show column headers"
 
 	showColumnHeaders := true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTablePresenter >> valueAtColumn: aColumn row: aRow [
 
 	^ (columns at: aColumn) readObject: (self model items at: aRow)
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTablePresenter >> whenColumnsChangedDo: aBlock [
 	"Inform when columns have changed. 
 	 `aBlock` has three optional arguments: 
@@ -170,7 +172,7 @@ SpTablePresenter >> whenColumnsChangedDo: aBlock [
 	self property: #columns whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTablePresenter >> whenIsResizableChangedDo: aBlock [
 	"Inform when resizable property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -181,7 +183,7 @@ SpTablePresenter >> whenIsResizableChangedDo: aBlock [
 	self property: #isResizable whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTablePresenter >> whenShowColumnHeadersChangedDo: aBlock [
 	"Inform when showColumnHeaders property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpTextInputFieldPresenter.class.st
+++ b/src/Spec2-Core/SpTextInputFieldPresenter.class.st
@@ -3,78 +3,80 @@ A presenter to handle a single line of text.
 
 "
 Class {
-	#name : #SpTextInputFieldPresenter,
-	#superclass : #SpAbstractTextPresenter,
+	#name : 'SpTextInputFieldPresenter',
+	#superclass : 'SpAbstractTextPresenter',
 	#instVars : [
 		'#entryCompletion => ObservableSlot',
 		'#isPassword => ObservableSlot',
 		'#editable => ObservableSlot',
 		'#maxLength => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTextInputFieldPresenter class >> adapterName [
 
 	^ #TextInputFieldAdapter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> beEditable [
 	"Allow edition (deny readonly)."
 
 	self editable: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> beNotEditable [
 	"Set content text as not editable (readonly)"
 
 	self editable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> bePassword [
 	"Set this input text as a password editor."
 	
 	self bePassword: true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextInputFieldPresenter >> bePassword: aBoolean [
 	
 	isPassword := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> beText [
 	"Set this input text as a text editor."
 
 	self bePassword: false
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextInputFieldPresenter >> editable: aBoolean [
 
 	editable := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> entryCompletion [
 	"Return an entry completion used to suggest text while typing"
 
 	^ entryCompletion
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> entryCompletion: anEntryCompletion [
 	"Set an entry completion used to suggest text while typing"
 
 	entryCompletion := anEntryCompletion
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTextInputFieldPresenter >> initialize [
 	super initialize.
 
@@ -84,28 +86,28 @@ SpTextInputFieldPresenter >> initialize [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextInputFieldPresenter >> isEditable [
 	"Answer true if edition is allowed (component is NOT readonly)"
 
 	^ editable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextInputFieldPresenter >> isPassword [
 	"Answer true if input field will be shown as a password (hiding characters)."
 	
 	^ isPassword
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> maxLength [
 	"Answer maximum allowed length (if set)"
 
 	^ maxLength
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> maxLength: anInteger [ 
 	"Set maximum allowed length."
 	
@@ -113,14 +115,14 @@ SpTextInputFieldPresenter >> maxLength: anInteger [
 	self updateText.
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> removeEntryCompletion [
 	"Remove the entry completion"
 	
 	self entryCompletion: nil
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> text: aString [
 	"Set input text contents."
 	| truncatedText |
@@ -131,14 +133,14 @@ SpTextInputFieldPresenter >> text: aString [
 	super text: truncatedText
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextInputFieldPresenter >> updateText [
 	"Update text but applying lenght constraints"
 	
 	self text: self text.
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextInputFieldPresenter >> whenEditableChangedDo: aBlock [
 	"Inform when editable property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -149,7 +151,7 @@ SpTextInputFieldPresenter >> whenEditableChangedDo: aBlock [
 	self property: #editable whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextInputFieldPresenter >> whenEntryCompletionChangedDo: aBlock [
 	"Inform when entryCompletion property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -160,7 +162,7 @@ SpTextInputFieldPresenter >> whenEntryCompletionChangedDo: aBlock [
 	self property: #entryCompletion whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextInputFieldPresenter >> whenMaxLengthChangedDo: aBlockClosure [ 
 	"Inform when maxLength property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -171,7 +173,7 @@ SpTextInputFieldPresenter >> whenMaxLengthChangedDo: aBlockClosure [
 	self property: #maxLength whenChangedDo: aBlockClosure
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextInputFieldPresenter >> whenPasswordChangedDo: aBlockClosure [ 
 	"Inform when password property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -182,7 +184,7 @@ SpTextInputFieldPresenter >> whenPasswordChangedDo: aBlockClosure [
 	self property: #isPassword whenChangedDo: aBlockClosure
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextInputFieldPresenter >> whenSubmitDo: aBlock [
 	"This method will add a 'submit' event to the widget. It will react when user 
 	 presses <meta+s> key (this is for historical reasons), and with enter (cr).

--- a/src/Spec2-Core/SpTextPresenter.class.st
+++ b/src/Spec2-Core/SpTextPresenter.class.st
@@ -2,8 +2,8 @@
 A presenter to handle basic multi-line text.
 "
 Class {
-	#name : #SpTextPresenter,
-	#superclass : #SpAbstractTextPresenter,
+	#name : 'SpTextPresenter',
+	#superclass : 'SpAbstractTextPresenter',
 	#traits : 'SpTHaveWrappingScrollBars',
 	#classTraits : 'SpTHaveWrappingScrollBars classTrait',
 	#instVars : [
@@ -13,16 +13,18 @@ Class {
 		'#wrapWord => ObservableSlot',
 		'#undoRedoHistory'
 	],
-	#category : #'Spec2-Core-Widgets-Text'
+	#category : 'Spec2-Core-Widgets-Text',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Text'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTextPresenter class >> adapterName [
 
 	^ #TextAdapter
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter class >> buildEditionCommandsGroupFor: presenterInstance [
 	| rootCommandGroup |
 
@@ -34,7 +36,7 @@ SpTextPresenter class >> buildEditionCommandsGroupFor: presenterInstance [
 	^ rootCommandGroup
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter class >> buildEditionCommandsGroupWith: presenter forRoot: aCmCommandsGroup [
 
 	aCmCommandsGroup beDisplayedAsGroup.
@@ -42,13 +44,13 @@ SpTextPresenter class >> buildEditionCommandsGroupWith: presenter forRoot: aCmCo
 	aCmCommandsGroup register: (self textEditionCommandsGroupWith: presenter).
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTextPresenter class >> documentFactoryMethodSelector [
 
 	^ #newText
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter class >> textEditionCommandsGroupWith: aPresenter [
 	| group |
 
@@ -63,7 +65,7 @@ SpTextPresenter class >> textEditionCommandsGroupWith: aPresenter [
 	^ group
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter class >> textSearchCommandsGroupWith: aPresenter [
 	| group |
 
@@ -78,13 +80,13 @@ SpTextPresenter class >> textSearchCommandsGroupWith: aPresenter [
 	^ group
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTextPresenter class >> title [
 
 	^ 'Text'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextPresenter >> backendIncludesEditionMenu [
 	"Some backends can contain bundled by default edition context menu (copy, cut, paste), 
 	 users may want to use it instead of Pharo's"
@@ -94,21 +96,21 @@ SpTextPresenter >> backendIncludesEditionMenu [
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> beEditable [
 	"Allow edition (deny readonly)."
 
 	self editable: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> beNotEditable [
 	"Set content text as not editable (readonly)"
 
 	self editable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> beNotWrapWord [
 	"Set component to not wrap words when text does not fit in screen.
 	 Instead, the editor will add an horizontal scrollbar."
@@ -116,63 +118,63 @@ SpTextPresenter >> beNotWrapWord [
 	self wrapWord: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> beWrapWord [
 	"Set component to wrap words to make the text fit in screen."
 
 	self wrapWord: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> cursorPosition [
 	"Answer a Point (column, row) with current cursor position"
 
 	^ self withAdapterDo: [ :anAdapter | anAdapter cursorPosition ]
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter >> doTextCopy [
 
 	self withAdapterDo: [ :anAdapter | anAdapter copyText ]
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter >> doTextCut [
 
 	self withAdapterDo: [ :anAdapter | anAdapter cutText ]
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter >> doTextFind [
 
 	self withAdapterDo: [ :anAdapter | anAdapter findText ]
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter >> doTextFindNext [
 
 		self withAdapterDo: [ :anAdapter | anAdapter findNextText ]
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter >> doTextPaste [
 
 		self withAdapterDo: [ :anAdapter | anAdapter pasteText ]
 ]
 
-{ #category : #commands }
+{ #category : 'commands' }
 SpTextPresenter >> doTextSelectAndPaste [
 
 	self withAdapterDo: [ :anAdapter | anAdapter selectAndPasteText ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextPresenter >> editable: aBoolean [
 
 	editable := aBoolean
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextPresenter >> editionCommandsGroup [
 
 	^ SpRecursiveContextSetter 
@@ -180,31 +182,31 @@ SpTextPresenter >> editionCommandsGroup [
 		toSetContext: self defaultCommandsContext
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextPresenter >> editionContextKeyBindings [
 
 	^ self editionCommandsGroup asKMCategory
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextPresenter >> editionContextMenu [
 
 	^ self editionCommandsGroup asMenuPresenter
 ]
 
-{ #category : #'private - testing' }
+{ #category : 'private - testing' }
 SpTextPresenter >> hasEditionContextMenu [
 
 	^ editionContextMenu
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextPresenter >> hasUndoRedoHistory [
 
 	^ undoRedoHistory
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTextPresenter >> initialize [ 
 
 	super initialize.
@@ -218,28 +220,28 @@ SpTextPresenter >> initialize [
 	self withUndoRedoHistory
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextPresenter >> isEditable [
 	"Answer true if edition is allowed (component is NOT readonly)"
 
 	^ editable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextPresenter >> isWrapWord [
 	"Answer true if words will be wrapped to make text fit horizontally into component area."
 
 	^ wrapWord
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> lineAtCursorPosition [
 
 	self withAdapterDo: [ :anAdapter | ^ anAdapter lineAtCursorPosition ].
 	^ nil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTextPresenter >> registerEvents [
 
 	super registerEvents.
@@ -247,21 +249,21 @@ SpTextPresenter >> registerEvents [
 		self changed: #setScrollValue: with: { newPosition } ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> scrollValue [
 	"Return the current scroll position"
 
 	^ scrollValue
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> scrollValue: aPoint [
 	"Set the scroll position"
 
 	^ scrollValue := aPoint
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextPresenter >> whenCursorPositionChangedDo: aBlock [
 	"Inform when cursorPosition property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -272,7 +274,7 @@ SpTextPresenter >> whenCursorPositionChangedDo: aBlock [
 	self property: #cursorPosition whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextPresenter >> whenEditableChangedDo: aBlock [
 	"Inform when editable property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -283,7 +285,7 @@ SpTextPresenter >> whenEditableChangedDo: aBlock [
 	self property: #editable whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextPresenter >> whenScrollValueChangedDo: aBlock [
 	"Inform when scrollValue property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -294,7 +296,7 @@ SpTextPresenter >> whenScrollValueChangedDo: aBlock [
 	self property: #scrollValue whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextPresenter >> whenSubmitDo: aBlock [
 	"This method will add a 'submit' event to the widget. It will react when user 
 	 presses <meta+s> key (this is for historical reasons) and with enter (cr).
@@ -305,7 +307,7 @@ SpTextPresenter >> whenSubmitDo: aBlock [
 		toAction: [ aBlock value: self text ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTextPresenter >> whenWrapWordChangedDo: aBlock [
 	"Inform when wordWrap property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -316,7 +318,7 @@ SpTextPresenter >> whenWrapWordChangedDo: aBlock [
 	self property: #wrapWord whenChangedDo: aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> withEditionContextMenu [
 	"Enables edition context menu. When this option is selected, right-clicking in the text area 
 	 will show a standard edition menu (copy, cut, copy&paste). 
@@ -326,13 +328,13 @@ SpTextPresenter >> withEditionContextMenu [
 	editionContextMenu := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> withUndoRedoHistory [
 
 	undoRedoHistory := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> withoutEditionContextMenu [
 	"Disable default edition context menu. 
 	 See also `SpTextPresenter>>#withEditionContextMenu`."
@@ -340,13 +342,13 @@ SpTextPresenter >> withoutEditionContextMenu [
 	editionContextMenu := false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTextPresenter >> withoutUndoRedoHistory [
 
 	undoRedoHistory := false
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTextPresenter >> wrapWord: aBoolean [
 
 	wrapWord := aBoolean

--- a/src/Spec2-Core/SpTickingWindowPresenter.class.st
+++ b/src/Spec2-Core/SpTickingWindowPresenter.class.st
@@ -2,23 +2,25 @@
 In addition to my superclass, I provide an API to execute the `step` method every `stepTime`.
 "
 Class {
-	#name : #SpTickingWindowPresenter,
-	#superclass : #SpWindowPresenter,
-	#category : #'Spec2-Core-Windows'
+	#name : 'SpTickingWindowPresenter',
+	#superclass : 'SpWindowPresenter',
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTickingWindowPresenter class >> adapterName [
 
 	^ #TickingWindowAdapter
 ]
 
-{ #category : #stepping }
+{ #category : 'stepping' }
 SpTickingWindowPresenter >> step [
 	self presenter step
 ]
 
-{ #category : #stepping }
+{ #category : 'stepping' }
 SpTickingWindowPresenter >> stepTime [
 	^ self presenter stepTime
 ]

--- a/src/Spec2-Core/SpToggleButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToggleButtonPresenter.class.st
@@ -4,35 +4,37 @@ A toggle button is a button that can be activated (toggled) or deactivated (unto
 
 "
 Class {
-	#name : #SpToggleButtonPresenter,
-	#superclass : #SpAbstractFormButtonPresenter,
+	#name : 'SpToggleButtonPresenter',
+	#superclass : 'SpAbstractFormButtonPresenter',
 	#instVars : [
 		'#associatedToggleButtons',
 		'#action => ObservableSlot',
 		'#icon => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToggleButtonPresenter class >> adapterName [
 	
 	^ #ToggleButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpToggleButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newToggleButton
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToggleButtonPresenter class >> title [
 
 	^ 'Toggle Button'
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToggleButtonPresenter >> action [ 
 	"Answer the action to execute when button is pressed.
 	 See `SpToggleButtonPresenter>>#action:`"
@@ -40,7 +42,7 @@ SpToggleButtonPresenter >> action [
 	^ action
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToggleButtonPresenter >> action: aBlock [
 	"Set the action to execute when button is pressed. 
 	 `aBlock` receives zero arguments."
@@ -48,13 +50,13 @@ SpToggleButtonPresenter >> action: aBlock [
 	action := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToggleButtonPresenter >> associatedToggleButtons [
 
 	^ associatedToggleButtons ifNil: [ #() ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToggleButtonPresenter >> associatedToggleButtons: aCollection [ 
 	"Set the list of toggle buttons associated with this one.
 	 By using this, you will be grouping together this toggle button along with the ones contained 
@@ -71,34 +73,34 @@ SpToggleButtonPresenter >> associatedToggleButtons: aCollection [
 	aCollection do: [ :each | each state: false ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToggleButtonPresenter >> basicAssociatedToggleButtons: aCollection [ 
 	
 	associatedToggleButtons := aCollection copyWithout: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToggleButtonPresenter >> icon [
 	"Answer the icon (an instance of `Form`) to be shown with the button."
 
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToggleButtonPresenter >> icon: anIcon [
 	"Set the icon (an instance of `Form`) to be shown with the button."
 
 	icon := anIcon
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpToggleButtonPresenter >> initialize [
 
 	super initialize.
 	action := [ ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToggleButtonPresenter >> whenIconChangedDo: aBlock [
 	"Inform when icon property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpTokenTreeFilter.class.st
+++ b/src/Spec2-Core/SpTokenTreeFilter.class.st
@@ -4,15 +4,17 @@ I am a filter for a token.
 If a node item contains my token I accept it
 "
 Class {
-	#name : #SpTokenTreeFilter,
-	#superclass : #SpAbstractTreeFilter,
+	#name : 'SpTokenTreeFilter',
+	#superclass : 'SpAbstractTreeFilter',
 	#instVars : [
 		'token'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTokenTreeFilter class >> token: token [
 
 	^ self new
@@ -20,20 +22,20 @@ SpTokenTreeFilter class >> token: token [
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTokenTreeFilter >> initialize [
 
 	super initialize.
 	token := ''.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTokenTreeFilter >> token [
 
 	^ token
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTokenTreeFilter >> token: anObject [
 	
 	token := anObject

--- a/src/Spec2-Core/SpToolbarButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarButtonPresenter.class.st
@@ -3,8 +3,8 @@ A button to be shown in a `SpToolbarPresenter`.
 A `SpToolbarButtonPresenter` can show a badge.
 "
 Class {
-	#name : #SpToolbarButtonPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpToolbarButtonPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#traits : 'SpTContextMenu',
 	#classTraits : 'SpTContextMenu classTrait',
 	#instVars : [
@@ -13,29 +13,31 @@ Class {
 		'#action',
 		'#badge'
 	],
-	#category : #'Spec2-Core-Widgets-Toolbar'
+	#category : 'Spec2-Core-Widgets-Toolbar',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Toolbar'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToolbarButtonPresenter class >> adapterName [
 
 	^ #ToolbarButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpToolbarButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newToolbarButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> action [
 	"Answer the block performed when the button is clicked."
 
 	^ action
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> action: aBlock [
 	"Set the block performed when the button is clicked. 
 	 `aBlock` receives zero arguments."
@@ -43,14 +45,14 @@ SpToolbarButtonPresenter >> action: aBlock [
 	action := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> badge [
 	"Answer the badge that will be shown with the button."
 
 	^ badge
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> badge: aString [
 	"Set the badge to be shown with the button.
 	 A badge is an extra piece of information that can be added to the button. Typically, this 
@@ -60,50 +62,50 @@ SpToolbarButtonPresenter >> badge: aString [
 	badge := aString
 ]
 
-{ #category : #simulating }
+{ #category : 'simulating' }
 SpToolbarButtonPresenter >> click [
 	
 	self action cull: self
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SpToolbarButtonPresenter >> execute [
 
 	self withAdapterDo: [ :anAdapter | anAdapter execute ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> icon [
 	"Answer the icon (an instance of `Form`) defined for this button (it can be nil)"
 
 	^ icon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> icon: anObject [
 	icon := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpToolbarButtonPresenter >> initialize [
 	super initialize.
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> label [
 	"Answer the label to be shown by the button"
 
 	^ label
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarButtonPresenter >> label: aString [
 	"Set the label to be shown by the button."
 
 	label := aString
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarButtonPresenter >> whenIconChangedDo: aBlock [ 
 	"Inform when icon property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -114,7 +116,7 @@ SpToolbarButtonPresenter >> whenIconChangedDo: aBlock [
 	self property: #icon whenChangedDo: aBlock 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarButtonPresenter >> whenLabelChangedDo: aBlock [ 
 	"Inform when label property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpToolbarDisplayMode.class.st
+++ b/src/Spec2-Core/SpToolbarDisplayMode.class.st
@@ -2,15 +2,17 @@
 A base for different display modes for a toolbar
 "
 Class {
-	#name : #SpToolbarDisplayMode,
-	#superclass : #Object,
+	#name : 'SpToolbarDisplayMode',
+	#superclass : 'Object',
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode class >> all [
 
 	^ { 
@@ -20,32 +22,32 @@ SpToolbarDisplayMode class >> all [
 	 }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode class >> default [
 	^ self modeIconAndLabel
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode class >> modeIcon [
 	^ SpIconToolbarDisplayMode uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode class >> modeIconAndLabel [
 	^ SpIconAndLabelToolbarDisplayMode uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode class >> modeLabel [
 	^ SpLabelToolbarDisplayMode uniqueInstance
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpToolbarDisplayMode class >> new [
 	self error: 'Use #uniqueInstance'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpToolbarDisplayMode class >> uniqueInstance [
 
 	self = SpToolbarDisplayMode 
@@ -53,39 +55,39 @@ SpToolbarDisplayMode class >> uniqueInstance [
 	^ uniqueInstance ifNil: [ uniqueInstance := self basicNew initialize ]
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpToolbarDisplayMode >> configureButton: aButton item: aToolbarItem [
 	self subclassResponsibility
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpToolbarDisplayMode >> configureDropList: aSpDropListMorph item: aSpDropListPresenter [ 
 	self flag: 'TODO: maybe customize the drop list to have a better look''n feel'.
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 SpToolbarDisplayMode >> configureMorph: aMorph item: itemPresenter [
 	aMorph configureWith: self item: itemPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode >> extent [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode >> height [
 
 	^ self extent y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode >> styleName [ 
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarDisplayMode >> width [
 
 	^ self extent x

--- a/src/Spec2-Core/SpToolbarItemLeftPosition.class.st
+++ b/src/Spec2-Core/SpToolbarItemLeftPosition.class.st
@@ -6,12 +6,14 @@ Do not use the class directly, instead use:
 	ITItemPosition left
 "
 Class {
-	#name : #SpToolbarItemLeftPosition,
-	#superclass : #SpToolbarItemPosition,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpToolbarItemLeftPosition',
+	#superclass : 'SpToolbarItemPosition',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarItemLeftPosition >> addItem: anObject into: aToolbar [
 	aToolbar addItemLeft: anObject
 ]

--- a/src/Spec2-Core/SpToolbarItemPosition.class.st
+++ b/src/Spec2-Core/SpToolbarItemPosition.class.st
@@ -8,43 +8,45 @@ The default item positioning is left.
 	ITItemPosition left
 "
 Class {
-	#name : #SpToolbarItemPosition,
-	#superclass : #Object,
+	#name : 'SpToolbarItemPosition',
+	#superclass : 'Object',
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'Spec2-Core-Widgets'
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarItemPosition class >> default [
 	^ self left	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarItemPosition class >> left [
 	^ SpToolbarItemLeftPosition uniqueInstance
 	
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpToolbarItemPosition class >> new [
 	self error: 'Use uniqueInstance'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarItemPosition class >> right [
 	^ SpToolbarItemRightPosition uniqueInstance
 	
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpToolbarItemPosition class >> uniqueInstance [
 
 	^ uniqueInstance ifNil: [ uniqueInstance := self basicNew initialize ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarItemPosition >> addItem: anObject into: aToolbar [
 	self subclassResponsibility
 ]

--- a/src/Spec2-Core/SpToolbarItemRightPosition.class.st
+++ b/src/Spec2-Core/SpToolbarItemRightPosition.class.st
@@ -6,12 +6,14 @@ Do not use the class directly, instead use:
 	ITItemPosition right
 "
 Class {
-	#name : #SpToolbarItemRightPosition,
-	#superclass : #SpToolbarItemPosition,
-	#category : #'Spec2-Core-Widgets'
+	#name : 'SpToolbarItemRightPosition',
+	#superclass : 'SpToolbarItemPosition',
+	#category : 'Spec2-Core-Widgets',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarItemRightPosition >> addItem: anObject into: aToolbar [
 	aToolbar addItemRight: anObject
 ]

--- a/src/Spec2-Core/SpToolbarMenuButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarMenuButtonPresenter.class.st
@@ -2,34 +2,36 @@
 A presenter to create a menu button (a button who exposes a menu instead having an action) in a `SpToolbarPresenter`.
 "
 Class {
-	#name : #SpToolbarMenuButtonPresenter,
-	#superclass : #SpToolbarButtonPresenter,
+	#name : 'SpToolbarMenuButtonPresenter',
+	#superclass : 'SpToolbarButtonPresenter',
 	#instVars : [
 		'menu'
 	],
-	#category : #'Spec2-Core-Widgets-Toolbar'
+	#category : 'Spec2-Core-Widgets-Toolbar',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Toolbar'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToolbarMenuButtonPresenter class >> adapterName [
 
 	^ #ToolbarMenuButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpToolbarMenuButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newToolbarMenuButton
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpToolbarMenuButtonPresenter >> initialize [
 
 	super initialize.
 	self addStyle: 'button'
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarMenuButtonPresenter >> menu [
 	"Answer the menu associated to this menu button. 
 	 It can also be a block (or valuable) which will answer an instance of `SpMenuPresenter`
@@ -38,7 +40,7 @@ SpToolbarMenuButtonPresenter >> menu [
 	^ menu
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarMenuButtonPresenter >> menu: aMenuOrBlock [
 	"Set the menu associated to this menu button. 
 	 It can also be a block (or valuable) which will answer an instance of `SpMenuPresenter`

--- a/src/Spec2-Core/SpToolbarPopoverButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarPopoverButtonPresenter.class.st
@@ -2,27 +2,29 @@
 A presenter to create a popover button (a button who exposes a popover instead having an action) in a `SpToolbarPresenter`.
 "
 Class {
-	#name : #SpToolbarPopoverButtonPresenter,
-	#superclass : #SpToolbarButtonPresenter,
+	#name : 'SpToolbarPopoverButtonPresenter',
+	#superclass : 'SpToolbarButtonPresenter',
 	#instVars : [
 		'content'
 	],
-	#category : #'Spec2-Core-Widgets-Toolbar'
+	#category : 'Spec2-Core-Widgets-Toolbar',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Toolbar'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToolbarPopoverButtonPresenter class >> adapterName [
 
 	^ #ToolbarPopoverButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpToolbarPopoverButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newToolbarPopoverButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPopoverButtonPresenter >> content [
 	"Answer the content presenter associated to this popover button. 
 	 It can also be a block (or valuable) which will answer an instance of `SpPresenter`
@@ -31,7 +33,7 @@ SpToolbarPopoverButtonPresenter >> content [
 	^ content
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPopoverButtonPresenter >> content: aPresenterOrBlock [
 	"Set the presenter associated to this popover button. 
 	 It can also be a block (or valuable) which will answer an instance of `SpPresenter`

--- a/src/Spec2-Core/SpToolbarPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarPresenter.class.st
@@ -3,36 +3,38 @@ A presenter to display a toolbar.
 
 "
 Class {
-	#name : #SpToolbarPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpToolbarPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#displayMode => ObservableSlot',
 		'#leftItems => ObservableSlot',
 		'#rightItems => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Toolbar'
+	#category : 'Spec2-Core-Widgets-Toolbar',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Toolbar'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToolbarPresenter class >> adapterName [
 
 	^ #ToolbarAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpToolbarPresenter class >> documentFactoryMethodSelector [
 
 	^ #newToolbar
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> add: aToolbarButtonPresenter [ 
 	"Add a toolbar button to the toolbar."
 	
 	self addItem: aToolbarButtonPresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> addItem: aToolbarItem [
 	"Add a toolbar button to the toolbar.
 	 This is a synonym of `SpToolbarPresenter>>#add:`"
@@ -40,14 +42,14 @@ SpToolbarPresenter >> addItem: aToolbarItem [
 	self addItem: aToolbarItem position: SpToolbarItemPosition left
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenter >> addItem: aToolbarItem position: aPosition [
 	
 	aToolbarItem owner: self.
 	aPosition addItem: aToolbarItem into: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenter >> addItemLeft: aToolbarItem [ 
 	
 	aToolbarItem owner: self.
@@ -55,7 +57,7 @@ SpToolbarPresenter >> addItemLeft: aToolbarItem [
 	self notifyPropertyChanged: #leftItems.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenter >> addItemRight: aToolbarItem [ 
 
 	aToolbarItem owner: self.
@@ -63,7 +65,7 @@ SpToolbarPresenter >> addItemRight: aToolbarItem [
 	self notifyPropertyChanged: #rightItems.	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> beBoth [
 	"Set the toolbar to display both text and icons.
 	 See also `SpToolbarPresenter>>#displayMode:`"
@@ -71,7 +73,7 @@ SpToolbarPresenter >> beBoth [
 	self displayMode: SpToolbarDisplayMode modeIconAndLabel
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> beIcons [
 	"Set the toolbar to display just the icons.
 	See also `SpToolbarPresenter>>#displayMode:`"
@@ -79,7 +81,7 @@ SpToolbarPresenter >> beIcons [
 	self displayMode: SpToolbarDisplayMode modeIcon
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> beText [
 	"Set the toolbar to display just the labels.
 	 See also `SpToolbarPresenter>>#displayMode:`"
@@ -87,14 +89,14 @@ SpToolbarPresenter >> beText [
 	self displayMode: SpToolbarDisplayMode modeLabel
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> displayMode [
 	"Answer the display mode of the toolbar (an instance of `SpToolbarDisplayMode`"
 
 	^ displayMode
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> displayMode: aDisplayMode [
 	"Set the display mode of this toolbar. 
 	 `aDisplayMode` is an instance of `SpToolbarDisplayMode`"
@@ -106,7 +108,7 @@ SpToolbarPresenter >> displayMode: aDisplayMode [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpToolbarPresenter >> initialize [
 
 	super initialize.
@@ -116,67 +118,67 @@ SpToolbarPresenter >> initialize [
 	rightItems := OrderedCollection new.	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpToolbarPresenter >> isDisplayModeBoth [
 
 	^ self displayMode = SpToolbarDisplayMode modeIconAndLabel
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpToolbarPresenter >> isDisplayModeIcons [
 
 	^ self displayMode = SpToolbarDisplayMode modeIcon
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpToolbarPresenter >> isDisplayModeText [
 
 	^ self displayMode = SpToolbarDisplayMode modeLabel
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpToolbarPresenter >> isEmpty [
 	
 	^ self items isEmpty
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenter >> itemNamed: aString [ 
 	
 	^ self items detect: [ :e | e label = aString ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> items [
 	"Answer all buttons in the toolbar"
 
 	^ leftItems , rightItems
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenter >> leftItems [
 	^ leftItems
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpToolbarPresenter >> notEmpty [
 
 	^ self isEmpty not
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpToolbarPresenter >> presenters [
 
 	^ self items
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpToolbarPresenter >> presentersInFocusOrder [
 
 	^ self items
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarPresenter >> removeAllItems [
 	"Remove all items in the toolbar"
 
@@ -184,19 +186,19 @@ SpToolbarPresenter >> removeAllItems [
 	rightItems := OrderedCollection new
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenter >> rightItems [
 	^ rightItems
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpToolbarPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	self presentersInFocusOrder do: [ :each |
 		each traverseInFocusOrderDo: aBlock excluding: excludes ]
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 SpToolbarPresenter >> whenItemsChangeDo: aBlockClosure [ 
 	
 	self 

--- a/src/Spec2-Core/SpToolbarToggleButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarToggleButtonPresenter.class.st
@@ -4,34 +4,36 @@ A toggle button is a button that can be activated (toggled) or deactivated (unto
 
 "
 Class {
-	#name : #SpToolbarToggleButtonPresenter,
-	#superclass : #SpToolbarButtonPresenter,
+	#name : 'SpToolbarToggleButtonPresenter',
+	#superclass : 'SpToolbarButtonPresenter',
 	#instVars : [
 		'#selected => ObservableSlot',
 		'#associatedToggleButtons'
 	],
-	#category : #'Spec2-Core-Widgets-Toolbar'
+	#category : 'Spec2-Core-Widgets-Toolbar',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Toolbar'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpToolbarToggleButtonPresenter class >> adapterName [
 
 	^ #ToolbarToggleButtonAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpToolbarToggleButtonPresenter class >> documentFactoryMethodSelector [
 
 	^ #newToolbarToggleButton
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> associatedToggleButtons [
 
 	^ associatedToggleButtons ifNil: [ #() ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> associatedToggleButtons: aCollection [ 
 	"Set the list of toggle buttons associated with this one.
 	 By using this, you will be grouping together this toggle button along with the ones contained 
@@ -48,27 +50,27 @@ SpToolbarToggleButtonPresenter >> associatedToggleButtons: aCollection [
 	aCollection do: [ :each | each state: false ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarToggleButtonPresenter >> basicAssociatedToggleButtons: aCollection [ 
 	
 	associatedToggleButtons := aCollection copyWithout: self
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> beSelected [
 	"Set the status of the button to 'selected' (toggled)"
 	
 	self setSelection: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> beUnselected [
 	"Set the status of the button to 'unselected' (untoggled)"
 
 	self setSelection: false
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SpToolbarToggleButtonPresenter >> execute: state [
 
 	self setSelection: state.
@@ -78,20 +80,20 @@ SpToolbarToggleButtonPresenter >> execute: state [
 		cull: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpToolbarToggleButtonPresenter >> initialize [
 
 	super initialize.
 	selected := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpToolbarToggleButtonPresenter >> isSelected [
 
 	^ self state
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> selected: aBoolean [
 
 	self 
@@ -100,33 +102,33 @@ SpToolbarToggleButtonPresenter >> selected: aBoolean [
 	self setSelection: aBoolean
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarToggleButtonPresenter >> setSelection: aBoolean [
 
 	selected := aBoolean.
 	self changed: #isSelected
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> state [
 
 	^ selected
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> state: aBoolean [
 
 	self setSelection: aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpToolbarToggleButtonPresenter >> toggle [
 	"Toggles the status of the button"
 	
 	self setSelection: selected not
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarToggleButtonPresenter >> whenActivatedDo: aBlock [
 	"Inform when the button has been selected. 
 	 `aBlock` receives zero arguments."
@@ -135,7 +137,7 @@ SpToolbarToggleButtonPresenter >> whenActivatedDo: aBlock [
 		newSelectedValue ifTrue: [ aBlock value ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarToggleButtonPresenter >> whenChangedDo: aBlock [
 	"Only execute aBlock if old value is different from new value"
 
@@ -146,7 +148,7 @@ SpToolbarToggleButtonPresenter >> whenChangedDo: aBlock [
 				ifFalse: [ aBlock cull: newSelectedValue cull: oldSelectedValue ] ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarToggleButtonPresenter >> whenDeactivatedDo: aBlock [
 	"Inform when the button has been selected. 
 	 `aBlock` receives zero arguments."
@@ -155,7 +157,7 @@ SpToolbarToggleButtonPresenter >> whenDeactivatedDo: aBlock [
 		newSelectedValue ifFalse: [ aBlock value ] ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarToggleButtonPresenter >> whenSelectedDo: aBlock [
 	"Inform when the button has been selected. 
 	 `aBlock` receives zero arguments."
@@ -168,7 +170,7 @@ SpToolbarToggleButtonPresenter >> whenSelectedDo: aBlock [
 		newSelectedValue ifTrue: [ aBlock value ] ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarToggleButtonPresenter >> whenToggledDo: aBlock [ 
 	"Inform when the button has been toggles. 
 	 `aBlock` has three optional arguments: 
@@ -179,7 +181,7 @@ SpToolbarToggleButtonPresenter >> whenToggledDo: aBlock [
 	self property: #selected whenChangedDo: aBlock 
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpToolbarToggleButtonPresenter >> whenUnselectedDo: aBlock [
 	"Inform when the button has been unselected. 
 	 `aBlock` receives zero arguments."

--- a/src/Spec2-Core/SpTransferPresenter.class.st
+++ b/src/Spec2-Core/SpTransferPresenter.class.st
@@ -2,37 +2,39 @@
 I am a model representing a transfer during a drag and drop operation. I keep a pointer the source of the drag, and a pointer to what is dragged
 "
 Class {
-	#name : #SpTransferPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpTransferPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#passenger => ObservableSlot',
 		'#source => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTransferPresenter class >> adapterName [
 
 	^ #TransferAdapter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTransferPresenter >> from: aModel [
 	source := aModel
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTransferPresenter >> passenger [
 	^ passenger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTransferPresenter >> source [
 	^ source
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTransferPresenter >> transfer: anObject [
 	passenger := anObject
 ]

--- a/src/Spec2-Core/SpTreeMultipleSelectionMode.class.st
+++ b/src/Spec2-Core/SpTreeMultipleSelectionMode.class.st
@@ -1,36 +1,38 @@
 Class {
-	#name : #SpTreeMultipleSelectionMode,
-	#superclass : #SpAbstractTreeSelectionMode,
-	#category : #'Spec2-Core-Widgets-Tree'
+	#name : 'SpTreeMultipleSelectionMode',
+	#superclass : 'SpAbstractTreeSelectionMode',
+	#category : 'Spec2-Core-Widgets-Tree',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tree'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeMultipleSelectionMode >> includesItem: anItem [
 	^ self selectedItems includes: anItem
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeMultipleSelectionMode >> includesItems: anItemList [
 	^ self selectedItems includesAll: anItemList
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeMultipleSelectionMode >> includesPath: aPath [
 	^ selection includes: aPath
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeMultipleSelectionMode >> includesPaths: aListOfPaths [
 	^ selection includesAll: aListOfPaths
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeMultipleSelectionMode >> isMultipleSelection [
 
 	^ true
 ]
 
-{ #category : #selection }
+{ #category : 'selection' }
 SpTreeMultipleSelectionMode >> selectPath: aPath [ 
 	"Check comment in my superclass to know how to use selectPath:"
 	
@@ -41,7 +43,7 @@ SpTreeMultipleSelectionMode >> selectPath: aPath [
 	selection := selection copyWith: aPath.
 ]
 
-{ #category : #selection }
+{ #category : 'selection' }
 SpTreeMultipleSelectionMode >> selectPaths: pathArray [
 	(pathArray isEmpty 
 		or: [ 
@@ -56,7 +58,7 @@ SpTreeMultipleSelectionMode >> selectPaths: pathArray [
 	selection := pathArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeMultipleSelectionMode >> selectedItem [
 
 	^ self selectedPaths 
@@ -64,13 +66,13 @@ SpTreeMultipleSelectionMode >> selectedItem [
 		ifEmpty: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeMultipleSelectionMode >> selectedItems [
 	selection ifEmpty: [ ^ #() ].
 	^ selection collect: [ :path | presenter itemAtPath: path ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeMultipleSelectionMode >> selectedPath [
 	
 	^ self selectedPaths 
@@ -78,12 +80,12 @@ SpTreeMultipleSelectionMode >> selectedPath [
 		ifEmpty: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeMultipleSelectionMode >> selectedPaths [
 	^ selection
 ]
 
-{ #category : #selection }
+{ #category : 'selection' }
 SpTreeMultipleSelectionMode >> unselectPath: aPath [
 	self selectPaths: (self selectedPaths copyWithout: aPath)
 ]

--- a/src/Spec2-Core/SpTreePresenter.class.st
+++ b/src/Spec2-Core/SpTreePresenter.class.st
@@ -6,8 +6,8 @@ A `SpTreePresenter` can be seen as a simplified `SpTreeTablePresenter`.
 
 "
 Class {
-	#name : #SpTreePresenter,
-	#superclass : #SpAbstractTreePresenter,
+	#name : 'SpTreePresenter',
+	#superclass : 'SpAbstractTreePresenter',
 	#traits : 'SpTDecoratedText',
 	#classTraits : 'SpTDecoratedText classTrait',
 	#instVars : [
@@ -16,22 +16,24 @@ Class {
 		'#iconBlock',
 		'#displayBlock'
 	],
-	#category : #'Spec2-Core-Widgets-Tree'
+	#category : 'Spec2-Core-Widgets-Tree',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tree'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTreePresenter class >> adapterName [
 
 	^ #TreeAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTreePresenter class >> documentFactoryMethodSelector [
 
 	^ #newTree
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTreePresenter class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -47,7 +49,7 @@ SpTreePresenter class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> beNotResizable [
 	"Mark the table as 'not resizable', which means there will be not possibility to resize the 
 	 columns of it."
@@ -55,21 +57,21 @@ SpTreePresenter >> beNotResizable [
 	self isResizable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> beResizable [
 	"Mark the table as 'resizable', which means there will be a slider to resize the columns."
 
 	self isResizable: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> display [
 	"Answer the display block that will transform the model nodes into a displayable string."
 
 	^ displayBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> display: aBlock [
 	"Set the block that will be applied on each of the list items. 
 	 The result of the block will be used to display the item on the screen.
@@ -86,14 +88,14 @@ SpTreePresenter >> display: aBlock [
 	displayBlock := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> displayIcon [
 	"Return the block used to return an icon that will be displayed in the tree"
 
 	^ iconBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> displayIcon: aBlock [
 	"Set a block which takes an item as argument and returns the icon to display in the tree.
 	 `aBlock` receives one argument"
@@ -101,14 +103,14 @@ SpTreePresenter >> displayIcon: aBlock [
 	iconBlock := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> hideColumnHeaders [
 	"Hide the column headers"
 
 	showColumnHeaders := false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTreePresenter >> initialize [
 	super initialize.
 
@@ -128,32 +130,32 @@ SpTreePresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreePresenter >> isResizable [
 	"Answer true if table allows resizing of its columns."
 
 	^ isResizable
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTreePresenter >> isResizable: aBoolean [
 	isResizable := aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreePresenter >> isShowingColumnHeaders [
 	"Answer true if the table is configured to show column headers."
 
 	^ showColumnHeaders
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTreePresenter >> shouldLazilyComputeChildren [
 
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreePresenter >> showColumnHeaders [
 	"Show column headers"
 

--- a/src/Spec2-Core/SpTreeSingleSelectionMode.class.st
+++ b/src/Spec2-Core/SpTreeSingleSelectionMode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpTreeSingleSelectionMode,
-	#superclass : #SpAbstractTreeSelectionMode,
-	#category : #'Spec2-Core-Widgets-Tree'
+	#name : 'SpTreeSingleSelectionMode',
+	#superclass : 'SpAbstractTreeSelectionMode',
+	#category : 'Spec2-Core-Widgets-Tree',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tree'
 }
 
-{ #category : #selection }
+{ #category : 'selection' }
 SpTreeSingleSelectionMode >> itemNotFoundAction [
 	self clearSelection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeSingleSelectionMode >> selectPath: aPath [
 	"Check comment in my superclass to know how to use selectPath:"
 
@@ -22,7 +24,7 @@ SpTreeSingleSelectionMode >> selectPath: aPath [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeSingleSelectionMode >> selectPaths: pathArray [
 
 	self selectPath: (pathArray 
@@ -30,7 +32,7 @@ SpTreeSingleSelectionMode >> selectPaths: pathArray [
 		ifEmpty: [ pathArray ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeSingleSelectionMode >> selectedItem [
 	
 	selection ifEmpty: [ ^ nil ].
@@ -38,20 +40,20 @@ SpTreeSingleSelectionMode >> selectedItem [
 	^ presenter itemAtPath: selection.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeSingleSelectionMode >> selectedPath [
 	
 	^ selection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeSingleSelectionMode >> selectedPaths [
 	
 	selection ifEmpty: [ ^ #() ].
 	^ { selection }
 ]
 
-{ #category : #selecting }
+{ #category : 'selecting' }
 SpTreeSingleSelectionMode >> unselectPath: aPath [
 	"If the path is out of range, keep the selection."
 	selection = aPath ifFalse: [ ^ self ].

--- a/src/Spec2-Core/SpTreeTablePresenter.class.st
+++ b/src/Spec2-Core/SpTreeTablePresenter.class.st
@@ -6,24 +6,26 @@ A table has columns with a type (See column types section).
 
 "
 Class {
-	#name : #SpTreeTablePresenter,
-	#superclass : #SpAbstractTreePresenter,
+	#name : 'SpTreeTablePresenter',
+	#superclass : 'SpAbstractTreePresenter',
 	#instVars : [
 		'#columns => ObservableSlot',
 		'#showColumnHeaders => ObservableSlot',
 		'#isResizable => ObservableSlot',
 		'#lazilyComputeChildren'
 	],
-	#category : #'Spec2-Core-Widgets-Tree'
+	#category : 'Spec2-Core-Widgets-Tree',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Tree'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTreeTablePresenter class >> adapterName [
 
 	^ #TreeTableAdapter
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTreeTablePresenter class >> addDocumentExtraSections: aBuilder [
 
 	aBuilder newLine.
@@ -34,13 +36,13 @@ SpTreeTablePresenter class >> addDocumentExtraSections: aBuilder [
 				aBuilder monospace: eachType name ] ] ]
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTreeTablePresenter class >> documentFactoryMethodSelector [
 
 	^ #newTreeTable
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 SpTreeTablePresenter class >> documentSections [
 
 	^ OrderedDictionary newFromPairs: {
@@ -56,14 +58,20 @@ SpTreeTablePresenter class >> documentSections [
 			  (self methods select: [ :method | method protocolName = #'api - events' ]) }
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> addColumn: aColumn [
 	"Add a column to the table. A column should be an instance of `SpTableColumn`"
 
 	columns := self columns copyWith: aColumn
 ]
 
-{ #category : #api }
+{ #category : 'drawing' }
+SpTreeTablePresenter >> alternateRowsColor [
+	" Will alternate Rows color for a better reading: one row lighter, the next row darker"
+	self withAdapterPerformOrDefer: [ :tableAdapter | tableAdapter alternateRowsColor ].
+]
+
+{ #category : 'api' }
 SpTreeTablePresenter >> beNotResizable [
 	"Mark the table as 'not resizable', which means there will be not possibility to resize the 
 	 columns of it."
@@ -71,21 +79,21 @@ SpTreeTablePresenter >> beNotResizable [
 	self isResizable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> beResizable [
 	"Mark the table as 'resizable', which means there will be a slider to resize the columns."
 
 	self isResizable: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> columns [
 	"Answer the columns composing this table."
 
 	^ columns
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> columns: aCollection [
 	"Set all columns at once. 
 	 `aCollection` is a list of instances of `SpTableColumn`"
@@ -93,14 +101,14 @@ SpTreeTablePresenter >> columns: aCollection [
 	columns := aCollection
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> hideColumnHeaders [
 	"Hide the column headers"
 
 	showColumnHeaders := false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTreeTablePresenter >> initialize [
 	super initialize.
 
@@ -122,38 +130,38 @@ SpTreeTablePresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeTablePresenter >> isResizable [
 	"Answer true if table allows resizing of its columns."
 
 	^ isResizable
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTreeTablePresenter >> isResizable: aBoolean [
 	isResizable := aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTreeTablePresenter >> isShowingColumnHeaders [
 	"Answer true if the table is configured to show column headers."
 
 	^ showColumnHeaders
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTreeTablePresenter >> lazilyComputeChildren [
 	"When we compute lazily the children, we will show in all cases the expand arrow even if there is no children until we open this children."
 
 	lazilyComputeChildren := true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTreeTablePresenter >> lazilyComputeChildren: aBoolean [
 	lazilyComputeChildren := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> selectionMode [
 	"Answer the selection object (an instance of `SpSingleSelectionMode` or `SpMultipleSelectionMode`).
 	 This is not the item selected, but the selection container (it may contain one or many selected 
@@ -163,19 +171,19 @@ SpTreeTablePresenter >> selectionMode [
 	^ selectionMode
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpTreeTablePresenter >> shouldLazilyComputeChildren [
 	^ lazilyComputeChildren
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTreeTablePresenter >> showColumnHeaders [
 	"Show column headers"
 
 	showColumnHeaders := true
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTreeTablePresenter >> whenColumnsChangedDo: aBlock [
 	"Inform when columns have changed. 
 	 `aBlock` has three optional arguments: 
@@ -187,7 +195,7 @@ SpTreeTablePresenter >> whenColumnsChangedDo: aBlock [
 	self property: #columns whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpTreeTablePresenter >> whenIsResizableChangedDo: aBlock [
 	"Inform when resizable property has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpVerticalAlignment.class.st
+++ b/src/Spec2-Core/SpVerticalAlignment.class.st
@@ -4,8 +4,8 @@ You can ask the first and last index of the visible rows.
 I can move the scrolling to make an element visible with the #desiredVisibleRow: method.
 "
 Class {
-	#name : #SpVerticalAlignment,
-	#superclass : #Object,
+	#name : 'SpVerticalAlignment',
+	#superclass : 'Object',
 	#traits : 'TObservable',
 	#classTraits : 'TObservable classTrait',
 	#instVars : [
@@ -13,49 +13,51 @@ Class {
 		'#lastVisibleRowIndex',
 		'#desiredVisibleRow => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Widgets-Table'
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpVerticalAlignment >> desiredVisibleRow [
 	^ desiredVisibleRow
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpVerticalAlignment >> desiredVisibleRow: anInteger [
 	desiredVisibleRow := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpVerticalAlignment >> firstVisibleRowIndex [
 	"valid only after UI is open"
 
 	^ firstVisibleRowIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpVerticalAlignment >> firstVisibleRowIndex: anInteger [
 	firstVisibleRowIndex := anInteger
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpVerticalAlignment >> initialize [
 	self class initializeSlots: self.
 	super initialize.
 	desiredVisibleRow := 1
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpVerticalAlignment >> lastVisibleRowIndex [
 	^ lastVisibleRowIndex
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpVerticalAlignment >> lastVisibleRowIndex: anInteger [
 	lastVisibleRowIndex := anInteger
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpVerticalAlignment >> whenChangedDo: aBlockClosure [
 	self property: #desiredVisibleRow whenChangedDo: aBlockClosure
 ]

--- a/src/Spec2-Core/SpWeakValueHolder.class.st
+++ b/src/Spec2-Core/SpWeakValueHolder.class.st
@@ -3,28 +3,30 @@ I'm a weak value holder.
 I keep a weak reference to the instance in contents.
 "
 Class {
-	#name : #SpWeakValueHolder,
-	#superclass : #Object,
-	#type : #weak,
-	#category : #'Spec2-Core-Support'
+	#name : 'SpWeakValueHolder',
+	#superclass : 'Object',
+	#type : 'weak',
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWeakValueHolder class >> contents: anObject [
 	^ self new contents: anObject
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWeakValueHolder class >> new [
 	^ (self basicNew: 1) initialize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWeakValueHolder >> contents [
 	^ self basicAt: 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWeakValueHolder >> contents: anObject [
 	self basicAt: 1 put: anObject
 ]

--- a/src/Spec2-Core/SpWidgetBuilt.class.st
+++ b/src/Spec2-Core/SpWidgetBuilt.class.st
@@ -2,16 +2,18 @@
 I am an announcement raised when a widget has been built with all its children, but not yet shown.
 "
 Class {
-	#name : #SpWidgetBuilt,
-	#superclass : #Announcement,
+	#name : 'SpWidgetBuilt',
+	#superclass : 'Announcement',
 	#instVars : [
 		'model',
 		'widget'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWidgetBuilt class >> model: model widget: widget [
 
 	^ self new
@@ -20,22 +22,22 @@ SpWidgetBuilt class >> model: model widget: widget [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetBuilt >> model [
 	^ model
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetBuilt >> model: anObject [
 	model := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetBuilt >> widget [
 	^ widget
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetBuilt >> widget: anObject [
 	widget := anObject
 ]

--- a/src/Spec2-Core/SpWidgetDisplayed.class.st
+++ b/src/Spec2-Core/SpWidgetDisplayed.class.st
@@ -2,31 +2,33 @@
 I am an announcement raised when a widget has been already shown in the screen.
 "
 Class {
-	#name : #SpWidgetDisplayed,
-	#superclass : #Announcement,
+	#name : 'SpWidgetDisplayed',
+	#superclass : 'Announcement',
 	#instVars : [
 		'presenter',
 		'widget'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetDisplayed >> presenter [
 	^ presenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetDisplayed >> presenter: anObject [
 	presenter := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetDisplayed >> widget [
 	^ widget
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetDisplayed >> widget: anObject [
 	widget := anObject
 ]

--- a/src/Spec2-Core/SpWidgetWillBeBuilt.class.st
+++ b/src/Spec2-Core/SpWidgetWillBeBuilt.class.st
@@ -4,15 +4,17 @@ I am an announcement  raised when a widget will be built.
 I may be used in situations when you need to change the content of the context menu before it will be displayed and so on.
 "
 Class {
-	#name : #SpWidgetWillBeBuilt,
-	#superclass : #Announcement,
+	#name : 'SpWidgetWillBeBuilt',
+	#superclass : 'Announcement',
 	#instVars : [
 		'model'
 	],
-	#category : #'Spec2-Core-Support'
+	#category : 'Spec2-Core-Support',
+	#package : 'Spec2-Core',
+	#tag : 'Support'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWidgetWillBeBuilt class >> model: model [
 
 	^ self new
@@ -20,12 +22,12 @@ SpWidgetWillBeBuilt class >> model: model [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetWillBeBuilt >> model [
 	^ model
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWidgetWillBeBuilt >> model: anObject [
 	model := anObject
 ]

--- a/src/Spec2-Core/SpWindowAnnouncement.class.st
+++ b/src/Spec2-Core/SpWindowAnnouncement.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #SpWindowAnnouncement,
-	#superclass : #Announcement,
+	#name : 'SpWindowAnnouncement',
+	#superclass : 'Announcement',
 	#instVars : [
 		'window'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowAnnouncement >> window [
 	^ window
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowAnnouncement >> window: anObject [
 	window := anObject
 ]

--- a/src/Spec2-Core/SpWindowBuilt.class.st
+++ b/src/Spec2-Core/SpWindowBuilt.class.st
@@ -2,15 +2,17 @@
 I am an announcement raised when a window has been built.
 "
 Class {
-	#name : #SpWindowBuilt,
-	#superclass : #Announcement,
+	#name : 'SpWindowBuilt',
+	#superclass : 'Announcement',
 	#instVars : [
 		'model'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWindowBuilt class >> model: aWindowPresenter [
 
 	^ self new 
@@ -18,13 +20,13 @@ SpWindowBuilt class >> model: aWindowPresenter [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowBuilt >> model [ 
 
 	^ model
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowBuilt >> model: aModel [
 
 	model := aModel

--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -20,8 +20,8 @@ SpTextPresenter new
 
 "
 Class {
-	#name : #SpWindowPresenter,
-	#superclass : #SpAbstractWidgetPresenter,
+	#name : 'SpWindowPresenter',
+	#superclass : 'SpAbstractWidgetPresenter',
 	#instVars : [
 		'#presenter => ObservableSlot',
 		'#initialPosition => ObservableSlot',
@@ -35,52 +35,54 @@ Class {
 		'#decorations => ObservableSlot',
 		'#resizable => ObservableSlot'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpWindowPresenter class >> adapterName [
 
 	^ #WindowAdapter
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWindowPresenter class >> application: anApplication [
 	^ self new
 		application: anApplication;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowPresenter class >> defaultTitle [
 
 	^ 'Untitled window'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter class >> isWindow [
 
 	^ true
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpWindowPresenter class >> presenter: aPresenter [
 	^ (self application: aPresenter application)
 		presenter: aPresenter;
 		yourself
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpWindowPresenter >> aboutText [
 	^ aboutText ifNil: [ aboutText := 'The about text for this window has not been set.' ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpWindowPresenter >> aboutText: aString [
 	aboutText := aString
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpWindowPresenter >> aboutTitle [
 	"Answer the title of my About window"
 
@@ -89,7 +91,7 @@ SpWindowPresenter >> aboutTitle [
 	^ self presenter toolName
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpWindowPresenter >> addPresenterIn: widget withSpecLayout: aSpec [
 	
 	self presenter ifNil: [ ^ self ].
@@ -97,13 +99,13 @@ SpWindowPresenter >> addPresenterIn: widget withSpecLayout: aSpec [
 		anAdapter addPresenterIn: widget withSpecLayout: aSpec ]
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpWindowPresenter >> askOkToClose: aBoolean [
 
 	askOkToClose := aBoolean
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpWindowPresenter >> basicBuildWithSpecLayout: presenterSpecLayout [
 
 	"Build the widget using the layout provided as argument"
@@ -116,7 +118,7 @@ SpWindowPresenter >> basicBuildWithSpecLayout: presenterSpecLayout [
 		  ifFalse: [ self adapter widget ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> beNotResizable [
 	"Make the window NOT resizable (borders will be undraggable). 
 	 Window can still be resized progamatically."
@@ -124,21 +126,21 @@ SpWindowPresenter >> beNotResizable [
 	self resizable: false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> beResizable [
 	"Make the window resizable (borders will be draggable)"
 
 	self resizable: true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> beep [ 
 	"Emits a beep if the backend allows it."
 	
 	self adapter beep
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpWindowPresenter >> buildWindowWithLayout: windowSpecLayout presenterLayout: presenterSpecLayout [
 
 	"set adapter of the window"
@@ -156,7 +158,7 @@ SpWindowPresenter >> buildWindowWithLayout: windowSpecLayout presenterLayout: pr
 	^ self window
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpWindowPresenter >> buildWithSpecLayout: aSpecLayout [
 	
 	^ SpBindings 
@@ -164,20 +166,20 @@ SpWindowPresenter >> buildWithSpecLayout: aSpecLayout [
 		during: [ self basicBuildWithSpecLayout: aSpecLayout ]
 ]
 
-{ #category : #'dialog compatibility' }
+{ #category : 'dialog compatibility' }
 SpWindowPresenter >> cancelled [
 
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> centered [
 	"Prepare the window to be centered"
 	
 	centered := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> centeredRelativeTo: aWindowPresenter [
 	"Prepare the window to be centered to another window"
 
@@ -185,7 +187,7 @@ SpWindowPresenter >> centeredRelativeTo: aWindowPresenter [
 		anAdapter centeredRelativeTo: aWindowPresenter ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> centeredRelativeToTopWindow [
 	"Prepare the window to be centered to top window (the window that is currently active)"
 
@@ -194,7 +196,7 @@ SpWindowPresenter >> centeredRelativeToTopWindow [
 		ifNil: [ self centered ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> close [
 	"Close current window."
 
@@ -204,13 +206,13 @@ SpWindowPresenter >> close [
 		anAdapter close ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> defaultInitialExtent [
 	
 	^ 400@300
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> delete [
 	"DO NOT USE. This will destroy the window and maybe you do not want that :/
 	 I'm keeping this here because of testing."
@@ -218,21 +220,21 @@ SpWindowPresenter >> delete [
 	self withAdapterDo: [ :anAdapter | anAdapter delete ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> hasDecorations [
 	"Answer if window has decorations (header bar and buttons)"
 
 	^ decorations
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> hasMenu [ 
 	"Answer if window has a menu defined"
 	
 	^ self menu notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> hasPresenter: aPresenter [
 	"Answer if window includes `aPresenter`"
 
@@ -240,21 +242,21 @@ SpWindowPresenter >> hasPresenter: aPresenter [
 		and: [ self adapter hasWidget: aPresenter adapter ]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> hasStatusBar [
 	"Answer if window has a status bar defined"
 	
 	^ self statusBar notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> hasToolbar [
 	"Answer if window has a toolbar defined"
 
 	^ self toolbar notNil and: [ self toolbar notEmpty ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> initialExtent [
 	"Answer initial extent of the window. By default, it answer what is defined 
 	 in `SpWindowPresenter>>#defaultInitialExtent`"
@@ -262,7 +264,7 @@ SpWindowPresenter >> initialExtent [
 	^ initialExtent ifNil: [ self defaultInitialExtent ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> initialExtent: anExtent [
 	"Set initial extent of the window. 
 	 `anExtent` is an instance of `Point`, indicating width@height"
@@ -270,7 +272,7 @@ SpWindowPresenter >> initialExtent: anExtent [
 	initialExtent := anExtent
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> initialPosition [
 	"Answer initial position of the window (if previously set).
 	 If initial position is not set, the backend will place the window within its own logic."
@@ -278,7 +280,7 @@ SpWindowPresenter >> initialPosition [
 	^ initialPosition
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> initialPosition: aPoint [
 	"Set initial position of the window. 
 	 `aPoint` is an instance of `Point`, indicating x@y coordinates"
@@ -286,7 +288,7 @@ SpWindowPresenter >> initialPosition: aPoint [
 	initialPosition := aPoint
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpWindowPresenter >> initialize [
 
 	super initialize.
@@ -309,34 +311,34 @@ SpWindowPresenter >> initialize [
 			self withAdapterDo: [ :anAdapter | anAdapter centered ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpWindowPresenter >> initializeWindow [
 		
 	self presenter initializeWindow: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isCentered [
 	"Answer if window is centered to screen."
 
 	^ centered
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isClosed [
 	"Answer if window has is closed"
 
 	^ isClosed
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isDialog [
 	"Answer if window instance is a dialog"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isDisplayed [
 	"Answer if window is displayed (visible)"
 
@@ -345,7 +347,7 @@ SpWindowPresenter >> isDisplayed [
 		ifNil: [ false ] 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isMaximized [
 	"Answer if window is maximized"
 
@@ -353,7 +355,7 @@ SpWindowPresenter >> isMaximized [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isMinimized [
 	"Answer if window is minimized"
 
@@ -361,21 +363,21 @@ SpWindowPresenter >> isMinimized [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isOpen [
 	"Answer if window is open."
 	
 	^ self isClosed not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isResizable [
 	"Answer if window is resizeable"
 
 	^ resizable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isResizeable [
 	"Answer if window is resizeable"
 	
@@ -386,7 +388,7 @@ SpWindowPresenter >> isResizeable [
 	^ self isResizable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isTopWindow [
 	"Answer true if this si the active window (the one that has the focus)"
 	
@@ -396,21 +398,21 @@ SpWindowPresenter >> isTopWindow [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowPresenter >> isWindowPresenter [
 	"Answer if current presenter instance is a window presenter"
 	
 	^ true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> maximize [
 	"Maximise the window"
 
 	self withAdapterDo: [ :anAdapter | anAdapter maximize ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> menu [
 	"Answer the menu of the window (if defined). 
 	 See also `SpWindowPresenter>>#menu:`"
@@ -418,7 +420,7 @@ SpWindowPresenter >> menu [
 	^ menu
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> menu: aMenuBarPresenter [
 	"Set a menu bar associated with this window.
 	 Menu will appear on top of the window allowing user to interact with it."
@@ -427,14 +429,14 @@ SpWindowPresenter >> menu: aMenuBarPresenter [
 	^ menu := aMenuBarPresenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> minimize [
 	"Minimize the window."
 	
 	self withAdapterDo: [ :anAdapter | anAdapter minimize ]
 ]
 
-{ #category : #notifying }
+{ #category : 'notifying' }
 SpWindowPresenter >> notify: aSpecNotification [
 	"Receives a notification and delivers it as required"
 
@@ -444,7 +446,7 @@ SpWindowPresenter >> notify: aSpecNotification [
 			on: anAdapter ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> okToChange [
 
 	self flag: #TODO. "Maybe wrong?"
@@ -454,19 +456,19 @@ SpWindowPresenter >> okToChange [
 	^ self canDiscardEdits
 ]
 
-{ #category : #'api - showing' }
+{ #category : 'api - showing' }
 SpWindowPresenter >> open [
 
 	self openWith: self presenter layout
 ]
 
-{ #category : #'api - showing' }
+{ #category : 'api - showing' }
 SpWindowPresenter >> openWith: aSpecLayout [
 
 	self openWithLayout: aSpecLayout
 ]
 
-{ #category : #'private - showing' }
+{ #category : 'private - showing' }
 SpWindowPresenter >> openWithLayout: aSpecLayout [
 
 	self buildWithSpecLayout: aSpecLayout.
@@ -477,14 +479,14 @@ SpWindowPresenter >> openWithLayout: aSpecLayout [
 			self updateTitle ] ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> presenter [
 	"Answer the presenter to show as content of the window."
 
 	^ presenter
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> presenter: aPresenter [
 	"Set the presenter to show as content of the window."
 
@@ -493,14 +495,14 @@ SpWindowPresenter >> presenter: aPresenter [
 	self initializeWindow
 ]
 
-{ #category : #'private - building' }
+{ #category : 'private - building' }
 SpWindowPresenter >> rebuildWithSpecLayout: aSpecLayout [
 
 	self withAdapterDo: [ :anAdapter | 
 		anAdapter rebuildWithSpecLayout: aSpecLayout ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> requestWindowClose [
 
 	^ self presenter
@@ -508,27 +510,27 @@ SpWindowPresenter >> requestWindowClose [
 		ifNil: [ true ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> resizable: aBoolean [
 
 	resizable := aBoolean
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> resize: anExtent [
 
 	self withAdapterPerformOrDefer: [ :anAdapter | 
 		anAdapter resize: anExtent ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> statusBar [
 	"Answer the status bar associated with this window (if defined)"
 
 	^ statusbar
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> statusBar: aStatusBarPresenter [
 	"Set a status bar for the window. 
 	 Status bar will be shown at the bottom of the window."
@@ -537,7 +539,7 @@ SpWindowPresenter >> statusBar: aStatusBarPresenter [
 	^ statusbar := aStatusBarPresenter
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpWindowPresenter >> taskbarIcon [
 
 	^ self windowIcon
@@ -547,24 +549,24 @@ SpWindowPresenter >> taskbarIcon [
 				ifNil: [ self taskbarIconName ]) ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> title [
 	^ titleHolder
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> title: aString [
 	titleHolder := aString
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> toolbar [
 	"Answer the toolbar associated with this window (if defined)"
 
 	^ toolbar
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> toolbar: aToolbarPresenter [
 	"Set a toolbar associated with this window.
 	 Menu will appear on top of the window allowing user to interact with it."
@@ -573,7 +575,7 @@ SpWindowPresenter >> toolbar: aToolbarPresenter [
 	^ toolbar := aToolbarPresenter
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpWindowPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 
 	"I am not focusable (not with tab)"
@@ -582,31 +584,31 @@ SpWindowPresenter >> traverseInFocusOrderDo: aBlock excluding: excludes [
 		excluding: excludes
 ]
 
-{ #category : #'private - traversing' }
+{ #category : 'private - traversing' }
 SpWindowPresenter >> traversePresentersDo: aBlock excluding: excludes [
 	
 	super traversePresentersDo: aBlock excluding: excludes.
 	presenter traversePresentersDo: aBlock excluding: excludes
 ]
 
-{ #category : #'dialog compatibility' }
+{ #category : 'dialog compatibility' }
 SpWindowPresenter >> triggerCancelAction [
 	"Do nothing (ensure polymorphism with DialogWindow)"
 ]
 
-{ #category : #'dialog compatibility' }
+{ #category : 'dialog compatibility' }
 SpWindowPresenter >> triggerOkAction [
 	"Do nothing (ensure polymorphism with DialogWindow)"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> updateTitle [
 	"Update the window title"
 
 	self changed: #title: with: { self title }
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenClosedDo: aBlock [
 	"Inform when window is closed.
 	 `aBlock` receives zero arguments."
@@ -616,7 +618,7 @@ SpWindowPresenter >> whenClosedDo: aBlock [
 		whenChangedDo: [ :value | value ifTrue: aBlock ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenDecorationsChangedDo: aBlock [
 	"Inform when decorations property has changed. 
 	 `aBlock` has three optional arguments: 
@@ -627,7 +629,7 @@ SpWindowPresenter >> whenDecorationsChangedDo: aBlock [
 	self property: #decorations whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenFocusLostDo: aBlock [
 	"Inform when window lost focus. 
 	 This is a convenience method that exposes a functionality of the event handler 
@@ -637,7 +639,7 @@ SpWindowPresenter >> whenFocusLostDo: aBlock [
 	self eventHandler whenFocusLostDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenFocusReceivedDo: aBlock [
 	"Inform when window receives focus. 
 	 This is a convenience method that exposes a functionality of the event handler 
@@ -647,7 +649,7 @@ SpWindowPresenter >> whenFocusReceivedDo: aBlock [
 	self eventHandler whenFocusReceivedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenOpenedDo: aBlock [
 	"Inform when window is opened. 
 	 `aBlock` receives zero arguments."
@@ -657,13 +659,13 @@ SpWindowPresenter >> whenOpenedDo: aBlock [
 		whenChangedDo: [ :value | value ifFalse: aBlock ]
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenResizableChangedDo: aBlock [
 
 	self property: #resizable whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenResizingDo: aBlock [
 	"Inform when window is resizing. 
 	 `aBlock` receives one optional argument (an instance of the announcement `SpWindowResizing`)"
@@ -671,7 +673,7 @@ SpWindowPresenter >> whenResizingDo: aBlock [
 	self announcer when: SpWindowResizing do: aBlock for: aBlock receiver
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenToolbarChangedDo: aBlock [
 	"Inform when the toolbar has been changed.
 	
@@ -682,7 +684,7 @@ SpWindowPresenter >> whenToolbarChangedDo: aBlock [
 	self property: #toolbar whenChangedDo: aBlock
 ]
 
-{ #category : #'api - events' }
+{ #category : 'api - events' }
 SpWindowPresenter >> whenWillCloseDo: aBlock [
 	"Inform when window will close, allowing process before the close happen. 
 	 Note that user cannot cancel the close operation using this event. 
@@ -693,59 +695,59 @@ SpWindowPresenter >> whenWillCloseDo: aBlock [
 		do: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> window [
 	^ window
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> window: aWindow [
 	window := aWindow
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> windowClosed [
 	
 	isClosed := true.
 	self application windowClosed: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> windowIcon [
 	^ windowIcon
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpWindowPresenter >> windowIcon: aForm [
 	windowIcon := aForm
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 SpWindowPresenter >> windowIsClosing [
 
 	self presenter windowIsClosing
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 SpWindowPresenter >> windowIsOpened [
 
 	isClosed := false
 ]
 
-{ #category : #TOREMOVE }
+{ #category : 'TOREMOVE' }
 SpWindowPresenter >> windowIsOpening [
 
 	self windowIsOpened
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> withDecorations [
 	"Add decorations on window (header bar and buttons)"
 	
 	decorations := true
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpWindowPresenter >> withoutDecorations [
 	"Remove decorations on window (header bar and buttons)"
 	

--- a/src/Spec2-Core/SpWindowResizing.class.st
+++ b/src/Spec2-Core/SpWindowResizing.class.st
@@ -6,36 +6,38 @@ trigger this announcement.
 I provide the old and new window size.
 "
 Class {
-	#name : #SpWindowResizing,
-	#superclass : #SpWindowAnnouncement,
+	#name : 'SpWindowResizing',
+	#superclass : 'SpWindowAnnouncement',
 	#instVars : [
 		'newSize',
 		'oldSize'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowResizing >> isResized [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowResizing >> newSize [
 	^ newSize
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowResizing >> newSize: anObject [
 	newSize := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowResizing >> oldSize [
 	^ oldSize
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowResizing >> oldSize: anObject [
 	oldSize := anObject
 ]

--- a/src/Spec2-Core/SpWindowWillClose.class.st
+++ b/src/Spec2-Core/SpWindowWillClose.class.st
@@ -2,33 +2,35 @@
 I am an announcement emitted when a window will be closed.
 "
 Class {
-	#name : #SpWindowWillClose,
-	#superclass : #SpWindowAnnouncement,
+	#name : 'SpWindowWillClose',
+	#superclass : 'SpWindowAnnouncement',
 	#instVars : [
 		'canClose'
 	],
-	#category : #'Spec2-Core-Windows'
+	#category : 'Spec2-Core-Windows',
+	#package : 'Spec2-Core',
+	#tag : 'Windows'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowWillClose >> allowClose [
 
 	canClose := true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpWindowWillClose >> canClose [
 
 	^ canClose
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowWillClose >> denyClose [
 
 	canClose := false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpWindowWillClose >> initialize [
 
 	super initialize. 

--- a/src/Spec2-Core/String.extension.st
+++ b/src/Spec2-Core/String.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 String >> asPresenter [ 
 
 	^ SpLabelPresenter new 
@@ -8,7 +8,7 @@ String >> asPresenter [
 		yourself
 ]
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 String >> asPresenterOn: aPresenter [
 
 	^ SpLabelPresenter new 
@@ -16,7 +16,7 @@ String >> asPresenterOn: aPresenter [
 		yourself
 ]
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 String >> localizedForPresenter: aPresenter [
 
 	"This message serves for the string modification for the purpose of a given Spec presenter. It may, for example, convert it to a presenter's locale. The implementation here (in the String) serves as fallback for regular strings."

--- a/src/Spec2-Core/Symbol.extension.st
+++ b/src/Spec2-Core/Symbol.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Symbol }
+Extension { #name : 'Symbol' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 Symbol >> asPresenterOn: aPresenter [
 
 	self flag: #TODO. "The additionalSubpresentersMap is a functionality that needs to 

--- a/src/Spec2-Core/UnixPlatform.extension.st
+++ b/src/Spec2-Core/UnixPlatform.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #UnixPlatform }
+Extension { #name : 'UnixPlatform' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 UnixPlatform >> configureApplication: anApplication configuration: aConfiguration [
 	
 	aConfiguration configureUnix: anApplication

--- a/src/Spec2-Core/WinPlatform.extension.st
+++ b/src/Spec2-Core/WinPlatform.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WinPlatform }
+Extension { #name : 'WinPlatform' }
 
-{ #category : #'*Spec2-Core' }
+{ #category : '*Spec2-Core' }
 WinPlatform >> configureApplication: anApplication configuration: aConfiguration [
 	
 	aConfiguration configureWindows: anApplication

--- a/src/Spec2-Core/package.st
+++ b/src/Spec2-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Spec2-Core' }
+Package { #name : 'Spec2-Core' }

--- a/src/Spec2-Tests/ManifestSpec2Tests.class.st
+++ b/src/Spec2-Tests/ManifestSpec2Tests.class.st
@@ -6,12 +6,14 @@ Spec is a framework in Pharo for describing user interfaces. It allows for the c
 I contain the tests of Spec2-Core. Those are the tests of Presenters that are independant of the backend used by the user.
 "
 Class {
-	#name : #ManifestSpec2Tests,
-	#superclass : #PackageManifest,
-	#category : #'Spec2-Tests-Manifest'
+	#name : 'ManifestSpec2Tests',
+	#superclass : 'PackageManifest',
+	#category : 'Spec2-Tests-Manifest',
+	#package : 'Spec2-Tests',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSpec2Tests class >> ruleRBSentNotImplementedRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#SpUIThemeDecoratorTest)) #'2018-10-10T14:57:43.139752+02:00') #(#(#RGMethodDefinition #(#RadioButtonGroupPresenterTest #testRebuildWidget #false)) #'2018-10-10T14:59:58.802602+02:00') )
 ]

--- a/src/Spec2-Tests/SpAbstractButtonPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractButtonPresenterTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpAbstractButtonPresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpAbstractButtonPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractButtonPresenterTest class >> isAbstract [
 
 	^ super isAbstract or: [ self = SpAbstractButtonPresenterTest ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractButtonPresenterTest >> testWhenHelpChanged [
 	presenter help: 'label1'.
 	presenter
@@ -23,7 +25,7 @@ SpAbstractButtonPresenterTest >> testWhenHelpChanged [
 	self assert: presenter help equals: 'label2'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractButtonPresenterTest >> testWhenIconChangedDo [
 
 	presenter iconName: #glamorousCancel.
@@ -41,7 +43,7 @@ SpAbstractButtonPresenterTest >> testWhenIconChangedDo [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractButtonPresenterTest >> testWhenLabelChangedDo [
 
 	presenter label: 'label1'.

--- a/src/Spec2-Tests/SpAbstractListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractListPresenterTest.class.st
@@ -2,25 +2,27 @@
 testing ListComposablePresenter
 "
 Class {
-	#name : #SpAbstractListPresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpAbstractListPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractListPresenterTest class >> isAbstract [
 
 	^ self == SpAbstractListPresenterTest
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpAbstractListPresenterTest >> setUp [
 
 	super setUp.
 	presenter items: #(10 20 30).
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpAbstractListPresenterTest >> testActivationOnDoubleClickShouldActivateOnDoubleClick [
 
 	| activatedItem |
@@ -34,7 +36,7 @@ SpAbstractListPresenterTest >> testActivationOnDoubleClickShouldActivateOnDouble
 	self assert: activatedItem equals: 10.
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpAbstractListPresenterTest >> testActivationOnDoubleClickShouldNotActivateOnClick [
 
 	| activatedItem |
@@ -48,7 +50,7 @@ SpAbstractListPresenterTest >> testActivationOnDoubleClickShouldNotActivateOnCli
 	self assert: activatedItem equals: nil.
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpAbstractListPresenterTest >> testActivationOnSingleClickShouldActivateOnClick [
 
 	| activatedItem |
@@ -62,7 +64,7 @@ SpAbstractListPresenterTest >> testActivationOnSingleClickShouldActivateOnClick 
 	self assert: activatedItem equals: 10.
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpAbstractListPresenterTest >> testActivationOnSingleClickShouldNotActivateOnClickOutside [
 
 	| activatedItem |
@@ -76,7 +78,7 @@ SpAbstractListPresenterTest >> testActivationOnSingleClickShouldNotActivateOnCli
 	self assert: activatedItem equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testActivationWithTransformation [
 	| activatedItem |
 
@@ -92,7 +94,7 @@ SpAbstractListPresenterTest >> testActivationWithTransformation [
 	self assert: activatedItem equals: 100
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpAbstractListPresenterTest >> testActivationWithoutActivationBlockDoesNothing [
 
 	| activatedItem |
@@ -104,7 +106,7 @@ SpAbstractListPresenterTest >> testActivationWithoutActivationBlockDoesNothing [
 	self assert: activatedItem equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testContextMenu [
 	| menu changed |
 	
@@ -118,7 +120,7 @@ SpAbstractListPresenterTest >> testContextMenu [
 	self assert: changed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testDisableActivationDuring [ 
 	| activated |
 
@@ -131,7 +133,7 @@ SpAbstractListPresenterTest >> testDisableActivationDuring [
 	self assert: presenter selectedItem equals: 20 "but the selection changed!"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testReplaceItemList [
 	| changed |
 
@@ -145,7 +147,7 @@ SpAbstractListPresenterTest >> testReplaceItemList [
 	self assert: changed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testSelectAll [
 
 	presenter beSingleSelection.
@@ -160,7 +162,7 @@ SpAbstractListPresenterTest >> testSelectAll [
 		equals: #(10 20 30)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testSelectedItemsSortedByIndex [
 
 	presenter beMultipleSelection.
@@ -175,7 +177,7 @@ SpAbstractListPresenterTest >> testSelectedItemsSortedByIndex [
 		equals: #(10 30)
 ]
 
-{ #category : #'tests - smoke' }
+{ #category : 'tests - smoke' }
 SpAbstractListPresenterTest >> testSetSortingBlockBeforeItems [
 	| count |
 	count := 0.
@@ -186,13 +188,13 @@ SpAbstractListPresenterTest >> testSetSortingBlockBeforeItems [
 	self assert: (presenter model at: 1) equals: 0
 ]
 
-{ #category : #'tests - smoke' }
+{ #category : 'tests - smoke' }
 SpAbstractListPresenterTest >> testSmokeOpenEmptyPresenter [
 
 	window := presenter open
 ]
 
-{ #category : #'tests - smoke' }
+{ #category : 'tests - smoke' }
 SpAbstractListPresenterTest >> testSmokeOpenPresenterWithItems [
 
 	window := presenter
@@ -200,7 +202,7 @@ SpAbstractListPresenterTest >> testSmokeOpenPresenterWithItems [
 		          open
 ]
 
-{ #category : #'tests - smoke' }
+{ #category : 'tests - smoke' }
 SpAbstractListPresenterTest >> testSortingBlock [
 	| count |
 	count := 0.
@@ -211,7 +213,7 @@ SpAbstractListPresenterTest >> testSortingBlock [
 	self assert: (presenter model at: 1) equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testUnselectAll [
 
 	presenter beMultipleSelection.
@@ -223,7 +225,7 @@ SpAbstractListPresenterTest >> testUnselectAll [
 	self assertEmpty: presenter selection selectedItems
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractListPresenterTest >> testUpdateItemsKeepingSelection [ 
 
 	presenter items: #($a $b $c).

--- a/src/Spec2-Tests/SpAbstractSelectionModeTest.class.st
+++ b/src/Spec2-Tests/SpAbstractSelectionModeTest.class.st
@@ -1,37 +1,39 @@
 Class {
-	#name : #SpAbstractSelectionModeTest,
-	#superclass : #TestCase,
+	#name : 'SpAbstractSelectionModeTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'presenter'
 	],
-	#category : #'Spec2-Tests-Layout'
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractSelectionModeTest class >> isAbstract [
 	^ self = SpAbstractSelectionModeTest
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractSelectionModeTest class >> shouldInheritSelectors [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpAbstractSelectionModeTest >> setUp [
 	super setUp.
 	presenter := SpListPresenter new.
 	presenter items: (1 to: 10)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpAbstractSelectionModeTest >> tearDown [ 
 
 	presenter delete.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractSelectionModeTest >> testSubscriptionsAreTransfered [
 	self subclassResponsibility
 ]

--- a/src/Spec2-Tests/SpAbstractTextPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractTextPresenterTest.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #SpAbstractTextPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpAbstractTextPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTextPresenterTest class >> isAbstract [
 	^ self = SpAbstractTextPresenterTest
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpAbstractTextPresenterTest >> classToTest [
 	^ self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpAbstractTextPresenterTest >> initializationText [
 	presenter text: 'Text for tests.'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testClearContent [
 	self initializationText.
 	self denyEmpty: presenter text.
@@ -27,7 +29,7 @@ SpAbstractTextPresenterTest >> testClearContent [
 	self assertEmpty: presenter text
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testClearSelection [
 	self initializationText.
 	self openInstance.
@@ -37,7 +39,7 @@ SpAbstractTextPresenterTest >> testClearSelection [
 	self assert: presenter selectionInterval isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testContextMenu [
 	| menu changed |
 	
@@ -51,7 +53,7 @@ SpAbstractTextPresenterTest >> testContextMenu [
 	self assert: changed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testCursorPositionIndex [
 
 	presenter text: (String loremIpsum: 80).
@@ -67,7 +69,7 @@ SpAbstractTextPresenterTest >> testCursorPositionIndex [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testPlaceholderIsSet [
 
 	presenter placeholder: 'enter something...'.
@@ -75,7 +77,7 @@ SpAbstractTextPresenterTest >> testPlaceholderIsSet [
 	self assert: presenter placeholder equals: 'enter something...'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testSelectAll [
 	self initializationText.
 	self openInstance.
@@ -83,7 +85,7 @@ SpAbstractTextPresenterTest >> testSelectAll [
 	self assert: presenter selectionInterval equals: (1 to: 15)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testWhenResetDo [
 	| reseted |
 
@@ -102,7 +104,7 @@ SpAbstractTextPresenterTest >> testWhenResetDo [
 	self assert: reseted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testWhenSubmitDo [
 	| submitted |
 
@@ -121,7 +123,7 @@ SpAbstractTextPresenterTest >> testWhenSubmitDo [
 	self assert: submitted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTextPresenterTest >> testWhenSubmitDoReceivesAString [
 	| submitted |
 
@@ -142,7 +144,7 @@ SpAbstractTextPresenterTest >> testWhenSubmitDoReceivesAString [
 	self assert: submitted equals: 'abc'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpAbstractTextPresenterTest >> textInputAdapter [
 	
 	^ presenter adapter

--- a/src/Spec2-Tests/SpAbstractTreePresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractTreePresenterTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpAbstractTreePresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpAbstractTreePresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpAbstractTreePresenterTest class >> isAbstract [
 
 	^ super isAbstract or: [ self = SpAbstractTreePresenterTest ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpAbstractTreePresenterTest >> setUp [
 
 	super setUp.
@@ -23,7 +25,7 @@ SpAbstractTreePresenterTest >> setUp [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testActivationOnDoubleClickShouldActivateOnDoubleClick [
 	| activatedItem |
 	presenter
@@ -35,7 +37,7 @@ SpAbstractTreePresenterTest >> testActivationOnDoubleClickShouldActivateOnDouble
 	self assert: activatedItem equals: 110
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testActivationOnDoubleClickShouldNotActivateOnClick [
 	| activatedItem |
 	presenter
@@ -47,7 +49,7 @@ SpAbstractTreePresenterTest >> testActivationOnDoubleClickShouldNotActivateOnCli
 	self assert: activatedItem isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testActivationOnSingleClickShouldActivateOnClick [
 	| activatedItem |
 	presenter
@@ -59,7 +61,7 @@ SpAbstractTreePresenterTest >> testActivationOnSingleClickShouldActivateOnClick 
 	self assert: activatedItem equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testActivationOnSingleClickShouldNotActivateOnClickOutside [
 	| activatedItem |
 	presenter
@@ -71,7 +73,7 @@ SpAbstractTreePresenterTest >> testActivationOnSingleClickShouldNotActivateOnCli
 	self assert: activatedItem isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testContextMenu [
 	| menu changed |
 	self assert: presenter contextMenu isNil.
@@ -84,7 +86,7 @@ SpAbstractTreePresenterTest >> testContextMenu [
 	self assert: changed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testDisableActivationDuring [ 
 	| activated |
 
@@ -97,7 +99,7 @@ SpAbstractTreePresenterTest >> testDisableActivationDuring [
 	self assert: presenter selectedItem equals: 2 "but the selection changed!"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testExpandAtPathExpandsTheNode [
 
 	self openInstance.
@@ -114,7 +116,7 @@ SpAbstractTreePresenterTest >> testExpandAtPathExpandsTheNode [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testPathIndexOf [
 
 	presenter 
@@ -128,7 +130,7 @@ SpAbstractTreePresenterTest >> testPathIndexOf [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testPathItemOf [
 
 	presenter 
@@ -142,7 +144,7 @@ SpAbstractTreePresenterTest >> testPathItemOf [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testUnselectAll [
 
 	presenter beMultipleSelection.
@@ -156,7 +158,7 @@ SpAbstractTreePresenterTest >> testUnselectAll [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testUpdateRootsKeepingSelection [ 
 
 	presenter roots: #($a $b $c).
@@ -165,7 +167,7 @@ SpAbstractTreePresenterTest >> testUpdateRootsKeepingSelection [
 	self assert: presenter selectedItem equals: $c
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testWhenSelectedItemChangedDo [
 	| selectedItem |
 

--- a/src/Spec2-Tests/SpAbstractWidgetLayoutTest.class.st
+++ b/src/Spec2-Tests/SpAbstractWidgetLayoutTest.class.st
@@ -2,33 +2,35 @@
 A SpecAbstractWidgetLayoutTest is a test class for testing the behavior of SpecAbstractWidgetLayout
 "
 Class {
-	#name : #SpAbstractWidgetLayoutTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpAbstractWidgetLayoutTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractWidgetLayoutTest >> testAdapterForBindings [
 	| layout |
 	layout := SpAbstractWidgetLayout for: #ListAdapter.
 	self assert: (layout adapterFor: SpListPresenter new bindings: SpStubAdapterBindings new) class equals: SpStubListAdapter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractWidgetLayoutTest >> testAdapterForBindingsRaiseErrorIfNoBinding [
 	| layout |
 	layout := SpAbstractWidgetLayout for: #NonExistingAdapter.
 	self should: [ layout adapterFor: SpListPresenter new bindings: SpStubAdapterBindings new ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractWidgetLayoutTest >> testBuildAdapterForBindings [
 	| layout |
 	layout := SpAbstractWidgetLayout for: #ListAdapter.
 	self assert: (layout buildAdapterFor: SpListPresenter new bindings: SpStubAdapterBindings new) widget class equals: SpStubListView
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractWidgetLayoutTest >> testDynamicBuild [
 
 	"Cyril: This is currently a duplicated of a test in SpecInterpreter, but this test is useful for more that the SpecInterpreter and since we plan to remove the interpreter I want to ensure we do not lose this test. This comment can be removed once the SpecInterpreter will be removed."

--- a/src/Spec2-Tests/SpAbstractWidgetPresenterDeferringActionTest.class.st
+++ b/src/Spec2-Tests/SpAbstractWidgetPresenterDeferringActionTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpAbstractWidgetPresenterDeferringActionTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Core'
+	#name : 'SpAbstractWidgetPresenterDeferringActionTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Core',
+	#package : 'Spec2-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractWidgetPresenterDeferringActionTest >> testWithAdapterPerformOrDeferDoesNotExecuteWhenNoAdapter [
 	| presenter executed |
 	
@@ -15,7 +17,7 @@ SpAbstractWidgetPresenterDeferringActionTest >> testWithAdapterPerformOrDeferDoe
 	self deny: executed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpAbstractWidgetPresenterDeferringActionTest >> testWithAdapterPerformOrDeferExecutesWhenAdapter [
 	| presenter executed |
 	

--- a/src/Spec2-Tests/SpApplicationTest.class.st
+++ b/src/Spec2-Tests/SpApplicationTest.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #SpApplicationTest,
-	#superclass : #TestCase,
+	#name : 'SpApplicationTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'application'
 	],
-	#category : #'Spec2-Tests-Core-Base'
+	#category : 'Spec2-Tests-Core-Base',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SpApplicationTest >> setUp [
 	
 	super setUp.
 	application := SpMockApplication new
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpApplicationTest >> tearDown [
 
 	application closeAllWindows.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testCloseDialogWindowRemovesItFromWindowCollection [
 
 	| window |
@@ -31,7 +33,7 @@ SpApplicationTest >> testCloseDialogWindowRemovesItFromWindowCollection [
 	self deny: (application windows includes: window)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testCloseWindowRemovesItFromWindowCollection [
 
 	| window |
@@ -41,13 +43,13 @@ SpApplicationTest >> testCloseWindowRemovesItFromWindowCollection [
 	self deny: (application windows includes: window)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testIsPresenter [
 
 	self deny: application isPresenter 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testNewPresenter [
 	| presenter |
 
@@ -55,7 +57,7 @@ SpApplicationTest >> testNewPresenter [
 	self assert: presenter application equals: application
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testOpenDialogWindowAddsItToWindowCollection [
 
 	| window |
@@ -64,7 +66,7 @@ SpApplicationTest >> testOpenDialogWindowAddsItToWindowCollection [
 	self assert: (application windows includes: window)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testOpenWindowAddsItToWindowCollection [
 
 	| window |
@@ -73,7 +75,7 @@ SpApplicationTest >> testOpenWindowAddsItToWindowCollection [
 	self assert: (application windows includes: window)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpApplicationTest >> testUseBackend [
 
 	self assert: application backend name equals: #Mock.

--- a/src/Spec2-Tests/SpApplicationWithToolbarTest.class.st
+++ b/src/Spec2-Tests/SpApplicationWithToolbarTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpApplicationWithToolbarTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpApplicationWithToolbarTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpApplicationWithToolbarTest >> classToTest [
 	^ SpApplicationWithToolbar
 ]

--- a/src/Spec2-Tests/SpBaseTest.class.st
+++ b/src/Spec2-Tests/SpBaseTest.class.st
@@ -1,26 +1,28 @@
 Class {
-	#name : #SpBaseTest,
-	#superclass : #TestCase,
+	#name : 'SpBaseTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'presenter',
 		'window'
 	],
-	#category : #'Spec2-Tests-Utils'
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpBaseTest class >> isAbstract [
 
 	^ self = SpBaseTest
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBaseTest >> adapter [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #assertions }
+{ #category : 'assertions' }
 SpBaseTest >> assertEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: aBlock [
 	
 	self
@@ -30,7 +32,7 @@ SpBaseTest >> assertEvent: anEventName isRaisedInPresenter: aPresenter whenDoing
 		whenDoing: aBlock
 ]
 
-{ #category : #assertions }
+{ #category : 'assertions' }
 SpBaseTest >> assertWith: assertionBlock timesRaisedEvent: anEventName inPresenter: aPresenter whenDoing: actionBlock [
 	
 	| timesCalled |
@@ -40,12 +42,12 @@ SpBaseTest >> assertWith: assertionBlock timesRaisedEvent: anEventName inPresent
 	assertionBlock value: timesCalled
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBaseTest >> classToTest [
 	self subclassResponsibility
 ]
 
-{ #category : #assertions }
+{ #category : 'assertions' }
 SpBaseTest >> denyEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: aBlock [
 	
 	self
@@ -55,45 +57,45 @@ SpBaseTest >> denyEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: 
 		whenDoing: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpBaseTest >> initializeTestedInstance [
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SpBaseTest >> openInstance [
 
 	window ifNil: [ window := presenter open ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBaseTest >> presenter [
 	^ presenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBaseTest >> setUp [
 	super setUp.
 	presenter := self classToTest new.
 	self initializeTestedInstance
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBaseTest >> tearDown [
 	window ifNotNil: [ window delete ].
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testNewPresenterIsNotBuilt [
 	self deny: presenter isBuilt
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testNewPresenterIsNotDisplayed [
 	self deny: presenter isDisplayed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testNonOpenPresenterDoesNotRaiseBuiltEvent [
 	| built |
 	built := false.
@@ -101,7 +103,7 @@ SpBaseTest >> testNonOpenPresenterDoesNotRaiseBuiltEvent [
 	self deny: built
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testNonOpenPresenterDoesNotRaiseDisplayedEvent [
 	| displayed |
 	displayed := false.
@@ -109,19 +111,19 @@ SpBaseTest >> testNonOpenPresenterDoesNotRaiseDisplayedEvent [
 	self deny: displayed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testOpenPresenterIsBuilt [
 	self openInstance.
 	self assert: presenter isBuilt
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testOpenPresenterIsDisplayed [
 	self openInstance.
 	self assert: presenter isDisplayed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testOpenPresenterRaisesBuiltEvent [
 	| built |
 	built := false.
@@ -130,7 +132,7 @@ SpBaseTest >> testOpenPresenterRaisesBuiltEvent [
 	self assert: built
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testOpenPresenterRaisesDisplayEvent [
 	| displayed |
 	displayed := false.
@@ -139,7 +141,7 @@ SpBaseTest >> testOpenPresenterRaisesDisplayEvent [
 	self assert: displayed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpBaseTest >> testRebuildPresenterDoNotLetReferencesInAnnouncer [
 
 	| oldSize newSize |
@@ -152,7 +154,7 @@ SpBaseTest >> testRebuildPresenterDoNotLetReferencesInAnnouncer [
 	self assert: oldSize equals: newSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpBaseTest >> widget [
 	
 	^ self adapter widget

--- a/src/Spec2-Tests/SpBoxLayoutTest.class.st
+++ b/src/Spec2-Tests/SpBoxLayoutTest.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #SpBoxLayoutTest,
-	#superclass : #SpLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpBoxLayoutTest',
+	#superclass : 'SpLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpBoxLayoutTest class >> isAbstract [
 
 	^ self == SpBoxLayoutTest
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpBoxLayoutTest >> extentOf: aPresenter [
 
 	^ aPresenter adapter widget bounds extent
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpBoxLayoutTest >> heightOf: aPresenter [
 
 	^ (self extentOf: aPresenter) y
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBoxLayoutTest >> testElementsAreAddedInOrder [
 
 	| second |
@@ -31,14 +33,14 @@ SpBoxLayoutTest >> testElementsAreAddedInOrder [
 	self assert: layout children last equals: second
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBoxLayoutTest >> testLayoutWithOneElementIsNotEmpty [
 
 	layout add: SpButtonPresenter new.
 	self deny: layout isEmpty
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBoxLayoutTest >> testRemoveElementFromLayoutTakesItOut [
 
 	| element |
@@ -47,7 +49,7 @@ SpBoxLayoutTest >> testRemoveElementFromLayoutTakesItOut [
 	self assert: layout isEmpty
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBoxLayoutTest >> testReplaceAtindexWith [
 	| p1 toReplace p3 replacement |
 
@@ -65,7 +67,7 @@ SpBoxLayoutTest >> testReplaceAtindexWith [
 	self assert: layout children equals: { p1. replacement. p3 }
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpBoxLayoutTest >> testReplaceWith [
 	| p1 toReplace p3 replacement |
 
@@ -83,7 +85,7 @@ SpBoxLayoutTest >> testReplaceWith [
 	self assert: layout children equals: { p1. replacement. p3 }
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpBoxLayoutTest >> widthOf: aPresenter [
 
 	^ (self extentOf: aPresenter) x

--- a/src/Spec2-Tests/SpButtonPresenterTest.class.st
+++ b/src/Spec2-Tests/SpButtonPresenterTest.class.st
@@ -2,24 +2,26 @@
 SUnit tests for Button model
 "
 Class {
-	#name : #SpButtonPresenterTest,
-	#superclass : #SpAbstractButtonPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpButtonPresenterTest',
+	#superclass : 'SpAbstractButtonPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpButtonPresenterTest >> classToTest [
 
 	^ SpButtonPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpButtonPresenterTest >> morph [
 
 	^ presenter adapter widget
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testAction [
 	| actionExecuted |
 
@@ -34,7 +36,7 @@ SpButtonPresenterTest >> testAction [
 	self assert: actionExecuted equals: true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testAskBeforeChanging [
 
 	| state |
@@ -48,7 +50,7 @@ SpButtonPresenterTest >> testAskBeforeChanging [
 	self assert: state
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testContextMenu [
 	| menu changed |
 	
@@ -62,7 +64,7 @@ SpButtonPresenterTest >> testContextMenu [
 	self assert: changed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testEnabled [
 	self assert: presenter isEnabled.
 	self openInstance.
@@ -71,7 +73,7 @@ SpButtonPresenterTest >> testEnabled [
 	self deny: self morph enabled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testWhenActionChangedDo [
 
 	| actionModified newBlock oldBlock |
@@ -96,7 +98,7 @@ SpButtonPresenterTest >> testWhenActionChangedDo [
 	self assert: actionModified equals: true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testWhenActionPerformedDo [
 
 	| actionExecuted actionPerformed |
@@ -122,7 +124,7 @@ SpButtonPresenterTest >> testWhenActionPerformedDo [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testWhenActionPerformedDoAfterAction [
 
 	| actionExecuted actionPerformed |
@@ -146,7 +148,7 @@ SpButtonPresenterTest >> testWhenActionPerformedDoAfterAction [
 	self assert: actionExecuted < actionPerformed.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpButtonPresenterTest >> testWhenStateChangedDo [
 
 	presenter whenStateChangedDo: [ :new :old | self deny: old. self assert: new ].

--- a/src/Spec2-Tests/SpCheckBoxExampleTest.class.st
+++ b/src/Spec2-Tests/SpCheckBoxExampleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpCheckBoxExampleTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpCheckBoxExampleTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCheckBoxExampleTest >> classToTest [
 	^ SpCheckBoxExample
 ]

--- a/src/Spec2-Tests/SpCheckboxPresenterTest.class.st
+++ b/src/Spec2-Tests/SpCheckboxPresenterTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SpCheckboxPresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpCheckboxPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCheckboxPresenterTest >> classToTest [
 
 	^ SpCheckBoxPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCheckboxPresenterTest >> morph [
 
 	^ presenter adapter widget
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testActivateDoesNotRaiseDeactivateEvent [
 
 	presenter state: false.
@@ -27,14 +29,14 @@ SpCheckboxPresenterTest >> testActivateDoesNotRaiseDeactivateEvent [
 		whenDoing: [ presenter state: true ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testActivatePresenterIsActive [
 
 	presenter state: true.
 	self assert: presenter state
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testActivateRaisesActivatedEvent [
 
 	presenter state: false.
@@ -44,7 +46,7 @@ SpCheckboxPresenterTest >> testActivateRaisesActivatedEvent [
 		whenDoing: [ presenter state: true ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testActivateRaisesChangedEvent [
 
 	presenter state: false.
@@ -54,7 +56,7 @@ SpCheckboxPresenterTest >> testActivateRaisesChangedEvent [
 		whenDoing: [ presenter state: true ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testActivateRaisesChangedEventOnce [
 
 	presenter state: false.
@@ -65,7 +67,7 @@ SpCheckboxPresenterTest >> testActivateRaisesChangedEventOnce [
 		whenDoing: [ presenter state: true ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testDeactivateDoesNotRaiseActivateEvent [
 
 	presenter state: true.
@@ -76,14 +78,14 @@ SpCheckboxPresenterTest >> testDeactivateDoesNotRaiseActivateEvent [
 		whenDoing: [ presenter state: false ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testDeactivatePresenterIsNotActive [
 
 	presenter state: false.
 	self deny: presenter state
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testDeactivateRaisesChangedEvent [
 
 	presenter state: true.
@@ -93,7 +95,7 @@ SpCheckboxPresenterTest >> testDeactivateRaisesChangedEvent [
 		whenDoing: [ presenter state: false ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testDeactivateRaisesChangedEventOnce [
 
 	presenter state: true.
@@ -104,7 +106,7 @@ SpCheckboxPresenterTest >> testDeactivateRaisesChangedEventOnce [
 		whenDoing: [ presenter state: false ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testDeactivateRaisesDeactivatedEvent [
 
 	presenter state: true.
@@ -114,14 +116,14 @@ SpCheckboxPresenterTest >> testDeactivateRaisesDeactivatedEvent [
 		whenDoing: [ presenter state: false ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testLabelIsSet [
 
 	presenter label: 'test'.
 	self assert: presenter label equals: 'test'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testStayingActiveDoesNotRaiseChangedEvent [
 
 	presenter state: true.
@@ -131,7 +133,7 @@ SpCheckboxPresenterTest >> testStayingActiveDoesNotRaiseChangedEvent [
 		whenDoing: [ presenter state: true ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCheckboxPresenterTest >> testStayingInactiveDoesNotRaiseChangedEvent [
 
 	presenter state: false.

--- a/src/Spec2-Tests/SpClassMethodBrowserTest.class.st
+++ b/src/Spec2-Tests/SpClassMethodBrowserTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpClassMethodBrowserTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpClassMethodBrowserTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpClassMethodBrowserTest >> classToTest [
 	^ SpClassMethodBrowser
 ]

--- a/src/Spec2-Tests/SpCodeCommandContextMock.class.st
+++ b/src/Spec2-Tests/SpCodeCommandContextMock.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #SpCodeCommandContextMock,
-	#superclass : #Object,
+	#name : 'SpCodeCommandContextMock',
+	#superclass : 'Object',
 	#instVars : [
 		'selection'
 	],
-	#category : #'Spec2-Tests-Commands'
+	#category : 'Spec2-Tests-Commands',
+	#package : 'Spec2-Tests',
+	#tag : 'Commands'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCodeCommandContextMock >> selection [
 
 	^ selection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCodeCommandContextMock >> selection: anObject [
 
 	selection := anObject

--- a/src/Spec2-Tests/SpCodeCommandTest.class.st
+++ b/src/Spec2-Tests/SpCodeCommandTest.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #SpCodeCommandTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Commands'
+	#name : 'SpCodeCommandTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Commands',
+	#package : 'Spec2-Tests',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpCodeCommandTest class >> isAbstract [
 
 	^ self = SpCodeCommandTest
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpCodeCommandTest class >> shouldInheritSelectors [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCodeCommandTest >> commandClass [
 		
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpCodeCommandTest >> commandToTest [
 
 	^ self commandClass new 
@@ -30,13 +32,13 @@ SpCodeCommandTest >> commandToTest [
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpCodeCommandTest >> newMockContext [
 	
 	^ SpCodeCommandContextMock new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpCodeCommandTest >> testExecute [ 
 
 	self flag: #TODO. "How to intercept messages to prevent execution?"

--- a/src/Spec2-Tests/SpComponentListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpComponentListPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpComponentListPresenterTest,
-	#superclass : #SpAbstractListPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpComponentListPresenterTest',
+	#superclass : 'SpAbstractListPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpComponentListPresenterTest >> classToTest [
 	^ SpComponentListPresenter
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpComponentListPresenterTest >> testActivationOnDoubleClickShouldActivateOnDoubleClick [
 
 	| activatedItem |
@@ -23,7 +25,7 @@ SpComponentListPresenterTest >> testActivationOnDoubleClickShouldActivateOnDoubl
 	self assert: activatedItem label equals: '10'.
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpComponentListPresenterTest >> testActivationOnSingleClickShouldActivateOnClick [
 
 	| activatedItem |
@@ -37,7 +39,7 @@ SpComponentListPresenterTest >> testActivationOnSingleClickShouldActivateOnClick
 	self assert: activatedItem label equals: '10'.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testActivationWithTransformation [
 	| activatedItem |
 
@@ -53,7 +55,7 @@ SpComponentListPresenterTest >> testActivationWithTransformation [
 	self assert: activatedItem equals: 100
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testAddNoPresenterToComponentListDoesNotRaiseEvent [
 	| raised |
 	
@@ -62,7 +64,7 @@ SpComponentListPresenterTest >> testAddNoPresenterToComponentListDoesNotRaiseEve
 	self deny: raised
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testAddPresenterToComponentListIsInPresenterCollection [
 	| button |
 
@@ -71,7 +73,7 @@ SpComponentListPresenterTest >> testAddPresenterToComponentListIsInPresenterColl
 	self assert: (presenter includes: button)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testAddPresenterToComponentListRaisesEvent [
 	| button raised |
 	raised := false.
@@ -83,7 +85,7 @@ SpComponentListPresenterTest >> testAddPresenterToComponentListRaisesEvent [
 	self assert: raised
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testAddPresenterToComponentListRaisesSingleEvent [
 	| button raised |
 	raised := 0.
@@ -95,13 +97,13 @@ SpComponentListPresenterTest >> testAddPresenterToComponentListRaisesSingleEvent
 	self assert: raised equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testAddPresenterToComponentListShouldNotBeEmpty [
 	presenter addPresenter: SpButtonPresenter new.
 	self deny: presenter isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testDisableActivationDuring [ 
 	| activated |
 
@@ -114,13 +116,13 @@ SpComponentListPresenterTest >> testDisableActivationDuring [
 	self assert: presenter selectedItem label equals: '20' "but the selection changed!"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testNewComponentListIsEmpty [
 
 	self assertEmpty: self classToTest new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testReplaceItemList [
 	| changed |
 
@@ -134,7 +136,7 @@ SpComponentListPresenterTest >> testReplaceItemList [
 	self assert: changed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testSelectAll [
 
 	presenter beSingleSelection.
@@ -149,7 +151,7 @@ SpComponentListPresenterTest >> testSelectAll [
 		equals: #('10' '20' '30')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testSelectedItemsSortedByIndex [
 
 	presenter beMultipleSelection.
@@ -164,7 +166,7 @@ SpComponentListPresenterTest >> testSelectedItemsSortedByIndex [
 		equals: #('10' '30')
 ]
 
-{ #category : #'tests - smoke' }
+{ #category : 'tests - smoke' }
 SpComponentListPresenterTest >> testSetSortingBlockBeforeItems [
 	| count |
 	
@@ -176,7 +178,7 @@ SpComponentListPresenterTest >> testSetSortingBlockBeforeItems [
 	self assert: (presenter model at: 1) label equals: '0'
 ]
 
-{ #category : #'tests - smoke' }
+{ #category : 'tests - smoke' }
 SpComponentListPresenterTest >> testSortingBlock [
 	| count |
 	
@@ -188,7 +190,7 @@ SpComponentListPresenterTest >> testSortingBlock [
 	self assert: (presenter model at: 1) label equals: '0'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testUnselectAll [
 
 	presenter beMultipleSelection.
@@ -200,7 +202,7 @@ SpComponentListPresenterTest >> testUnselectAll [
 	self assertEmpty: presenter selection selectedItems
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComponentListPresenterTest >> testUpdateItemsKeepingSelection [ 
 	| presenters |
 

--- a/src/Spec2-Tests/SpComposablePresenterWithAdditionalSubpresentersTest.class.st
+++ b/src/Spec2-Tests/SpComposablePresenterWithAdditionalSubpresentersTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #SpComposablePresenterWithAdditionalSubpresentersTest,
-	#superclass : #TestCase,
+	#name : 'SpComposablePresenterWithAdditionalSubpresentersTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'application'
 	],
-	#category : #'Spec2-Tests-Core'
+	#category : 'Spec2-Tests-Core',
+	#package : 'Spec2-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SpComposablePresenterWithAdditionalSubpresentersTest >> setUp [
 	super setUp.
 	application := SpMockApplication new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpComposablePresenterWithAdditionalSubpresentersTest >> testOpening [
 
 	| aPresenter |

--- a/src/Spec2-Tests/SpComposablePresenterWithModelTest.class.st
+++ b/src/Spec2-Tests/SpComposablePresenterWithModelTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpComposablePresenterWithModelTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Core'
+	#name : 'SpComposablePresenterWithModelTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Core',
+	#package : 'Spec2-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testInstanceCreation [
 
 	| aPoint presenter |
@@ -19,7 +21,7 @@ SpComposablePresenterWithModelTest >> testInstanceCreation [
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testInstanceCreationWithValueHolder [
 
 	| point valueHolder presenter |
@@ -35,7 +37,7 @@ SpComposablePresenterWithModelTest >> testInstanceCreationWithValueHolder [
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testModelSettingModelToModel [
 
 	"we had a Model, new model is another Model"
@@ -55,7 +57,7 @@ SpComposablePresenterWithModelTest >> testModelSettingModelToModel [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testModelSettingModelToValueHolder [
 
 	| point model presenter |
@@ -78,7 +80,7 @@ SpComposablePresenterWithModelTest >> testModelSettingModelToValueHolder [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testModelSettingObjectToModel [
 
 	| point model presenter |
@@ -101,7 +103,7 @@ SpComposablePresenterWithModelTest >> testModelSettingObjectToModel [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testModelSettingObjectToValueHolder [
 
 	| point point2 presenter |
@@ -122,7 +124,7 @@ SpComposablePresenterWithModelTest >> testModelSettingObjectToValueHolder [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testModelSettingValueHolderToModel [
 
 	"we had a Model, new model is a value holder"
@@ -143,7 +145,7 @@ SpComposablePresenterWithModelTest >> testModelSettingValueHolderToModel [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testModelSettingValueHolderToValueHolder [
 
 	| point point2 valueHolder presenter |
@@ -168,7 +170,7 @@ SpComposablePresenterWithModelTest >> testModelSettingValueHolderToValueHolder [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testUpdateModel [
 
 	| aPoint presenter |
@@ -191,7 +193,7 @@ SpComposablePresenterWithModelTest >> testUpdateModel [
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpComposablePresenterWithModelTest >> testUpdateModelWithValueHolder [
 
 	| aPoint aValueHolder presenter anAnnouncer |

--- a/src/Spec2-Tests/SpDemoTest.class.st
+++ b/src/Spec2-Tests/SpDemoTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpDemoTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpDemoTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDemoTest >> classToTest [
 	^ SpDemo
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDemoTest >> testSmokeTestForDemoPages [
 
 	self timeLimit: 1 minute.

--- a/src/Spec2-Tests/SpDropListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpDropListPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpDropListPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpDropListPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDropListPresenterTest >> classToTest [
 	^ SpDropListPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDropListPresenterTest >> testDisableSelectionDuring [ 
 	| changed |
 
@@ -24,7 +26,7 @@ SpDropListPresenterTest >> testDisableSelectionDuring [
 	self assert: presenter selectedItem equals: $b "but the selection changed!"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDropListPresenterTest >> testEmptyList [
 
 	| changed |
@@ -39,7 +41,7 @@ SpDropListPresenterTest >> testEmptyList [
 	self assert: presenter selectedIndex equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDropListPresenterTest >> testSetItemsWithCollectionSmallerThanSelection [
 
 	| changed |
@@ -53,7 +55,7 @@ SpDropListPresenterTest >> testSetItemsWithCollectionSmallerThanSelection [
 	self assert: presenter selectedIndex equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDropListPresenterTest >> testSetItemsWithEmptyCollection [
 
 	| changed |
@@ -68,7 +70,7 @@ SpDropListPresenterTest >> testSetItemsWithEmptyCollection [
 	self assert: presenter selectedIndex equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDropListPresenterTest >> testSortingBlock [
 	| count |
 	count := 0.
@@ -80,7 +82,7 @@ SpDropListPresenterTest >> testSortingBlock [
 	self assert: (presenter model at: 1) model equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpDropListPresenterTest >> testUpdateItemsKeepingSelection [ 
 
 	presenter items: #($a $b $c).

--- a/src/Spec2-Tests/SpDynamicWidgetChangeTest.class.st
+++ b/src/Spec2-Tests/SpDynamicWidgetChangeTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpDynamicWidgetChangeTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpDynamicWidgetChangeTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpDynamicWidgetChangeTest >> classToTest [
 	^ SpDynamicWidgetChange
 ]

--- a/src/Spec2-Tests/SpEditableListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpEditableListPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpEditableListPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpEditableListPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEditableListPresenterTest >> classToTest [
 	^ SpEditableListPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEditableListPresenterTest >> testCanAddNewItem [
 	presenter 
 		items: #(1 2 3) asOrderedCollection;
@@ -22,7 +24,7 @@ SpEditableListPresenterTest >> testCanAddNewItem [
 		hasSameElements: #(1 2 3 4)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEditableListPresenterTest >> testCanCancelAddNewItem [
 	presenter 
 		items: #(1 2 3) asOrderedCollection;
@@ -35,7 +37,7 @@ SpEditableListPresenterTest >> testCanCancelAddNewItem [
 		hasSameElements: #(1 2 3)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEditableListPresenterTest >> testCanRemoveSelectedItem [
 	presenter 
 		items: #(1 2 3) asOrderedCollection;
@@ -48,7 +50,7 @@ SpEditableListPresenterTest >> testCanRemoveSelectedItem [
 		hasSameElements: #(1 3)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEditableListPresenterTest >> testMoveElementAtTo [
 	presenter items: {'AAA' . 'BBB' . 'CCC'} asOrderedCollection.
 	presenter moveElementAt: 1 to: 3.
@@ -57,7 +59,7 @@ SpEditableListPresenterTest >> testMoveElementAtTo [
 		equals: {'BBB' . 'CCC' . 'AAA'}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEditableListPresenterTest >> testRemoveBlockExecutedWhenSelectedItemRemoved [
 	| executed selectedItem |
 	executed := false.
@@ -76,7 +78,7 @@ SpEditableListPresenterTest >> testRemoveBlockExecutedWhenSelectedItemRemoved [
 		equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEditableListPresenterTest >> testWhenAddingNewItemThenNewItemIsSelected [
 	presenter 
 		items: #(1 2 3) asOrderedCollection;

--- a/src/Spec2-Tests/SpEmptyPresenter.class.st
+++ b/src/Spec2-Tests/SpEmptyPresenter.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpEmptyPresenter,
-	#superclass : #SpPresenter,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpEmptyPresenter',
+	#superclass : 'SpPresenter',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpEmptyPresenter >> layout: aSpLayout [
 	
 	layout := aSpLayout

--- a/src/Spec2-Tests/SpEventHandlerTest.class.st
+++ b/src/Spec2-Tests/SpEventHandlerTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SpEventHandlerTest,
-	#superclass : #TestCase,
+	#name : 'SpEventHandlerTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'presenter'
 	],
-	#category : #'Spec2-Tests-Core-Base'
+	#category : 'Spec2-Tests-Core-Base',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SpEventHandlerTest >> tearDown [
 
 	presenter ifNil: [ ^ self ].
@@ -17,7 +19,7 @@ SpEventHandlerTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEventHandlerTest >> testEventIsInstalledDynamically [
 
 	| t1 t2 lost got |
@@ -40,7 +42,7 @@ SpEventHandlerTest >> testEventIsInstalledDynamically [
 	self assert: lost
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEventHandlerTest >> testEventIsInstalledOnBuild [
 
 	| t1 t2 lost got |
@@ -63,7 +65,7 @@ SpEventHandlerTest >> testEventIsInstalledOnBuild [
 	self assert: lost
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpEventHandlerTest >> testEventIsTransmittedOnText [
 
 	| t1 t2 lost got |

--- a/src/Spec2-Tests/SpGridLayout.extension.st
+++ b/src/Spec2-Tests/SpGridLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SpGridLayout }
+Extension { #name : 'SpGridLayout' }
 
-{ #category : #'*Spec2-Tests' }
+{ #category : '*Spec2-Tests' }
 SpGridLayout >> at: aPoint [
 	
 	^ childrenByPosition at: aPoint

--- a/src/Spec2-Tests/SpGridLayoutBuilderTest.class.st
+++ b/src/Spec2-Tests/SpGridLayoutBuilderTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpGridLayoutBuilderTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpGridLayoutBuilderTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpGridLayoutBuilderTest >> newPresenters: nbPresesenters [
 
 	^ (1 to: nbPresesenters)
@@ -12,7 +14,7 @@ SpGridLayoutBuilderTest >> newPresenters: nbPresesenters [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpGridLayoutBuilderTest >> testBuilderAddsElementsOnRaw [
 	| layout presenters |
 	
@@ -34,7 +36,7 @@ SpGridLayoutBuilderTest >> testBuilderAddsElementsOnRaw [
 		equals: presenters third.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpGridLayoutBuilderTest >> testBuilderCanAddElementsOnMultipleRaws [
 	| layout presenters |
 	
@@ -66,7 +68,7 @@ SpGridLayoutBuilderTest >> testBuilderCanAddElementsOnMultipleRaws [
 		equals: presenters fifth.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpGridLayoutBuilderTest >> testNewBuilderReturnsGridLayout [
 	| layout |
 	layout := SpGridLayout build: [ :builder | ].

--- a/src/Spec2-Tests/SpGridLayoutTest.class.st
+++ b/src/Spec2-Tests/SpGridLayoutTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpGridLayoutTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpGridLayoutTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpGridLayoutTest >> testInitialStatus [
 	| layout |
 

--- a/src/Spec2-Tests/SpHorizontalBoxLayoutTest.class.st
+++ b/src/Spec2-Tests/SpHorizontalBoxLayoutTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #SpHorizontalBoxLayoutTest,
-	#superclass : #SpBoxLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpHorizontalBoxLayoutTest',
+	#superclass : 'SpBoxLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpHorizontalBoxLayoutTest >> initializeTestedInstance [
 
 	layout := SpBoxLayout newLeftToRight.
 	presenter layout: layout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpHorizontalBoxLayoutTest >> testPresenterExtentFollowsChildrenExtent [
 	| label button |
 
@@ -25,7 +27,7 @@ SpHorizontalBoxLayoutTest >> testPresenterExtentFollowsChildrenExtent [
 	self assert: (self heightOf: presenter) >= ((self heightOf: label) max: (self heightOf: button))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpHorizontalBoxLayoutTest >> testReplaceWithFixedWidth [
 	| p1 toReplace p3 replacement |
 
@@ -43,7 +45,7 @@ SpHorizontalBoxLayoutTest >> testReplaceWithFixedWidth [
 	self assert: layout children equals: { p1. replacement. p3 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpHorizontalBoxLayoutTest >> testReplaceWithFixedWidthAllFixed [
 	| p1 toReplace p3 replacement |
 
@@ -61,7 +63,7 @@ SpHorizontalBoxLayoutTest >> testReplaceWithFixedWidthAllFixed [
 	self assert: layout children equals: { p1. replacement. p3 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpHorizontalBoxLayoutTest >> testReplaceWithFixedWidthComposed [
 	| p1 layoutToReplace toReplace p3 replacement |
 

--- a/src/Spec2-Tests/SpHorizontalPanedLayoutTest.class.st
+++ b/src/Spec2-Tests/SpHorizontalPanedLayoutTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpHorizontalPanedLayoutTest,
-	#superclass : #SpPanedLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpHorizontalPanedLayoutTest',
+	#superclass : 'SpPanedLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpHorizontalPanedLayoutTest >> initializeTestedInstance [
 
 	layout := SpPanedLayout newLeftToRight.

--- a/src/Spec2-Tests/SpImagePresenterTest.class.st
+++ b/src/Spec2-Tests/SpImagePresenterTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SpImagePresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpImagePresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpImagePresenterTest >> classToTest [
 	^ SpImagePresenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpImagePresenterTest >> tearDown [ 
 
 	presenter ifNotNil: [ presenter delete ].
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpImagePresenterTest >> testAutoScale [
 	| count result |
 	count := 0.
@@ -29,7 +31,7 @@ SpImagePresenterTest >> testAutoScale [
 	self assert: result
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpImagePresenterTest >> testCanDefineImagePresenterFromAForm [
 	| title form windowPresenter presenterItems |
 	
@@ -46,7 +48,7 @@ SpImagePresenterTest >> testCanDefineImagePresenterFromAForm [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpImagePresenterTest >> testSwitchAutoScale [
 	| autoState |
 	autoState := presenter autoScale.

--- a/src/Spec2-Tests/SpLabelPresenterTest.class.st
+++ b/src/Spec2-Tests/SpLabelPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpLabelPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpLabelPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLabelPresenterTest >> classToTest [
 	^ SpLabelPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpLabelPresenterTest >> testLabelChangeRaisesEvent [
 
 	self
@@ -18,7 +20,7 @@ SpLabelPresenterTest >> testLabelChangeRaisesEvent [
 		whenDoing: [ presenter label: 'test' ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpLabelPresenterTest >> testLabelChangeRaisesEventOnce [
 
 	self
@@ -28,7 +30,7 @@ SpLabelPresenterTest >> testLabelChangeRaisesEventOnce [
 		whenDoing: [ presenter label: 'test' ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpLabelPresenterTest >> testLabelIsSet [
 
 	presenter label: 'test'.

--- a/src/Spec2-Tests/SpLayoutTest.class.st
+++ b/src/Spec2-Tests/SpLayoutTest.class.st
@@ -1,31 +1,33 @@
 Class {
-	#name : #SpLayoutTest,
-	#superclass : #SpSpecTest,
+	#name : 'SpLayoutTest',
+	#superclass : 'SpSpecTest',
 	#instVars : [
 		'layout'
 	],
-	#category : #'Spec2-Tests-Layout'
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpLayoutTest class >> isAbstract [
 
 	^ self == SpLayoutTest
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpLayoutTest class >> shouldInheritSelectors [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpLayoutTest >> classToTest [
 
 	^ SpEmptyPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpLayoutTest >> testInitialLayoutIsEmpty [
 
 	self assert: layout isEmpty

--- a/src/Spec2-Tests/SpListPresenterMultipleSelectionTest.class.st
+++ b/src/Spec2-Tests/SpListPresenterMultipleSelectionTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpListPresenterMultipleSelectionTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpListPresenterMultipleSelectionTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpListPresenterMultipleSelectionTest >> classToTest [
 	^ SpListPresenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpListPresenterMultipleSelectionTest >> setUp [
 	super setUp.
 	presenter
@@ -17,7 +19,7 @@ SpListPresenterMultipleSelectionTest >> setUp [
 		items: #(10 20 30)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectAllRaisesSelectionEventOnce [
 	"Because it does nothing in single selection mode"
 	| events |
@@ -29,49 +31,49 @@ SpListPresenterMultipleSelectionTest >> testSelectAllRaisesSelectionEventOnce [
 	self assert: events equals: 1
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectAllSelectsAllItems [
 
 	presenter selectAll.
 	self assert: presenter selection selectedItems asSet equals: presenter model items asSet
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexAddsIndexToSelectedIndexList [
 
 	presenter selectIndex: 1.
 	self assert: (presenter selection includesIndex: 1)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexAddsItemToSelectedItemList [
 
 	presenter selectIndex: 1.
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexOutsideRangeHasNoSelectedIndexes [
 
 	presenter selectIndex: 4.
 	self assert: presenter selection selectedIndexes isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexOutsideRangeHasNoSelectedItems [
 
 	presenter selectIndex: 4.
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexOutsideRangeIsEmpty [
 
 	presenter selectIndex: 4.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexThenSelectOutsideRangeKeepsFirstElement [
 
 	presenter selectIndex: 1.
@@ -79,7 +81,7 @@ SpListPresenterMultipleSelectionTest >> testSelectIndexThenSelectOutsideRangeKee
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexThenSelectOutsideRangeKeepsFirstIndex [
 
 	presenter selectIndex: 1.
@@ -87,7 +89,7 @@ SpListPresenterMultipleSelectionTest >> testSelectIndexThenSelectOutsideRangeKee
 	self assert: (presenter selection includesIndex: 1)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexThenSelectOutsideRangeKeepsSingleSelectedItem [
 
 	presenter selectIndex: 1.
@@ -95,7 +97,7 @@ SpListPresenterMultipleSelectionTest >> testSelectIndexThenSelectOutsideRangeKee
 	self assert: presenter selection selectedItems size equals: 1
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexTwiceAddsIndexToSelectedIndexListOnlyOnce [
 
 	presenter
@@ -104,51 +106,51 @@ SpListPresenterMultipleSelectionTest >> testSelectIndexTwiceAddsIndexToSelectedI
 	self assert: presenter selection selectedIndexes asArray equals: #(1)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesAddsIndexesToSelectedIndexList [
 	presenter selectIndexes: {1 . 2}.
 	self assert: (presenter selection includesIndexes: {1 . 2})
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesAddsItemsToSelectedItemList [
 	presenter selectIndexes: {1 . 2}.
 	self assert: (presenter selection includesItems: {10 . 20})
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesOutsideRangeHasNoSelectedIndexes [
 	presenter selectIndexes: {4 . 5}.
 	self assert: presenter selection selectedIndexes isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesOutsideRangeHasNoSelectedItems [
 	presenter selectIndexes: {4 . 5}.
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesOutsideRangeIsEmpty [
 	presenter selectIndexes: {4 . 5}.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesThenSelectOutsideRangeKeepsElements [
 	presenter selectIndexes: {1 . 2}.
 	presenter selectIndexes: {50 . 60}.
 	self assert: (presenter selection includesItems: {10 . 20})
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesThenSelectOutsideRangeKeepsIndexes [
 	presenter selectIndexes: {1 . 2}.
 	presenter selectIndexes: {50 . 60}.
 	self assert: (presenter selection includesIndexes: {1 . 2})
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectIndexesTwiceAddsIndexesToSelectedIndexListOnlyOnce [
 	presenter
 		selectIndexes: {1 . 2};
@@ -156,42 +158,42 @@ SpListPresenterMultipleSelectionTest >> testSelectIndexesTwiceAddsIndexesToSelec
 	self assertCollection: presenter selection selectedIndexes hasSameElements: {1 . 2}
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemAddsIndexToSelectedIndexList [
 
 	presenter selectItem: 10.
 	self assert: (presenter selection includesIndex: 1)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemAddsItemToSelectedItemList [
 
 	presenter selectItem: 10.
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemOutsideRangeHasNoSelectedIndexes [
 
 	presenter selectItem: 400.
 	self assert: presenter selection selectedIndexes isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemOutsideRangeHasNoSelectedItems [
 
 	presenter selectItem: 400.
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemOutsideRangeIsEmpty [
 
 	presenter selectItem: 4000.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeepsFirstElement [
 
 	presenter selectItem: 10.
@@ -199,7 +201,7 @@ SpListPresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeep
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeepsFirstIndex [
 
 	presenter selectItem: 10.
@@ -207,7 +209,7 @@ SpListPresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeep
 	self assert: (presenter selection includesIndex: 1)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeepsSingleSelectedItem [
 
 	presenter selectItem: 10.
@@ -215,51 +217,51 @@ SpListPresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeep
 	self assert: presenter selection selectedItems size equals: 1
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsAddsIndexesToSelectedIndexList [
 	presenter selectItems: {10 . 20}.
 	self assert: (presenter selection includesIndexes: #(1 2))
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsAddsItemsToSelectedItemList [
 	presenter selectItems: {10 . 20}.
 	self assert: (presenter selection includesItems: {10 . 20})
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsOutsideRangeHasNoSelectedIndexes [
 	presenter selectItems: {300 . 400}.
 	self assert: presenter selection selectedIndexes isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsOutsideRangeHasNoSelectedItems [
 	presenter selectItems: {300 . 400}.
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsOutsideRangeIsEmpty [
 	presenter selectItems: {4000 . 5000}.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsThenSelectOutsideRangeKeepsElements [
 	presenter selectItems: {10 . 20}.
 	presenter selectItems: {4000 . 5000}.
 	self assert: (presenter selection includesItems: {10 . 20})
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectItemsThenSelectOutsideRangeKeepsIndexes [
 	presenter selectItems: {10 . 20}.
 	presenter selectItems: {500 . 600}.
 	self assert: (presenter selection includesIndexes: {1 . 2})
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectMultipleIndexesAddsAllToSelectedIndexList [
 
 	presenter selectIndex: 1.
@@ -268,7 +270,7 @@ SpListPresenterMultipleSelectionTest >> testSelectMultipleIndexesAddsAllToSelect
 	self assert: (presenter selection includesIndex: 3).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectMultipleIndexesAddsAllToSelectedItemList [
 
 	presenter selectIndex: 1.
@@ -277,7 +279,7 @@ SpListPresenterMultipleSelectionTest >> testSelectMultipleIndexesAddsAllToSelect
 	self assert: (presenter selection includesItem: 30).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSelectMultipleIndexesRaisesSelectionChangeEventMultipleTimes [
 	| events |
 	events := 0.
@@ -289,7 +291,7 @@ SpListPresenterMultipleSelectionTest >> testSelectMultipleIndexesRaisesSelection
 	self assert: events equals: 2
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectMultipleItemAddsAllToSelectedIndexList [
 
 	presenter selectItem: 10.
@@ -298,7 +300,7 @@ SpListPresenterMultipleSelectionTest >> testSelectMultipleItemAddsAllToSelectedI
 	self assert: (presenter selection includesIndex: 3).
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectMultipleItemsAddsAllToSelectedItemList [
 
 	presenter selectItem: 10.
@@ -307,7 +309,7 @@ SpListPresenterMultipleSelectionTest >> testSelectMultipleItemsAddsAllToSelected
 	self assert: (presenter selection includesItem: 30).
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSelectMultipleItemsRaisesSelectionChangeEventMultipleTimes [
 	| events |
 	events := 0.
@@ -319,7 +321,7 @@ SpListPresenterMultipleSelectionTest >> testSelectMultipleItemsRaisesSelectionCh
 	self assert: events equals: 2
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSetSelectIndexOutsideRangeDoesNotModifySelection [
 
 	presenter whenSelectionChangedDo: [ :selection | self fail ].
@@ -328,7 +330,7 @@ SpListPresenterMultipleSelectionTest >> testSetSelectIndexOutsideRangeDoesNotMod
 	"If we arrive here and the test did not fail, we succeeded"
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSetSelectIndexRaisesSelectionChangeEventWithSelectedIndex [
 	| selectedIndexes |
 	presenter
@@ -337,7 +339,7 @@ SpListPresenterMultipleSelectionTest >> testSetSelectIndexRaisesSelectionChangeE
 	self assert: (selectedIndexes includes: 1)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterMultipleSelectionTest >> testSetSelectIndexRaisesSelectionChangeEventWithSelectedItem [
 	| selectedItems |
 	presenter
@@ -346,7 +348,7 @@ SpListPresenterMultipleSelectionTest >> testSetSelectIndexRaisesSelectionChangeE
 	self assert: (selectedItems includes: 10)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterMultipleSelectionTest >> testSetSelectItemOutsideRangeDoesNotModifySelection [
 
 	presenter whenSelectionChangedDo: [ :selection | self fail ].
@@ -355,7 +357,7 @@ SpListPresenterMultipleSelectionTest >> testSetSelectItemOutsideRangeDoesNotModi
 	"If we arrive here and the test did not fail, we succeeded"
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterMultipleSelectionTest >> testUnselectAllRaisesSelectionEventOnce [
 	"Because it does nothing in single selection mode"
 
@@ -370,7 +372,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectAllRaisesSelectionEventOnce 
 	self assert: events equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterMultipleSelectionTest >> testUnselectAllUnselectsall [
 
 	presenter
@@ -379,7 +381,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectAllUnselectsall [
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterMultipleSelectionTest >> testUnselectSelectedIndexRaisesSelectionEventOnce [
 	
 	| counter |
@@ -391,7 +393,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectSelectedIndexRaisesSelection
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterMultipleSelectionTest >> testUnselectSelectedIndexRemovesItFromSelectionList [
 
 	presenter
@@ -400,7 +402,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectSelectedIndexRemovesItFromSe
 	self assert: (presenter selection isEmpty)
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterMultipleSelectionTest >> testUnselectSelectedItemRaisesSelectionEventOnce [
 	
 	| counter |
@@ -412,7 +414,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectSelectedItemRaisesSelectionE
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterMultipleSelectionTest >> testUnselectSelectedItemRemovesItFromSelectionList [
 
 	presenter
@@ -421,7 +423,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectSelectedItemRemovesItFromSel
 	self assert: (presenter selection isEmpty)
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterMultipleSelectionTest >> testUnselectUnselectedIndexKeepsSelectionList [
 
 	presenter
@@ -430,7 +432,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectUnselectedIndexKeepsSelectio
 	self assert: presenter selection selectedIndexes asArray equals: #(1)
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterMultipleSelectionTest >> testUnselectUnselectedIndexRaisesNoSelectionEvent [
 	
 	| counter |
@@ -442,7 +444,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectUnselectedIndexRaisesNoSelec
 	self assert: counter equals: 0
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterMultipleSelectionTest >> testUnselectUnselectedItemKeepsSelectionList [
 
 	presenter
@@ -451,7 +453,7 @@ SpListPresenterMultipleSelectionTest >> testUnselectUnselectedItemKeepsSelection
 	self assert: presenter selection selectedItems asArray equals: #(10)
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterMultipleSelectionTest >> testUnselectUnselectedItemRaisesNoSelectionEvent [
 	
 	| counter |

--- a/src/Spec2-Tests/SpListPresenterSingleSelectionTest.class.st
+++ b/src/Spec2-Tests/SpListPresenterSingleSelectionTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpListPresenterSingleSelectionTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpListPresenterSingleSelectionTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpListPresenterSingleSelectionTest >> classToTest [
 	^ SpListPresenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpListPresenterSingleSelectionTest >> setUp [
 	super setUp.
 
@@ -18,7 +20,7 @@ SpListPresenterSingleSelectionTest >> setUp [
 		items: #(10 20 30)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectAllDoesNotRaiseEvent [
 	"Because it does nothing in single selection mode"
 	| events |
@@ -30,14 +32,14 @@ SpListPresenterSingleSelectionTest >> testSelectAllDoesNotRaiseEvent [
 	self assert: events equals: 0
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectAllDoesNotSelect [
 	presenter selectAll.
 
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectAllWithExistingSelectionLeavesSelection [
 	presenter
 		selectIndex: 1;
@@ -46,35 +48,35 @@ SpListPresenterSingleSelectionTest >> testSelectAllWithExistingSelectionLeavesSe
 	self assert: (presenter selection includesIndex: 1)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectIndexOutsideRangeUnsetsSelectedIndex [
 	presenter selectIndex: 4.
 
 	self assert: (presenter selection includesIndex: 0)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectIndexOutsideRangeUnsetsSelectedItem [
 
 	presenter selectIndex: 4.
 	self assert: presenter selection selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectIndexSetsSelectedIndex [
 
 	presenter selectIndex: 1.
 	self assert: presenter selection selectedIndex equals: 1
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectIndexSetsSelectedItem [
 
 	presenter selectIndex: 1.
 	self assert: presenter selection selectedItem equals: 10
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectIndexTwiceMakesIndexSelected [
 	presenter
 		selectIndex: 3;
@@ -83,7 +85,7 @@ SpListPresenterSingleSelectionTest >> testSelectIndexTwiceMakesIndexSelected [
 	self assert: (presenter selection includesIndex: 3)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectIndexTwiceMakesIsListedOnceInSelectedIndexes [
 	presenter
 		selectIndex: 3;
@@ -92,34 +94,34 @@ SpListPresenterSingleSelectionTest >> testSelectIndexTwiceMakesIsListedOnceInSel
 	self assert: presenter selection selectedIndexes asArray equals: #(3)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSelectItemOutsideRangeUnsetsSelectedIndex [
 	
 	presenter selectItem: 40.
 	self assert: presenter selection selectedIndex equals: 0
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSelectItemOutsideRangeUnsetsSelectedItem [
 
 	presenter selectItem: 40.
 	self assert: presenter selection selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSelectItemSetsSelectedIndex [
 
 	presenter selectItem: 20.
 	self assert: presenter selection selectedIndex equals: 2
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSelectItemSetsSelectedItem [
 	presenter selectItem: 20.
 	self assert: presenter selection selectedItem equals: 20
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSelectMultipleIndexesRaisesSelectionChangeEventMultipleTimes [
 	| events |
 	events := 0.
@@ -131,7 +133,7 @@ SpListPresenterSingleSelectionTest >> testSelectMultipleIndexesRaisesSelectionCh
 	self assert: events equals: 2
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexOutsideRangeRaisesSelectionChangeEventWithUnsetIndex [
 	| selectedIndex |
 	presenter
@@ -140,7 +142,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexOutsideRangeRaisesSelect
 	self assert: selectedIndex equals: 0
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexOutsideRangeRaisesSelectionChangeEventWithUnsetItem [
 	| selectedItem |
 	presenter
@@ -149,7 +151,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexOutsideRangeRaisesSelect
 	self assert: selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionChangeEventWithSelectedIndex [
 	| selectedIndex |
 	presenter
@@ -158,7 +160,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionChangeEve
 	self assert: selectedIndex equals: 1
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionChangeEventWithSelectedItem [
 	| selectedElement |
 
@@ -168,7 +170,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionChangeEve
 	self assert: selectedElement equals: 10
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionIndexChangeEventWithSelectedIndex [
 	| selectedIndex |
 	presenter selection
@@ -178,7 +180,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionIndexChan
 	self assert: selectedIndex equals: 1
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionItemChangeEventWithSelectedIndex [
 	| selectedItem |
 	presenter
@@ -187,7 +189,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectIndexRaisesSelectionItemChang
 	self assert: selectedItem equals: 10
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelectionChangeEventWithUnsetIndex [
 	| selectedIndex |
 
@@ -197,7 +199,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelecti
 	self assert: selectedIndex equals: 0
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelectionChangeEventWithUnsetItem [
 	| selectedItem |
 	presenter
@@ -206,7 +208,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelecti
 	self assert: selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChangeEventWithSelectedIndex [
 	| selectedIndex |
 
@@ -216,7 +218,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChangeEven
 	self assert: selectedIndex equals: 2
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChangeEventWithSelectedItem [
 	| selectedElement |
 	presenter
@@ -225,7 +227,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChangeEven
 	self assert: selectedElement equals: 20
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionIndexChangeEventWithSelectedIndex [
 	| selectedIndex |
 	presenter selection
@@ -234,7 +236,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionIndexChang
 	self assert: selectedIndex equals: 1
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionItemChangeEventWithSelectedItem [
 	| selectedItem |
 	presenter
@@ -243,7 +245,7 @@ SpListPresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionItemChange
 	self assert: selectedItem equals: 10
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectAllRaisesSelectionEventOnce [
 	"Because it does nothing in single selection mode"
 	| events |
@@ -255,7 +257,7 @@ SpListPresenterSingleSelectionTest >> testUnselectAllRaisesSelectionEventOnce [
 	self assert: events equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectAllUnselectsSingleSelection [
 
 	presenter
@@ -264,7 +266,7 @@ SpListPresenterSingleSelectionTest >> testUnselectAllUnselectsSingleSelection [
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectNonSelectedIndexDoesNotRemovesSelection [
 	presenter
 		selectIndex: 1;
@@ -273,7 +275,7 @@ SpListPresenterSingleSelectionTest >> testUnselectNonSelectedIndexDoesNotRemoves
 	self assert: presenter selection selectedIndex equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectNonSelectedIndexRaisesNoEvent [
 	
 	| counter |
@@ -286,7 +288,7 @@ SpListPresenterSingleSelectionTest >> testUnselectNonSelectedIndexRaisesNoEvent 
 	self assert: counter equals: 0
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterSingleSelectionTest >> testUnselectNonSelectedItemDoesNotRemovesSelection [
 	presenter
 		selectItem: 10;
@@ -295,7 +297,7 @@ SpListPresenterSingleSelectionTest >> testUnselectNonSelectedItemDoesNotRemovesS
 	self assert: presenter selection selectedItem equals: 10
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterSingleSelectionTest >> testUnselectNonSelectedItemRaisesNoEvent [
 	
 	| counter |
@@ -308,7 +310,7 @@ SpListPresenterSingleSelectionTest >> testUnselectNonSelectedItemRaisesNoEvent [
 	self assert: counter equals: 0
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectSelectedIndexRaisesSingleEvent [
 	
 	| counter |
@@ -321,7 +323,7 @@ SpListPresenterSingleSelectionTest >> testUnselectSelectedIndexRaisesSingleEvent
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpListPresenterSingleSelectionTest >> testUnselectSelectedIndexRemovesSelection [
 	presenter
 		selectIndex: 1;
@@ -330,7 +332,7 @@ SpListPresenterSingleSelectionTest >> testUnselectSelectedIndexRemovesSelection 
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterSingleSelectionTest >> testUnselectSelectedItemRaisesSingleEvent [
 	
 	| counter |
@@ -343,7 +345,7 @@ SpListPresenterSingleSelectionTest >> testUnselectSelectedItemRaisesSingleEvent 
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpListPresenterSingleSelectionTest >> testUnselectSelectedItemRemovesSelection [
 
 	presenter

--- a/src/Spec2-Tests/SpListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpListPresenterTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpListPresenterTest,
-	#superclass : #SpAbstractListPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpListPresenterTest',
+	#superclass : 'SpAbstractListPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpListPresenterTest >> classToTest [
 	
 	^ SpListPresenter
 ]
 
-{ #category : #'tests - header' }
+{ #category : 'tests - header' }
 SpListPresenterTest >> testHideHeaderTitleUnsetsTitle [
 
 	presenter
@@ -20,7 +22,7 @@ SpListPresenterTest >> testHideHeaderTitleUnsetsTitle [
 	self deny: presenter hasHeaderTitle
 ]
 
-{ #category : #'tests - header' }
+{ #category : 'tests - header' }
 SpListPresenterTest >> testIconFor [
 	presenter
 		items: #(#add #back #catalog);
@@ -28,7 +30,7 @@ SpListPresenterTest >> testIconFor [
 	self assert: (presenter iconFor: #add) equals: (Smalltalk ui icons iconNamed: #add)
 ]
 
-{ #category : #'tests - header' }
+{ #category : 'tests - header' }
 SpListPresenterTest >> testSetHeaderTitleHasTitle [
 
 	presenter headerTitle: 'title'.
@@ -36,7 +38,7 @@ SpListPresenterTest >> testSetHeaderTitleHasTitle [
 	self assert: presenter hasHeaderTitle
 ]
 
-{ #category : #'tests - header' }
+{ #category : 'tests - header' }
 SpListPresenterTest >> testSetHeaderTitleSetsTitle [
 
 	presenter headerTitle: 'title'.
@@ -44,7 +46,7 @@ SpListPresenterTest >> testSetHeaderTitleSetsTitle [
 	self assert: presenter headerTitle equals: 'title'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpListPresenterTest >> testWhenIconsChangedDo [
 	| icon counter |
 	counter := 0.

--- a/src/Spec2-Tests/SpListSelectionPresenterTest.class.st
+++ b/src/Spec2-Tests/SpListSelectionPresenterTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpListSelectionPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpListSelectionPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpListSelectionPresenterTest >> classToTest [
 	^ SpListSelectionPresenter
 ]

--- a/src/Spec2-Tests/SpMenuBarPresenterTest.class.st
+++ b/src/Spec2-Tests/SpMenuBarPresenterTest.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #SpMenuBarPresenterTest,
-	#superclass : #SpMenuPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpMenuBarPresenterTest',
+	#superclass : 'SpMenuPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }

--- a/src/Spec2-Tests/SpMenuButtonPresenterTest.class.st
+++ b/src/Spec2-Tests/SpMenuButtonPresenterTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpMenuButtonPresenterTest,
-	#superclass : #SpAbstractButtonPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpMenuButtonPresenterTest',
+	#superclass : 'SpAbstractButtonPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuButtonPresenterTest >> classToTest [
 
 	^ SpMenuButtonPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMenuButtonPresenterTest >> testSmokeMenu [
 	
 	presenter menu: (SpMenuPresenter new

--- a/src/Spec2-Tests/SpMenuItemPresenterTest.class.st
+++ b/src/Spec2-Tests/SpMenuItemPresenterTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpMenuItemPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpMenuItemPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuItemPresenterTest >> classToTest [
 
 	^ SpMenuItemPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMenuItemPresenterTest >> testIcon [
 
 	presenter icon: (Smalltalk ui icons iconNamed: 'smallCancel').
@@ -21,7 +23,7 @@ SpMenuItemPresenterTest >> testIcon [
 		equals: (Smalltalk ui icons iconNamed: 'smallOk')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMenuItemPresenterTest >> testName [
 
 	presenter name: 'Test'.

--- a/src/Spec2-Tests/SpMenuPresenterTest.class.st
+++ b/src/Spec2-Tests/SpMenuPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpMenuPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpMenuPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMenuPresenterTest >> classToTest [
 	^ SpMenuPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMenuPresenterTest >> testValue [ 
 
 	self assert: presenter value equals: presenter

--- a/src/Spec2-Tests/SpMillerColumnPresenterTest.class.st
+++ b/src/Spec2-Tests/SpMillerColumnPresenterTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpMillerColumnPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Miller'
+	#name : 'SpMillerColumnPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Miller',
+	#package : 'Spec2-Tests',
+	#tag : 'Miller'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMillerColumnPresenterTest >> classToTest [
 	
 	^ SpMillerColumnPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testActivateSubPresenterPushesElementToList [
 
 	| mock |
@@ -21,21 +23,21 @@ SpMillerColumnPresenterTest >> testActivateSubPresenterPushesElementToList [
 	self assert: self presenter size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testAddManyPresentersPushesThemToPresenterList [
 
 	3 timesRepeat: [self presenter addPresenter: (SpNullMillerPresenter on: SpLabelPresenter new)].
 	self assert: self presenter size equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testAddPresenterPushesItToPresenterList [
 
 	self presenter addPresenter: (SpNullMillerPresenter on: SpLabelPresenter new).
 	self assert: self presenter size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testPushModelUsesPresenterBlock [
 
 	| subpresenter |
@@ -45,7 +47,7 @@ SpMillerColumnPresenterTest >> testPushModelUsesPresenterBlock [
 	self assert: self presenter presenters first equals: subpresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testSetRootModelManyTimesPushesOnlyLastPresenterToList [
 
 	| nullMillerPresenter |
@@ -60,7 +62,7 @@ SpMillerColumnPresenterTest >> testSetRootModelManyTimesPushesOnlyLastPresenterT
 		equals: 3 asString
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testSetRootModelManyTimesPushesOnlyOnePresenterToList [
 
 	self presenter presenterBlock: [ :model | 
@@ -71,7 +73,7 @@ SpMillerColumnPresenterTest >> testSetRootModelManyTimesPushesOnlyOnePresenterTo
 	self assert: self presenter size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testSetRootModelPushesPresenterToList [
 
 	self presenter presenterBlock: [ :model | 
@@ -81,7 +83,7 @@ SpMillerColumnPresenterTest >> testSetRootModelPushesPresenterToList [
 	self assert: self presenter size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testSetRootModelResetsToSinglePresenter [
 
 	self presenter presenterBlock: [ :model | 
@@ -92,7 +94,7 @@ SpMillerColumnPresenterTest >> testSetRootModelResetsToSinglePresenter [
 	self assert: self presenter size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testSetRootModelWithPresenterDoesNotFail [
 
 	self presenter presenterBlock: [ :model | 
@@ -103,7 +105,7 @@ SpMillerColumnPresenterTest >> testSetRootModelWithPresenterDoesNotFail [
 		raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMillerColumnPresenterTest >> testSetRootModelWithoutPresenterBlockFails [
 
 	self

--- a/src/Spec2-Tests/SpMockApplication.class.st
+++ b/src/Spec2-Tests/SpMockApplication.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpMockApplication,
-	#superclass : #SpApplication,
-	#category : #'Spec2-Tests-Core-Base'
+	#name : 'SpMockApplication',
+	#superclass : 'SpApplication',
+	#category : 'Spec2-Tests-Core-Base',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMockApplication class >> defaultBackendName [
 
 	^ #Mock

--- a/src/Spec2-Tests/SpMockBackend.class.st
+++ b/src/Spec2-Tests/SpMockBackend.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SpMockBackend,
-	#superclass : #SpApplicationBackend,
-	#category : #'Spec2-Tests-Core-Base'
+	#name : 'SpMockBackend',
+	#superclass : 'SpApplicationBackend',
+	#category : 'Spec2-Tests-Core-Base',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMockBackend class >> backendName [
 
 	^ #Mock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpMockBackend >> adapterBindingsClass [
 
 	^ SpStubAdapterBindings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpMockBackend >> defaultConfigurationFor: anApplication [
 
 	^ SpMockConfiguration new

--- a/src/Spec2-Tests/SpMockConfiguration.class.st
+++ b/src/Spec2-Tests/SpMockConfiguration.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #SpMockConfiguration,
-	#superclass : #SpApplicationConfiguration,
-	#category : #'Spec2-Tests-Core-Base'
+	#name : 'SpMockConfiguration',
+	#superclass : 'SpApplicationConfiguration',
+	#category : 'Spec2-Tests-Core-Base',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Base'
 }

--- a/src/Spec2-Tests/SpMockMillerPresenter.class.st
+++ b/src/Spec2-Tests/SpMockMillerPresenter.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #SpMockMillerPresenter,
-	#superclass : #SpMillerPresenter,
+	#name : 'SpMockMillerPresenter',
+	#superclass : 'SpMillerPresenter',
 	#instVars : [
 		'activationBlock'
 	],
-	#category : #'Spec2-Tests-Miller'
+	#category : 'Spec2-Tests-Miller',
+	#package : 'Spec2-Tests',
+	#tag : 'Miller'
 }
 
-{ #category : #simulating }
+{ #category : 'simulating' }
 SpMockMillerPresenter >> activate [
 	
 	activationBlock value: (SpMillerActivation on: 1)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMockMillerPresenter >> whenActivatedDo: aBlock [
 
 	activationBlock := aBlock

--- a/src/Spec2-Tests/SpMockPesenterWithoutGetter.class.st
+++ b/src/Spec2-Tests/SpMockPesenterWithoutGetter.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #SpMockPesenterWithoutGetter,
-	#superclass : #SpPresenter,
+	#name : 'SpMockPesenterWithoutGetter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'buttonPresenter'
 	],
-	#category : #'Spec2-Tests-Utils'
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpMockPesenterWithoutGetter class >> defaultLayout [
 	^ SpBoxLayout newLeftToRight
 		add: #buttonPresenter;
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpMockPesenterWithoutGetter >> initializePresenters [
 	buttonPresenter := self newButton
 ]

--- a/src/Spec2-Tests/SpMultipleSelectionModeTest.class.st
+++ b/src/Spec2-Tests/SpMultipleSelectionModeTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpMultipleSelectionModeTest,
-	#superclass : #SpAbstractSelectionModeTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpMultipleSelectionModeTest',
+	#superclass : 'SpAbstractSelectionModeTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMultipleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged [
 
 	presenter := SpTablePresenter new. "use a TablePresenter since ListPresenter cannot sort"
@@ -23,7 +25,7 @@ SpMultipleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged 
 		equals: #( 10 8 )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMultipleSelectionModeTest >> testSelectionIsResetAfterItemsAssignment [
 
 	presenter
@@ -36,7 +38,7 @@ SpMultipleSelectionModeTest >> testSelectionIsResetAfterItemsAssignment [
 	self assert: presenter selection selectedItems asArray equals: #(  )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMultipleSelectionModeTest >> testSelectionIsResetAfterSorting [
 
 	presenter := SpTablePresenter new. "use a TablePresenter since ListPresenter cannot sort"
@@ -55,7 +57,7 @@ SpMultipleSelectionModeTest >> testSelectionIsResetAfterSorting [
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpMultipleSelectionModeTest >> testSubscriptionsAreTransfered [
 	| count |
 	count := 0.

--- a/src/Spec2-Tests/SpNotebookPresenterTest.class.st
+++ b/src/Spec2-Tests/SpNotebookPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpNotebookPresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpNotebookPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNotebookPresenterTest >> classToTest [
 	^ SpNotebookPresenter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNotebookPresenterTest >> mockPage [
 	^ SpNotebookPage
 		title: 'Mock'
@@ -17,7 +19,7 @@ SpNotebookPresenterTest >> mockPage [
 		provider: [ SpButtonPresenter new ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testAddPage [
 	self assertEmpty: presenter pages.
 	presenter addPage: self mockPage.
@@ -25,7 +27,7 @@ SpNotebookPresenterTest >> testAddPage [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testPageAt [
 	| page |
 	presenter addPage: self mockPage.
@@ -34,7 +36,7 @@ SpNotebookPresenterTest >> testPageAt [
 	self assert: (presenter pageAt: 2) equals: page
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testRemoveAfterSettingPagesWithAnArray [
 	| page |
 	
@@ -47,7 +49,7 @@ SpNotebookPresenterTest >> testRemoveAfterSettingPagesWithAnArray [
 	self assertCollection: presenter pages hasSameElements: {page}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testRemoveAll [
 	| page |
 	
@@ -59,7 +61,7 @@ SpNotebookPresenterTest >> testRemoveAll [
 	self assert: presenter pages size equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testRemoveAllCleansSelection [
 	| page |
 	
@@ -74,7 +76,7 @@ SpNotebookPresenterTest >> testRemoveAllCleansSelection [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testRemoveAllDoesNotSelectsAnyPage [
 
 	| page1 page2 selected |
@@ -98,7 +100,7 @@ SpNotebookPresenterTest >> testRemoveAllDoesNotSelectsAnyPage [
 	self assert: selected equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testRemovePage [
 	| page |
 	presenter addPage: self mockPage.
@@ -109,7 +111,7 @@ SpNotebookPresenterTest >> testRemovePage [
 	self assert: presenter pages size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testRemovePageAt [
 	| page |
 	presenter addPage: self mockPage.
@@ -120,7 +122,7 @@ SpNotebookPresenterTest >> testRemovePageAt [
 	self assertCollection: presenter pages hasSameElements: {page}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testSelectPage [
 	| mock mock2 |
 	mock := self mockPage.
@@ -131,7 +133,7 @@ SpNotebookPresenterTest >> testSelectPage [
 	self assert: presenter selectedPage equals: mock2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testSelectPageIndex [
 	| mock mock2 |
 	mock := self mockPage.
@@ -142,7 +144,7 @@ SpNotebookPresenterTest >> testSelectPageIndex [
 	self assert: presenter selectedPage equals: mock2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testWhenPagesChangedDo [
 	| counter |
 	counter := 0.
@@ -152,7 +154,7 @@ SpNotebookPresenterTest >> testWhenPagesChangedDo [
 	self assert: counter equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNotebookPresenterTest >> testWhenSelectedPageChangedDo [
 	| mock mock2 counter selected |
 	counter := 0.

--- a/src/Spec2-Tests/SpNumberInputFieldPresenterTest.class.st
+++ b/src/Spec2-Tests/SpNumberInputFieldPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpNumberInputFieldPresenterTest,
-	#superclass : #SpTextInputFieldPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpNumberInputFieldPresenterTest',
+	#superclass : 'SpTextInputFieldPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpNumberInputFieldPresenterTest >> classToTest [
 	^ SpNumberInputFieldPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenClimbRateChangedDo [
 	| count result |
 	count := 0.
@@ -22,7 +24,7 @@ SpNumberInputFieldPresenterTest >> testWhenClimbRateChangedDo [
 	self assert: result equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenDigitsChangedDo [
 	| count result |
 	count := 0.
@@ -35,7 +37,7 @@ SpNumberInputFieldPresenterTest >> testWhenDigitsChangedDo [
 	self assert: result equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenMaximumChangedDo [
 	| count result |
 	count := 0.
@@ -48,7 +50,7 @@ SpNumberInputFieldPresenterTest >> testWhenMaximumChangedDo [
 	self assert: result equals: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenMinimumChangedDo [
 	| count result |
 	count := 0.
@@ -61,7 +63,7 @@ SpNumberInputFieldPresenterTest >> testWhenMinimumChangedDo [
 	self assert: result equals: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenNumberChangedDo [
 	| count result |
 	count := 0.
@@ -74,7 +76,7 @@ SpNumberInputFieldPresenterTest >> testWhenNumberChangedDo [
 	self assert: result equals: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenNumberTypeChangedDo [
 	| count result |
 	count := 0.

--- a/src/Spec2-Tests/SpOpenOnIntExampleTest.class.st
+++ b/src/Spec2-Tests/SpOpenOnIntExampleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpOpenOnIntExampleTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples-Wrapper'
+	#name : 'SpOpenOnIntExampleTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples-Wrapper',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples-Wrapper'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpOpenOnIntExampleTest >> classToTest [
 	^ SpOpenOnIntExample
 ]

--- a/src/Spec2-Tests/SpOpenOnNilExampleTest.class.st
+++ b/src/Spec2-Tests/SpOpenOnNilExampleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpOpenOnNilExampleTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples-Wrapper'
+	#name : 'SpOpenOnNilExampleTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples-Wrapper',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples-Wrapper'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpOpenOnNilExampleTest >> classToTest [
 	^ SpOpenOnNilExample
 ]

--- a/src/Spec2-Tests/SpOpenOnStringExampleTest.class.st
+++ b/src/Spec2-Tests/SpOpenOnStringExampleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpOpenOnStringExampleTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples-Wrapper'
+	#name : 'SpOpenOnStringExampleTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples-Wrapper',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples-Wrapper'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpOpenOnStringExampleTest >> classToTest [
 	^ SpOpenOnStringExample
 ]

--- a/src/Spec2-Tests/SpOptionListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpOptionListPresenterTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SpOptionListPresenterTest,
-	#superclass : #TestCase,
+	#name : 'SpOptionListPresenterTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'dialog'
 	],
-	#category : #'Spec2-Tests-Common-Widgets'
+	#category : 'Spec2-Tests-Common-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Common-Widgets'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpOptionListPresenterTest >> newOptionsPresenterWithOneOption [
 	| optionPresenterClass optionPresenter presenter |
 	
@@ -23,7 +25,7 @@ SpOptionListPresenterTest >> newOptionsPresenterWithOneOption [
 	^ presenter
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpOptionListPresenterTest >> newOptionsPresenterWithTwoOptions [
 	| optionPresenterClass optionPresenter presenter |
 	
@@ -46,13 +48,13 @@ SpOptionListPresenterTest >> newOptionsPresenterWithTwoOptions [
 	^ presenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpOptionListPresenterTest >> tearDown [ 
 	dialog ifNotNil: [ :d | d delete].
 	super tearDown .
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testContentPanelIsEmptyWhenNoSelection [
 	| presenterClass presenter |
 	presenterClass := SpOptionListPresenter newAnonymousSubclass.
@@ -64,7 +66,7 @@ SpOptionListPresenterTest >> testContentPanelIsEmptyWhenNoSelection [
 	self assertEmpty: presenter contentLayout.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testContentPanelIsUpdatedWhenSelectionChanges [
 	| presenter optionPanel |
 	presenter := SpOptionListExample new.
@@ -80,7 +82,7 @@ SpOptionListPresenterTest >> testContentPanelIsUpdatedWhenSelectionChanges [
 		equals: presenter allOptions second class.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testDoAcceptIsExecutedOnSelectedOptionWhenAcceptingDialog [
 	| presenter optionPresenter |
 	
@@ -95,7 +97,7 @@ SpOptionListPresenterTest >> testDoAcceptIsExecutedOnSelectedOptionWhenAccepting
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testDoAcceptIsNotExecutedOnSelectedOptionWhenCancelingDialog [
 	| presenter optionPresenter |
 	
@@ -110,7 +112,7 @@ SpOptionListPresenterTest >> testDoAcceptIsNotExecutedOnSelectedOptionWhenCancel
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testFirstOptionIsSelectedWhenOpening [
 	| presenter |
 	presenter := SpOptionListExample new.
@@ -121,7 +123,7 @@ SpOptionListPresenterTest >> testFirstOptionIsSelectedWhenOpening [
 		equals: (presenter optionAt: 1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testOptionListItemHasIcon [
 	| presenter optionIndex iconColumn icon |
 	presenter := SpOptionListExample new.
@@ -135,7 +137,7 @@ SpOptionListPresenterTest >> testOptionListItemHasIcon [
 		equals: presenter allOptions first optionIcon
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testOptionListItemHasTitle [
 	| presenter optionIndex titleColumn icon |
 	presenter := SpOptionListExample new.
@@ -149,7 +151,7 @@ SpOptionListPresenterTest >> testOptionListItemHasTitle [
 		equals: presenter allOptions first optionTitle
 ]
 
-{ #category : #'tests - validation' }
+{ #category : 'tests - validation' }
 SpOptionListPresenterTest >> testValidationIsCalledOnSelectedOptionPresenter [
 	| presenter optionPresenter |
 	
@@ -164,7 +166,7 @@ SpOptionListPresenterTest >> testValidationIsCalledOnSelectedOptionPresenter [
 	self assert: (optionPresenter class propertyAt: #validated) equals: true.
 ]
 
-{ #category : #'tests - validation' }
+{ #category : 'tests - validation' }
 SpOptionListPresenterTest >> testValidationIsNotCalledOnNotSelectedOptionPresenters [
 	| presenter optionPresenter |
 	
@@ -179,7 +181,7 @@ SpOptionListPresenterTest >> testValidationIsNotCalledOnNotSelectedOptionPresent
 	self assert: (optionPresenter class propertyAt: #validated) equals: nil.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testWhenAcceptedDoIsExecutedWhenAcceptingDialog [
 	| presenter executed |
 	
@@ -194,7 +196,7 @@ SpOptionListPresenterTest >> testWhenAcceptedDoIsExecutedWhenAcceptingDialog [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionListPresenterTest >> testWhenAcceptedDoIsNotExecutedWhenCancelingDialog [
 	| presenter executed |
 	

--- a/src/Spec2-Tests/SpOptionPresenterTest.class.st
+++ b/src/Spec2-Tests/SpOptionPresenterTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SpOptionPresenterTest,
-	#superclass : #TestCase,
+	#name : 'SpOptionPresenterTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'optionPresenterClass'
 	],
-	#category : #'Spec2-Tests-Common-Widgets'
+	#category : 'Spec2-Tests-Common-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Common-Widgets'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SpOptionPresenterTest >> setUp [
 	super setUp.
 	
@@ -20,7 +22,7 @@ SpOptionPresenterTest >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionPresenterTest >> testValidationFailsWhenValidationsNotSatisfied [
 	| optionPresenter validationReport |
 	
@@ -39,7 +41,7 @@ SpOptionPresenterTest >> testValidationFailsWhenValidationsNotSatisfied [
 	self assert: validationReport errors first target equals: optionPresenter input.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOptionPresenterTest >> testValidationSucceedsWhenValidationsSatisfied [
 	| optionPresenter validationReport |
 	

--- a/src/Spec2-Tests/SpOverlayLayoutTest.class.st
+++ b/src/Spec2-Tests/SpOverlayLayoutTest.class.st
@@ -1,31 +1,33 @@
 Class {
-	#name : #SpOverlayLayoutTest,
-	#superclass : #SpLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpOverlayLayoutTest',
+	#superclass : 'SpLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpOverlayLayoutTest >> initializeTestedInstance [
 
 	layout := SpOverlayLayout new.
 	presenter layout: layout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOverlayLayoutTest >> testLayoutWithOneElementIsNotEmpty [
 
 	layout child: SpButtonPresenter new.
 	self deny: layout isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOverlayLayoutTest >> testLayoutWithOverlayWidgetIsNotEmpty [
 
 	layout addOverlay: SpButtonPresenter new.
 	self deny: layout isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOverlayLayoutTest >> testRemoveElementFromLayoutTakesItOut [
 
 	| element |
@@ -34,7 +36,7 @@ SpOverlayLayoutTest >> testRemoveElementFromLayoutTakesItOut [
 	self assert: layout isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOverlayLayoutTest >> testRemoveOverlayFromLayoutTakesItOut [
 
 	| element |
@@ -43,7 +45,7 @@ SpOverlayLayoutTest >> testRemoveOverlayFromLayoutTakesItOut [
 	self assert: layout isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpOverlayLayoutTest >> testReplaceElementKeepsSingleElement [
 
 	| replacement |

--- a/src/Spec2-Tests/SpPanedLayoutTest.class.st
+++ b/src/Spec2-Tests/SpPanedLayoutTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SpPanedLayoutTest,
-	#superclass : #SpLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpPanedLayoutTest',
+	#superclass : 'SpLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpPanedLayoutTest class >> isAbstract [
 
 	^ self == SpPanedLayoutTest
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testElementsAreAddedInOrder [
 
 	| second |
@@ -19,7 +21,7 @@ SpPanedLayoutTest >> testElementsAreAddedInOrder [
 	self assert: layout children last equals: second
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testElementsAreAddedInOrderIndependentlyOfTheConfigurationOrder [
 	| second |
 	
@@ -28,7 +30,7 @@ SpPanedLayoutTest >> testElementsAreAddedInOrderIndependentlyOfTheConfigurationO
 	self assert: layout children last equals: second
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testElementsAreAddedInOrderWhenUsingAdd [
 
 	| second |
@@ -37,7 +39,7 @@ SpPanedLayoutTest >> testElementsAreAddedInOrderWhenUsingAdd [
 	self assert: layout children last equals: second
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testElementsAreAddedInOrderWhenUsingAddWithConstraints [
 
 	| second |
@@ -46,21 +48,21 @@ SpPanedLayoutTest >> testElementsAreAddedInOrderWhenUsingAddWithConstraints [
 	self assert: layout children last equals: second
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testLayoutWithOneFirstElementIsNotEmpty [
 
 	layout first: SpButtonPresenter new.
 	self deny: layout isEmpty
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testLayoutWithOneSecondElementIsNotEmpty [
 
 	layout second: SpButtonPresenter new.
 	self deny: layout isEmpty
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testRemoveFirstElementFromLayoutTakesItOut [
 
 	| element |
@@ -69,7 +71,7 @@ SpPanedLayoutTest >> testRemoveFirstElementFromLayoutTakesItOut [
 	self assert: layout isEmpty
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testRemoveSecondElementFromLayoutTakesItOut [
 
 	| element |
@@ -78,7 +80,7 @@ SpPanedLayoutTest >> testRemoveSecondElementFromLayoutTakesItOut [
 	self assert: layout isEmpty
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testReplaceFirst [
 
 	| replacement |
@@ -87,7 +89,7 @@ SpPanedLayoutTest >> testReplaceFirst [
 	self assert: layout children first equals: replacement
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testReplaceFirstElementKeepsSingleElement [
 
 	| replacement |
@@ -96,7 +98,7 @@ SpPanedLayoutTest >> testReplaceFirstElementKeepsSingleElement [
 	self assert: layout children size equals: 1
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testReplaceFirstElementReplacesIt [
 
 	| replacement |
@@ -105,7 +107,7 @@ SpPanedLayoutTest >> testReplaceFirstElementReplacesIt [
 	self assert: layout children first equals: replacement
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testReplaceSecond [
 
 	| replacement |
@@ -115,7 +117,7 @@ SpPanedLayoutTest >> testReplaceSecond [
 	self assert: layout children second equals: replacement
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testReplaceSecondElementKeepsSingleElement [
 
 	| replacement |
@@ -124,7 +126,7 @@ SpPanedLayoutTest >> testReplaceSecondElementKeepsSingleElement [
 	self assert: layout children size equals: 1
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpPanedLayoutTest >> testReplaceSecondElementReplacesIt [
 
 	| replacement |

--- a/src/Spec2-Tests/SpPopoverPresenterTest.class.st
+++ b/src/Spec2-Tests/SpPopoverPresenterTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #SpPopoverPresenterTest,
-	#superclass : #SpSmokeTest,
+	#name : 'SpPopoverPresenterTest',
+	#superclass : 'SpSmokeTest',
 	#instVars : [
 		'ownerPresenter'
 	],
-	#category : #'Spec2-Tests-Core-Widgets'
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpPopoverPresenterTest >> classToTest [
 	
 	
 	^ SpPopoverPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpPopoverPresenterTest >> initializeTestedInstance [
 
 	"Adding an owner to be sure it some functions (relative to its owner/referenced object) 
@@ -33,7 +35,7 @@ SpPopoverPresenterTest >> initializeTestedInstance [
 			 yourself)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPopoverPresenterTest >> testPopoverPopupTakesExtentFromPresenter [
 
 	[ 
@@ -50,7 +52,7 @@ SpPopoverPresenterTest >> testPopoverPopupTakesExtentFromPresenter [
 		presenter dismiss ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPopoverPresenterTest >> testPopoverPopupTextTakesExtentFromPresenter [
 
 	[ 
@@ -76,7 +78,7 @@ SpPopoverPresenterTest >> testPopoverPopupTextTakesExtentFromPresenter [
 		presenter dismiss ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPopoverPresenterTest >> testPopoverTakesExtentFromPresenter [
 
 	self openInstance.

--- a/src/Spec2-Tests/SpPresenterTest.class.st
+++ b/src/Spec2-Tests/SpPresenterTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SpPresenterTest,
-	#superclass : #TestCase,
+	#name : 'SpPresenterTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'presenter'
 	],
-	#category : #'Spec2-Tests-Core'
+	#category : 'Spec2-Tests-Core',
+	#package : 'Spec2-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPresenterTest >> testAdapterDoesNotRemainsAsDependencyWhenReplacingIt [
 
 	presenter := SpPresenter new.
@@ -23,7 +25,7 @@ SpPresenterTest >> testAdapterDoesNotRemainsAsDependencyWhenReplacingIt [
 	self assert: presenter dependents size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPresenterTest >> testAsDialogWindow [
 
 	presenter := SpPresenter new.
@@ -32,7 +34,7 @@ SpPresenterTest >> testAsDialogWindow [
 		equals: presenter application defaultDialogWindowPresenterClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPresenterTest >> testAsModalWindow [
 
 	presenter := SpPresenter new.
@@ -41,7 +43,7 @@ SpPresenterTest >> testAsModalWindow [
 		equals: presenter application defaultModalWindowPresenterClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPresenterTest >> testAsWindow [
 
 	presenter := SpPresenter new.
@@ -50,7 +52,7 @@ SpPresenterTest >> testAsWindow [
 		equals: presenter application defaultWindowPresenterClass
 ]
 
-{ #category : #'tests - layout' }
+{ #category : 'tests - layout' }
 SpPresenterTest >> testLayoutIsDefaultLayoutWhenDefaultLayoutAndDefaultSpecDefined [
 	| presenterClass |
 	
@@ -64,7 +66,7 @@ SpPresenterTest >> testLayoutIsDefaultLayoutWhenDefaultLayoutAndDefaultSpecDefin
 		equals: SpGridLayout
 ]
 
-{ #category : #'tests - layout' }
+{ #category : 'tests - layout' }
 SpPresenterTest >> testLayoutIsNotSetWhenAlreadyInitialized [
 	| presenterClass |
 	
@@ -78,7 +80,7 @@ SpPresenterTest >> testLayoutIsNotSetWhenAlreadyInitialized [
 		equals: SpBoxLayout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPresenterTest >> testPresentersIncludesPresentersAddedToTheLayout [
 	| p1 p2 |
 	
@@ -91,7 +93,7 @@ SpPresenterTest >> testPresentersIncludesPresentersAddedToTheLayout [
 	self assert: presenter presenters equals: { p1. p2 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpPresenterTest >> testTraversePresentersDoIncludesPresentersAddedToTheLayout [
 	| p1 p2 result |
 	

--- a/src/Spec2-Tests/SpRadioButtonExampleTest.class.st
+++ b/src/Spec2-Tests/SpRadioButtonExampleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpRadioButtonExampleTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpRadioButtonExampleTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpRadioButtonExampleTest >> classToTest [
 	^ SpRadioButtonExample
 ]

--- a/src/Spec2-Tests/SpRadioButtonPresenterTest.class.st
+++ b/src/Spec2-Tests/SpRadioButtonPresenterTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpRadioButtonPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpRadioButtonPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpRadioButtonPresenterTest >> classToTest [
 	^  SpRadioButtonPresenter
 ]

--- a/src/Spec2-Tests/SpRequiredFieldValidationTest.class.st
+++ b/src/Spec2-Tests/SpRequiredFieldValidationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpRequiredFieldValidationTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpRequiredFieldValidationTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpRequiredFieldValidationTest >> testValidationIsKoWhenTextIsEmpty [
 	| validation presenter |
 	presenter := SpTextInputFieldPresenter new
@@ -15,7 +17,7 @@ SpRequiredFieldValidationTest >> testValidationIsKoWhenTextIsEmpty [
 	self deny: (validation isValid: presenter )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpRequiredFieldValidationTest >> testValidationIsKoWhenTextIsNil [
 	| validation presenter |
 	presenter := SpTextInputFieldPresenter new
@@ -26,7 +28,7 @@ SpRequiredFieldValidationTest >> testValidationIsKoWhenTextIsNil [
 	self deny: (validation isValid: presenter )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpRequiredFieldValidationTest >> testValidationIsKoWhenTextOnlyHasWhiteSpaces [
 	| validation presenter |
 	presenter := SpTextInputFieldPresenter new
@@ -37,7 +39,7 @@ SpRequiredFieldValidationTest >> testValidationIsKoWhenTextOnlyHasWhiteSpaces [
 	self deny: (validation isValid: presenter )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpRequiredFieldValidationTest >> testValidationIsOkWhenTextContainsOneChar [
 	| validation presenter |
 	presenter := SpTextInputFieldPresenter new

--- a/src/Spec2-Tests/SpSingleSelectionModeTest.class.st
+++ b/src/Spec2-Tests/SpSingleSelectionModeTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpSingleSelectionModeTest,
-	#superclass : #SpAbstractSelectionModeTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpSingleSelectionModeTest',
+	#superclass : 'SpAbstractSelectionModeTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSingleSelectionModeTest >> testDropListSelectionIsNotAffectedBySorting [
 
 	"To get the proper selection when a presenter is sorted, the selection asks the adapter to return the right element according to the sorting.
@@ -20,7 +22,7 @@ SpSingleSelectionModeTest >> testDropListSelectionIsNotAffectedBySorting [
 	self assert: presenter selection selectedItem model equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSingleSelectionModeTest >> testDropListSelectionIsResetAfterItemsAssignment [
 	presenter := SpDropListPresenter new.
 	presenter
@@ -34,7 +36,7 @@ SpSingleSelectionModeTest >> testDropListSelectionIsResetAfterItemsAssignment [
 		equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSingleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged [
 
 	presenter := SpTablePresenter new. "use a TablePresenter since ListPresenter cannot sort"
@@ -51,7 +53,7 @@ SpSingleSelectionModeTest >> testGetRightElementAfterSortingOfElementsChanged [
 	self assert: presenter selection selectedItem equals: 8
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSingleSelectionModeTest >> testSelectionIsResetAfterItemsAssignment [
 
 	presenter
@@ -64,7 +66,7 @@ SpSingleSelectionModeTest >> testSelectionIsResetAfterItemsAssignment [
 	self assert: presenter selection selectedItem equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSingleSelectionModeTest >> testSelectionIsResetAfterSorting [
 
 	presenter := SpTablePresenter new. "use a TablePresenter since ListPresenter cannot sort"
@@ -83,7 +85,7 @@ SpSingleSelectionModeTest >> testSelectionIsResetAfterSorting [
 	self assert: presenter selection selectedItem equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSingleSelectionModeTest >> testSubscriptionsAreTransfered [
 	| count |
 	count := 0.

--- a/src/Spec2-Tests/SpSliderInputPresenterTest.class.st
+++ b/src/Spec2-Tests/SpSliderInputPresenterTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpSliderInputPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpSliderInputPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderInputPresenterTest >> classToTest [
 	^ SpSliderInputPresenter
 ]

--- a/src/Spec2-Tests/SpSliderPresenterTest.class.st
+++ b/src/Spec2-Tests/SpSliderPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpSliderPresenterTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpSliderPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpSliderPresenterTest >> classToTest [
 	^ SpSliderPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpSliderPresenterTest >> initMinMax [
 
 	presenter
@@ -17,20 +19,20 @@ SpSliderPresenterTest >> initMinMax [
 		max: 100
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSliderPresenterTest >> testAbsoluteValue [
 	self initMinMax.
 	presenter absoluteValue: 0.5.
 	self assert: presenter value == 50
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSliderPresenterTest >> testAbsoluteValueToValueScales [
 	self initMinMax.
 	self assert:  (presenter absoluteValueToValue: 0.5) equals: 50
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSliderPresenterTest >> testReset [
 	self initMinMax.
 	presenter
@@ -39,7 +41,7 @@ SpSliderPresenterTest >> testReset [
 	self assert: presenter value == 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSliderPresenterTest >> testValueToAbsoluteValueScales [
 	self initMinMax.
 	self assert:  (presenter valueToAbsoluteValue: 50) equals: 0.5

--- a/src/Spec2-Tests/SpSmokeTest.class.st
+++ b/src/Spec2-Tests/SpSmokeTest.class.st
@@ -9,22 +9,24 @@ I provide openInstance and openInstance: to open it. These methods make me keep 
 - testExample tests the class side method example if exist, example should be a representative use.
 "
 Class {
-	#name : #SpSmokeTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Utils'
+	#name : 'SpSmokeTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSmokeTest class >> isAbstract [
 	^ self name = #SpSmokeTest
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSmokeTest class >> shouldInheritSelectors [
 	^ true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSmokeTest >> testExample [
 	"We do not use #shouldnt:raise: to get feedback on the CI"
 
@@ -42,7 +44,7 @@ SpSmokeTest >> testExample [
 ' , e signalerContext shortStack ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpSmokeTest >> testOpen [
 	"We do not use #shouldnt:raise: to get feedback on the CI"
 

--- a/src/Spec2-Tests/SpSpecTest.class.st
+++ b/src/Spec2-Tests/SpSpecTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpSpecTest,
-	#superclass : #SpBaseTest,
-	#category : #'Spec2-Tests-Utils'
+	#name : 'SpSpecTest',
+	#superclass : 'SpBaseTest',
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpSpecTest class >> isAbstract [
 	^ self = SpSpecTest
 ]

--- a/src/Spec2-Tests/SpStringTableColumnTest.class.st
+++ b/src/Spec2-Tests/SpStringTableColumnTest.class.st
@@ -2,12 +2,14 @@
 A SpStringTableColumnTest is a test class for testing the behavior of SpStringTableColumn
 "
 Class {
-	#name : #SpStringTableColumnTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpStringTableColumnTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpStringTableColumnTest >> testIsSortable [
 	|widget|
 	widget := SpStringTableColumn new.

--- a/src/Spec2-Tests/SpTablePresenterTest.class.st
+++ b/src/Spec2-Tests/SpTablePresenterTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SpTablePresenterTest,
-	#superclass : #SpAbstractListPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTablePresenterTest',
+	#superclass : 'SpAbstractListPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTablePresenterTest >> classToTest [
 	
 	^ SpTablePresenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpTablePresenterTest >> tearDown [ 
 	presenter delete.
 	super tearDown.
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testAddColumnRaisesColumnChangedEvent [
 
 	| columnsChanged |
@@ -28,7 +30,7 @@ SpTablePresenterTest >> testAddColumnRaisesColumnChangedEvent [
 	self assert: columnsChanged
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testAddColumnRaisesOneEventOnly [
 
 	| count |
@@ -40,7 +42,7 @@ SpTablePresenterTest >> testAddColumnRaisesOneEventOnly [
 	self assert: count equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTablePresenterTest >> testGivenSortingIsActiveWhenAffectingNewItemsThenNewItemsAreSorted [
 
 	[ 
@@ -63,7 +65,7 @@ SpTablePresenterTest >> testGivenSortingIsActiveWhenAffectingNewItemsThenNewItem
 		ensure: [ presenter delete ]
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testHideColumnHeadersDoesNotShowHeaders [
 
 	presenter hideColumnHeaders.
@@ -71,7 +73,7 @@ SpTablePresenterTest >> testHideColumnHeadersDoesNotShowHeaders [
 	self deny: presenter isShowingColumnHeaders
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testHideColumnHeadersRaisesOneEventOnly [
 
 	| count |
@@ -82,7 +84,7 @@ SpTablePresenterTest >> testHideColumnHeadersRaisesOneEventOnly [
 	self assert: count equals: 1
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testRemoveColumnRaisesColumnChangedEvent [
 	| column columnsChanged |
 
@@ -96,7 +98,7 @@ SpTablePresenterTest >> testRemoveColumnRaisesColumnChangedEvent [
 	self assert: columnsChanged
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTablePresenterTest >> testSelectedItemsReturnsRightElementAfterSortingOfElementsChanged [
 
 	[ 
@@ -117,7 +119,7 @@ SpTablePresenterTest >> testSelectedItemsReturnsRightElementAfterSortingOfElemen
 		ensure: [ presenter delete ]
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testShowColumnHeadersRaisesOneEventOnly [
 
 	| count |
@@ -128,7 +130,7 @@ SpTablePresenterTest >> testShowColumnHeadersRaisesOneEventOnly [
 	self assert: count equals: 1
 ]
 
-{ #category : #'tests - activation' }
+{ #category : 'tests - activation' }
 SpTablePresenterTest >> testShowColumnHeadersShowHeaders [
 
 	presenter showColumnHeaders.

--- a/src/Spec2-Tests/SpTestApplicationWithLocale.class.st
+++ b/src/Spec2-Tests/SpTestApplicationWithLocale.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SpTestApplicationWithLocale,
-	#superclass : #SpApplication,
+	#name : 'SpTestApplicationWithLocale',
+	#superclass : 'SpApplication',
 	#instVars : [
 		'locale'
 	],
-	#category : #'Spec2-Tests-Localization'
+	#category : 'Spec2-Tests-Localization',
+	#package : 'Spec2-Tests',
+	#tag : 'Localization'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestApplicationWithLocale >> initialize [ 
 
 	super initialize.
@@ -15,12 +17,12 @@ SpTestApplicationWithLocale >> initialize [
 	locale := Locale isoLanguage: 'en' isoCountry: 'US'.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestApplicationWithLocale >> locale [
 	^ locale
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestApplicationWithLocale >> locale: anObject [
 	locale := anObject
 ]

--- a/src/Spec2-Tests/SpTestLocalizedString.class.st
+++ b/src/Spec2-Tests/SpTestLocalizedString.class.st
@@ -1,38 +1,40 @@
 Class {
-	#name : #SpTestLocalizedString,
-	#superclass : #Object,
+	#name : 'SpTestLocalizedString',
+	#superclass : 'Object',
 	#instVars : [
 		'string',
 		'requestsCount'
 	],
-	#category : #'Spec2-Tests-Localization'
+	#category : 'Spec2-Tests-Localization',
+	#package : 'Spec2-Tests',
+	#tag : 'Localization'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTestLocalizedString class >> from: aString [
 
 	^ self new string: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestLocalizedString >> asString [ 
 	^ string asString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestLocalizedString >> initialize [ 
 
 	super initialize.
 	requestsCount := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestLocalizedString >> isEmptyOrNil [
 
 	^ self string isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestLocalizedString >> localizedForPresenter: aPresenter [ 
 
 	requestsCount := requestsCount + 1.
@@ -40,17 +42,17 @@ SpTestLocalizedString >> localizedForPresenter: aPresenter [
 	^ string, '[', aPresenter locale localeID isoString, '](', requestsCount asString, ')'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestLocalizedString >> string [
 	^ string
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestLocalizedString >> string: anObject [
 	string := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestLocalizedString >> withAccentuatedCharacter: aCharacter [
 
 

--- a/src/Spec2-Tests/SpTestPresenterWithToolbar.class.st
+++ b/src/Spec2-Tests/SpTestPresenterWithToolbar.class.st
@@ -2,15 +2,17 @@
 A presenter with a tollbar and a button to use in Window / World tests.
 "
 Class {
-	#name : #SpTestPresenterWithToolbar,
-	#superclass : #SpPresenter,
+	#name : 'SpTestPresenterWithToolbar',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'button'
 	],
-	#category : #'Spec2-Tests-Core-Support'
+	#category : 'Spec2-Tests-Core-Support',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Support'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpTestPresenterWithToolbar class >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
@@ -20,14 +22,14 @@ SpTestPresenterWithToolbar class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestPresenterWithToolbar >> initializePresenters [
 	button := self newButton
 		label: 'test';
 		yourself.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestPresenterWithToolbar >> initializeWindow: aWindowPresenter [
 	| toolbar |
 	toolbar := SpToolbarPresenter new

--- a/src/Spec2-Tests/SpTestingPointModel.class.st
+++ b/src/Spec2-Tests/SpTestingPointModel.class.st
@@ -2,44 +2,46 @@
 A testing model for testing of the class ComposablePresenterWithModel
 "
 Class {
-	#name : #SpTestingPointModel,
-	#superclass : #Model,
+	#name : 'SpTestingPointModel',
+	#superclass : 'Model',
 	#instVars : [
 		'x',
 		'y'
 	],
-	#category : #'Spec2-Tests-Utils'
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SpTestingPointModel class >> x: xInteger y: yInteger [ 
 
 	^ self new setX: xInteger setY: yInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPointModel >> setX: xValue setY: yValue [ 
 
 	x := xValue.
 	y := yValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPointModel >> x [
 	^ x
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPointModel >> x: anObject [
 	x := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPointModel >> y [
 	^ y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPointModel >> y: anObject [
 	y := anObject
 ]

--- a/src/Spec2-Tests/SpTestingPresenter.class.st
+++ b/src/Spec2-Tests/SpTestingPresenter.class.st
@@ -2,38 +2,40 @@
 A TestingComposablePresenter is a stupid composable model used to test SpecInterpreter.
 "
 Class {
-	#name : #SpTestingPresenter,
-	#superclass : #SpPresenter,
+	#name : 'SpTestingPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'list'
 	],
-	#category : #'Spec2-Tests-Utils'
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpTestingPresenter class >> defaultLayout [
 	^ SpBoxLayout newTopToBottom
 		add: #list;
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTestingPresenter class >> title [
 
 	^ 'You should not see me !'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenter >> getText [
 	^ Text new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestingPresenter >> initializePresenters [
 	list := self newList
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenter >> list [
 
 	^ list

--- a/src/Spec2-Tests/SpTestingPresenterWithAdditionalPresenters.class.st
+++ b/src/Spec2-Tests/SpTestingPresenterWithAdditionalPresenters.class.st
@@ -2,15 +2,17 @@
 This presenter contains several subpresenters that are stored in additionalSubpresentersMap plus one presenter that is stored in instance variable but does not have any public accessors.
 "
 Class {
-	#name : #SpTestingPresenterWithAdditionalPresenters,
-	#superclass : #SpPresenter,
+	#name : 'SpTestingPresenterWithAdditionalPresenters',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'subpresenter4'
 	],
-	#category : #'Spec2-Tests-Utils'
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpTestingPresenterWithAdditionalPresenters class >> defaultLayout [
 	| aLayout |
 
@@ -20,13 +22,13 @@ SpTestingPresenterWithAdditionalPresenters class >> defaultLayout [
 	^ aLayout
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenterWithAdditionalPresenters class >> keys [ 
 
 	^ #(subpresenter1 subpresenter2 subpresenter3)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestingPresenterWithAdditionalPresenters >> initializePresenters [
  
 	self class keys do: [ :aKey |

--- a/src/Spec2-Tests/SpTestingPresenterWithModel.class.st
+++ b/src/Spec2-Tests/SpTestingPresenterWithModel.class.st
@@ -7,16 +7,18 @@ A testing presenter for testing of the class SpPresenterWithModel
 	presenter openWithSpec
 "
 Class {
-	#name : #SpTestingPresenterWithModel,
-	#superclass : #SpPresenterWithModel,
+	#name : 'SpTestingPresenterWithModel',
+	#superclass : 'SpPresenterWithModel',
 	#instVars : [
 		'x',
 		'y'
 	],
-	#category : #'Spec2-Tests-Utils'
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 SpTestingPresenterWithModel class >> defaultLayout [
 	^ SpBoxLayout newLeftToRight
 		add: #x;
@@ -24,7 +26,7 @@ SpTestingPresenterWithModel class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 SpTestingPresenterWithModel class >> open [
 
 	<example>
@@ -32,14 +34,14 @@ SpTestingPresenterWithModel class >> open [
 	(self on: 1@2) open
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestingPresenterWithModel >> initializePresenters [
 	
 	x := self newTextInput.
 	y := self newTextInput.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpTestingPresenterWithModel >> modelChanged [
 
 	x text: self model x asString.
@@ -47,28 +49,28 @@ SpTestingPresenterWithModel >> modelChanged [
 	
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpTestingPresenterWithModel >> title [
 
 	^ 'Point'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenterWithModel >> x [
 	^ x
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenterWithModel >> x: anObject [
 	x := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenterWithModel >> y [
 	^ y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTestingPresenterWithModel >> y: anObject [
 	y := anObject
 ]

--- a/src/Spec2-Tests/SpTextFieldExampleTest.class.st
+++ b/src/Spec2-Tests/SpTextFieldExampleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpTextFieldExampleTest,
-	#superclass : #SpSmokeTest,
-	#category : #'Spec2-Tests-Examples'
+	#name : 'SpTextFieldExampleTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTextFieldExampleTest >> classToTest [
 	^ SpTextFieldExample
 ]

--- a/src/Spec2-Tests/SpTextInputFieldPresenterTest.class.st
+++ b/src/Spec2-Tests/SpTextInputFieldPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpTextInputFieldPresenterTest,
-	#superclass : #SpAbstractTextPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTextInputFieldPresenterTest',
+	#superclass : 'SpAbstractTextPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTextInputFieldPresenterTest >> classToTest [
 	^ SpTextInputFieldPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testBeNotPasswordIsSet [
 
 	presenter bePassword: false.
@@ -17,7 +19,7 @@ SpTextInputFieldPresenterTest >> testBeNotPasswordIsSet [
 	self deny: presenter isPassword
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testBePasswordIsSet [
 
 	presenter bePassword.
@@ -25,37 +27,37 @@ SpTextInputFieldPresenterTest >> testBePasswordIsSet [
 	self assert: presenter isPassword
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testBeTextIsSet [
 	presenter beText.
 	self deny: presenter isPassword
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testDefaultIsNotPassword [
 
 	self deny: presenter isPassword
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testDefaultMaxLengthIsZero [
 
 	self assert: presenter maxLength equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testDefaultPlaceholderIsEmpty [
 
 	self assert: presenter placeholder isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testDefaultTextIsEmpty [
 
 	self assert: presenter text isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testMaxLengthIsSet [
 
 	presenter maxLength: 10.
@@ -63,7 +65,7 @@ SpTextInputFieldPresenterTest >> testMaxLengthIsSet [
 	self assert: presenter maxLength equals: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testMaxLengthTruncatesAlreadyTypedText [
 
 	presenter text: '1234567890 ---'.
@@ -71,7 +73,7 @@ SpTextInputFieldPresenterTest >> testMaxLengthTruncatesAlreadyTypedText [
 	self assert: presenter text equals: '1234567890'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testMaxLengthTruncatesText [
 
 	presenter maxLength: 10.
@@ -79,7 +81,7 @@ SpTextInputFieldPresenterTest >> testMaxLengthTruncatesText [
 	self assert: presenter text equals: '1234567890'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testTextIsSet [
 
 	presenter text: 'aText'.
@@ -87,7 +89,7 @@ SpTextInputFieldPresenterTest >> testTextIsSet [
 	self assert: presenter text equals: 'aText'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testWhenPlaceholderChangesRaisesSingleEvent [
 
 	self
@@ -97,7 +99,7 @@ SpTextInputFieldPresenterTest >> testWhenPlaceholderChangesRaisesSingleEvent [
 		whenDoing: [ presenter placeholder: 'test' ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldPresenterTest >> testWhenTextChangesRaisesSingleEvent [
 
 	self

--- a/src/Spec2-Tests/SpTextInputFieldWithValidationPresenterTest.class.st
+++ b/src/Spec2-Tests/SpTextInputFieldWithValidationPresenterTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #SpTextInputFieldWithValidationPresenterTest,
-	#superclass : #SpAbstractTextPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTextInputFieldWithValidationPresenterTest',
+	#superclass : 'SpAbstractTextPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SpTextInputFieldWithValidationPresenterTest class >> shouldInheritSelectors [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTextInputFieldWithValidationPresenterTest >> classToTest [
 	^ SpTextInputFieldWithValidationPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldWithValidationPresenterTest >> testErrorIconIsPresentWhenValidationFails [	
 	presenter 
 		beRequired;
@@ -24,7 +26,7 @@ SpTextInputFieldWithValidationPresenterTest >> testErrorIconIsPresentWhenValidat
 	self assert: presenter statusIcon image equals: presenter errorIcon.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldWithValidationPresenterTest >> testErrorMessageIsPresentWhenValidationFails [	
 	presenter
 		name: 'city';
@@ -35,7 +37,7 @@ SpTextInputFieldWithValidationPresenterTest >> testErrorMessageIsPresentWhenVali
 	self assert: presenter statusIcon help equals: 'city is required'.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextInputFieldWithValidationPresenterTest >> testOkIconIsPresentWhenValidationIsOk [
 	presenter 
 		beRequired;

--- a/src/Spec2-Tests/SpTextPresenterTest.class.st
+++ b/src/Spec2-Tests/SpTextPresenterTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpTextPresenterTest,
-	#superclass : #SpAbstractTextPresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTextPresenterTest',
+	#superclass : 'SpAbstractTextPresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTextPresenterTest >> classToTest [
 	^ SpTextPresenter
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testEditable [
 
 	presenter beNotEditable.
@@ -37,7 +39,7 @@ SpTextPresenterTest >> testEditable [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testInsertAt [
 	
 	self initializationText.
@@ -46,7 +48,7 @@ SpTextPresenterTest >> testInsertAt [
 	self assert: presenter text equals: 'Text for insertion tests.'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testPropagateNaturalHeight [
 
 
@@ -61,7 +63,7 @@ SpTextPresenterTest >> testPropagateNaturalHeight [
 	self assert: presenter adapter widget height >= String loremIpsum asMorph height.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testPropagateNaturalHeightWithMultipleLines [
 	| string |
 
@@ -77,7 +79,7 @@ SpTextPresenterTest >> testPropagateNaturalHeightWithMultipleLines [
 	self assert: presenter adapter widget height >= (string lines size * string asMorph height).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testPropagateNaturalWidth [
 	| lipsum stringMorph expectedWidth |
 
@@ -104,7 +106,7 @@ SpTextPresenterTest >> testPropagateNaturalWidth [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testSelectLine [
 
 	presenter text: 'Text for tests.
@@ -115,7 +117,7 @@ lines'.
 	self assert: presenter selectionInterval equals: (1 to: 15)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpTextPresenterTest >> testSelectLineSecondLine [
 
 	presenter text: 'Text for tests.

--- a/src/Spec2-Tests/SpToolbarPresenterTest.class.st
+++ b/src/Spec2-Tests/SpToolbarPresenterTest.class.st
@@ -1,29 +1,31 @@
 Class {
-	#name : #SpToolbarPresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpToolbarPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpToolbarPresenterTest >> classToTest [
 
 	^ SpToolbarPresenter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SpToolbarPresenterTest >> newToolbarItem [
 	
 	^ SpToolbarButtonPresenter new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarPresenterTest >> testAddItem [
 
 	presenter addItem: SpToolbarButtonPresenter new.
 	self assert: presenter items size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarPresenterTest >> testAddItemPosition [
 	| itemLeft itemRight |
 
@@ -35,7 +37,7 @@ SpToolbarPresenterTest >> testAddItemPosition [
 	self assertCollection: presenter rightItems hasSameElements: { itemRight }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarPresenterTest >> testDisplayMode [
 
 	presenter beBoth.
@@ -47,7 +49,7 @@ SpToolbarPresenterTest >> testDisplayMode [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarPresenterTest >> testIsEmpty [ 
 
 	self assert: presenter isEmpty.
@@ -55,7 +57,7 @@ SpToolbarPresenterTest >> testIsEmpty [
 	self deny: presenter isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarPresenterTest >> testItems [ 
 	| item |
 

--- a/src/Spec2-Tests/SpToolbarToggleButtonPresenterTest.class.st
+++ b/src/Spec2-Tests/SpToolbarToggleButtonPresenterTest.class.st
@@ -2,12 +2,14 @@
 A SpToolBarToggleButtonTest is a test class for testing the behavior of SpToolBarToggleButton
 "
 Class {
-	#name : #SpToolbarToggleButtonPresenterTest,
-	#superclass : #TestCase,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpToolbarToggleButtonPresenterTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testBecomeSelectedWhenToggledAndUnselected [
 	| toggleButton |
 	toggleButton := SpToolbarToggleButtonPresenter new.
@@ -19,7 +21,7 @@ SpToolbarToggleButtonPresenterTest >> testBecomeSelectedWhenToggledAndUnselected
 	self deny: toggleButton isSelected.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testBecomeUnselectedWhenToggledAndSelected [
 	| toggleButton |
 	toggleButton := SpToolbarToggleButtonPresenter new.
@@ -31,7 +33,7 @@ SpToolbarToggleButtonPresenterTest >> testBecomeUnselectedWhenToggledAndSelected
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testSelectedBlockExecutedWhenBecomeSelected [
 
 	| toggleButton selectedBlockExecuted |
@@ -44,7 +46,7 @@ SpToolbarToggleButtonPresenterTest >> testSelectedBlockExecutedWhenBecomeSelecte
 	self assert: selectedBlockExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testSelectedBlockNotExecutedWhenAlreadySelectedAndUnselectedTriggered [
 
 	| toggleButton selectedBlockExecuted |
@@ -58,7 +60,7 @@ SpToolbarToggleButtonPresenterTest >> testSelectedBlockNotExecutedWhenAlreadySel
 	self deny: selectedBlockExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testSelectedBlockNotExecutedWhenBecomeUnselected [
 
 	| toggleButton selectedBlockExecuted |
@@ -72,7 +74,7 @@ SpToolbarToggleButtonPresenterTest >> testSelectedBlockNotExecutedWhenBecomeUnse
 	self deny: selectedBlockExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testToggleBlockExecutedWhenToggled [
 	| toggleButton toggled |
 	toggled := false.
@@ -84,7 +86,7 @@ SpToolbarToggleButtonPresenterTest >> testToggleBlockExecutedWhenToggled [
 	self assert: toggled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testUnselectedBlockExecutedWhenBecomeUnselected [
 
 	| toggleButton unselectedBlockExecuted |
@@ -98,7 +100,7 @@ SpToolbarToggleButtonPresenterTest >> testUnselectedBlockExecutedWhenBecomeUnsel
 	self assert: unselectedBlockExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testUnselectedBlockNotExecutedWhenAlreadyUnselectedAndUnselectedTriggered [
 
 	| toggleButton unselectedBlockExecuted |
@@ -112,7 +114,7 @@ SpToolbarToggleButtonPresenterTest >> testUnselectedBlockNotExecutedWhenAlreadyU
 	self deny: unselectedBlockExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpToolbarToggleButtonPresenterTest >> testUnselectedBlockNotExecutedWhenBecomeSelected [
 
 	| toggleButton unselectedBlockExecuted |

--- a/src/Spec2-Tests/SpTreePresenterTest.class.st
+++ b/src/Spec2-Tests/SpTreePresenterTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpTreePresenterTest,
-	#superclass : #SpAbstractTreePresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTreePresenterTest',
+	#superclass : 'SpAbstractTreePresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreePresenterTest >> classToTest [
 
 	^ SpTreePresenter

--- a/src/Spec2-Tests/SpTreeTablePresenterMultipleSelectionTest.class.st
+++ b/src/Spec2-Tests/SpTreeTablePresenterMultipleSelectionTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpTreeTablePresenterMultipleSelectionTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTreeTablePresenterMultipleSelectionTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeTablePresenterMultipleSelectionTest >> classToTest [
 	^ SpTreeTablePresenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpTreeTablePresenterMultipleSelectionTest >> setUp [
 	super setUp.
 	presenter
@@ -23,74 +25,74 @@ SpTreeTablePresenterMultipleSelectionTest >> setUp [
 		yourself.
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectAbsentItemGivesEmptySelection [
 
 	presenter selectItem: 4000.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectInvalidPathHasNoSelectedItems [
 
 	presenter selectPath: #(4).
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectInvalidPathHasNoSelectedPaths [
 
 	presenter selectPath: #(4).
 	self assert: presenter selection selectedPaths isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectInvalidPathsHasNoSelectedItems [
 	presenter selectPaths: { #(10 20) . #(20 20) }.
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectInvalidPathsHasNoSelectedPaths [
 	presenter selectPaths: { #(10 20) . #(20 20) }.
 	self assert: presenter selection selectedPaths isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectInvalidPathsIsEmpty [
 	presenter selectPaths: { #(40) . #(10 20)}.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemAddsItemToSelectedItemList [
 
 	presenter selectItem: 10.
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemAddsPathToSelectedPathList [
 
 	presenter selectItem: 10.
 	self assert: (presenter selection includesPath: #(1 3))
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemOutsideRangeHasNoSelectedItems [
 
 	presenter selectItem: 4000.
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemOutsideRangeHasNoSelectedPath [
 
 	presenter selectItem: 4000.
 	self assert: presenter selection selectedPaths isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeepsFirstElement [
 
 	presenter selectItem: 10.
@@ -98,7 +100,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRang
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeepsFirstPath [
 
 	presenter selectItem: 10.
@@ -108,7 +110,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRang
 		hasSameElements: #( #(1 3) )
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRangeKeepsSingleSelectedItem [
 
 	presenter selectItem: 10.
@@ -116,13 +118,13 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectItemThenSelectOutsideRang
 	self assert: presenter selection selectedItems size equals: 1
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsAddsItemsToSelectedItemList [
 	presenter selectItems: {10 . 20}.
 	self assert: (presenter selection includesItems: {10 . 20})
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsAddsPathsToSelectedPathList [
 	presenter selectItems: {10 . 20}.
 
@@ -131,34 +133,34 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsAddsPathsToSelectedP
 		hasSameElements: { #(1 3) . #(1 1 3) }
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsOutsideRangeHasNoSelectedItems [
 	presenter selectItems: {3000 . 4000}.
 	
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsOutsideRangeHasNoSelectedPaths [
 	presenter selectItems: {3000 . 4000}.
 	
 	self assert: presenter selection selectedPaths isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsOutsideRangeIsEmpty [
 	presenter selectItems: {4000 . 5000}.
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsThenSelectOutsideRangeKeepsElements [
 	presenter selectItems: {10 . 20}.
 	presenter selectItems: {4000 . 5000}.
 	self assert: (presenter selection includesItems: {10 . 20})
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsThenSelectOutsideRangeKeepsPaths [
 	presenter selectItems: {10 . 20}.
 	presenter selectItems: {5000 . 6000}.
@@ -168,7 +170,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectItemsThenSelectOutsideRan
 		hasSameElements: { #(1 1 3) . #(1 3) }
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectMultipleItemAddsAllToSelectedPathList [
 
 	presenter 
@@ -179,7 +181,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectMultipleItemAddsAllToSele
 		hasSameElements: { #(1 3) . #(1 2 3) }
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectMultipleItemsAddsAllToSelectedItemList [
 
 	presenter selectItem: 10.
@@ -188,7 +190,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectMultipleItemsAddsAllToSel
 	self assert: (presenter selection includesItem: 30).
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectMultipleItemsRaisesSelectionChangeEventMultipleTimes [
 	| events |
 	events := 0.
@@ -200,7 +202,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectMultipleItemsRaisesSelect
 	self assert: events equals: 2
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectMultiplePathsAddsAllToSelectedItemList [
 
 	presenter 
@@ -210,7 +212,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectMultiplePathsAddsAllToSel
 	self assert: (presenter selection includesItem: 6).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectMultiplePathsAddsAllToSelectedPathList [
 
 	presenter 
@@ -223,7 +225,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectMultiplePathsAddsAllToSel
 	self assert: (presenter selection includesPath: #(2 2)).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectMultiplePathsRaisesSelectionChangeEventMultipleTimes [
 	| events |
 	events := 0.
@@ -235,21 +237,21 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectMultiplePathsRaisesSelect
 	self assert: events equals: 2
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathAddsIndexToSelectedPathList [
 
 	presenter selectPath: #(1).
 	self assert: (presenter selection includesPath: #(1))
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathAddsItemToSelectedItemList [
 
 	presenter selectPath: #(1 3).
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathRaisesSelectionChangeEventWithSelectedPath [
 	| selectedPaths |
 	presenter
@@ -260,7 +262,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathRaisesSelectionChange
 	self assert: (selectedPaths includes: #(1 2)).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathThenSelectInvalidPathKeepsFirstElement [
 	
 	presenter selectPath: #(1 3).
@@ -268,7 +270,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathThenSelectInvalidPath
 	self assert: (presenter selection includesItem: 10)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathThenSelectInvalidPathKeepsFirstPath [
 	
 	presenter selectPath: #(1 3).
@@ -276,7 +278,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathThenSelectInvalidPath
 	self assert: (presenter selection includesPath: #(1 3))
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathThenSelectInvalidPathKeepsSingleSelectedItem [
 	
 	presenter selectPath: #(1 3).
@@ -286,7 +288,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathThenSelectInvalidPath
 		equals: 1
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathTwiceAddsPathToSelectedPathListOnlyOnce [
 
 	presenter selectPath: #(1 3).
@@ -296,7 +298,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathTwiceAddsPathToSelect
 		equals: #( #(1 3) )
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsAddsItemsToSelectedItemList [
 	| paths |
 	paths := { #(1 2) . #(2 2) }.
@@ -306,7 +308,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsAddsItemsToSelectedI
 	
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsAddsPathsToSelectedPathList [
 	| paths |
 	paths := { #(1 2) . #(2 2) }.
@@ -314,7 +316,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsAddsPathsToSelectedP
 	self assert: (presenter selection includesPaths: paths).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsThenSelectInvalidPathKeepsElements [
 
 	presenter 
@@ -323,7 +325,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsThenSelectInvalidPat
 	self assert: (presenter selection includesItems: #(10 6))
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsThenSelectInvalidPathKeepsPaths [
 	| paths |
 	paths := {#(1 3) . #(2 2)}.
@@ -333,7 +335,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsThenSelectInvalidPat
 	self assert: (presenter selection includesPaths: paths)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsTwiceAddsPathssToSelectedPathListOnlyOnce [
 	| paths |
 	paths := {#(1 3) . #(2 2)}.
@@ -345,7 +347,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectPathsTwiceAddsPathssToSel
 		hasSameElements: paths
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectedItemIsNilIfNothingIsSelected [
 
 	self assert: presenter selection selectedItem isNil.
@@ -355,7 +357,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectedItemIsNilIfNothingIsSel
 	self assert: presenter selection selectedItem isNil
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectedItemsIsEmptyIfNothingIsSelected [
 
 	self assert: presenter selection selectedItems isEmpty.
@@ -365,7 +367,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectedItemsIsEmptyIfNothingIs
 	self assert: presenter selection selectedItems isEmpty
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectedPathIsNilIfNothingIsSelected [
 
 	self assert: presenter selection selectedPath isNil.
@@ -375,7 +377,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectedPathIsNilIfNothingIsSel
 	self assert: presenter selection selectedPath isNil
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSelectedPathsIsEmptyIfNothingIsSelected [
 
 	self assert: presenter selection selectedPaths isEmpty.
@@ -385,7 +387,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSelectedPathsIsEmptyIfNothingIs
 	self assert: presenter selection selectedPaths isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSetSelectInvalidPathDoesNotModifySelection [
 
 	presenter whenSelectionChangedDo: [ :selection | self fail ].
@@ -394,7 +396,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSetSelectInvalidPathDoesNotModi
 	"If we arrive here and the test did not fail, we succeeded".
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testSetSelectItemOutsideRangeDoesNotModifySelection [
 
 	presenter whenSelectionChangedDo: [ :selection | self fail ].
@@ -403,7 +405,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSetSelectItemOutsideRangeDoesNo
 	"If we arrive here and the test did not fail, we succeeded"
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testSetSelectPathRaisesSelectionChangeEventWithSelectedItem [
 	| selectedItems |
 	presenter
@@ -414,7 +416,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testSetSelectPathRaisesSelectionCha
 	self assert: (selectedItems includes: 10)
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectAllRaisesSelectionEventOnce [
 	"Because it does nothing in single selection mode"
 
@@ -431,7 +433,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectAllRaisesSelectionEvent
 	self assert: nbEvents equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectAllUnselectsall [
 
 	presenter
@@ -441,7 +443,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectAllUnselectsall [
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedItemRaisesSelectionEventOnce [
 	
 	| counter |
@@ -453,7 +455,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedItemRaisesSelec
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedItemRemovesItFromSelectionList [
 
 	presenter
@@ -462,7 +464,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedItemRemovesItFr
 	self assert: (presenter selection isEmpty)
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedPathRaisesSelectionEventOnce [
 	
 	| counter |
@@ -475,7 +477,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedPathRaisesSelec
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedPathRemovesItFromSelectionList [
 
 	presenter
@@ -484,7 +486,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectSelectedPathRemovesItFr
 	self assert: (presenter selection isEmpty)
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedItemKeepsSelectionList [
 
 	presenter
@@ -493,7 +495,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedItemKeepsSele
 	self assert: presenter selection selectedItems asArray equals: #(10)
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedItemRaisesNoSelectionEvent [
 	
 	| counter |
@@ -505,7 +507,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedItemRaisesNoS
 	self assert: counter equals: 0
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedPathKeepsSelectionList [
 
 	presenter
@@ -516,7 +518,7 @@ SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedPathKeepsSele
 		equals: { #(1 2) }
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterMultipleSelectionTest >> testUnselectUnselectedPathRaisesNoSelectionEvent [
 	
 	| counter |

--- a/src/Spec2-Tests/SpTreeTablePresenterSingleSelectionTest.class.st
+++ b/src/Spec2-Tests/SpTreeTablePresenterSingleSelectionTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SpTreeTablePresenterSingleSelectionTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTreeTablePresenterSingleSelectionTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeTablePresenterSingleSelectionTest >> classToTest [
 	^ SpTreeTablePresenter
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SpTreeTablePresenterSingleSelectionTest >> setUp [
 	super setUp.
 
@@ -25,14 +27,14 @@ SpTreeTablePresenterSingleSelectionTest >> setUp [
 		yourself.
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectItemOutsideRangeUnsetsSelectedItem [
 
 	presenter selectItem: 4000.
 	self assert: presenter selection selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectItemOutsideRangeUnsetsSelectedPath [
 	
 	presenter selectItem: 4000.
@@ -41,20 +43,20 @@ SpTreeTablePresenterSingleSelectionTest >> testSelectItemOutsideRangeUnsetsSelec
 		assert: presenter selection selectedPath equals: #()
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectItemSetsSelectedItem [
 	presenter selectItem: 20.
 	self assert: presenter selection selectedItem equals: 20
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectItemSetsSelectedPath [
 
 	presenter selectItem: 20.
 	self assert: presenter selection selectedPath equals: #(1 1 3)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectMultiplePathsRaisesSelectionChangeEventMultipleTimes [
 	| events |
 	events := 0.
@@ -66,7 +68,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSelectMultiplePathsRaisesSelectio
 	self assert: events equals: 2
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectPathOutsideRangeUnsetsSelectedItem [
 	presenter selectPath: { 4 }.
 	
@@ -75,7 +77,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSelectPathOutsideRangeUnsetsSelec
 		equals: nil
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectPathOutsideRangeUnsetsSelectedPath [
 	presenter selectPath: #(4).
 
@@ -84,7 +86,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSelectPathOutsideRangeUnsetsSelec
 	 	equals: #()
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectPathSetsSelectedItem [
 
 	presenter selectPath: #(1 3).
@@ -94,7 +96,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSelectPathSetsSelectedItem [
 		equals: 10
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSelectPathSetsSelectedPath [
 
 	presenter selectPath: #(1 1).
@@ -104,7 +106,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSelectPathSetsSelectedPath [
 		equals: #(1 1)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelectionChangeEventWithUnsetItem [
 	| selectedItem |
 	presenter
@@ -113,7 +115,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSe
 	self assert: selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSelectionChangeEventWithUnsetPath [
 	| selectedPath |
 
@@ -123,7 +125,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemOutsideRangeRaisesSe
 	self assert: selectedPath equals: #()
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChangeEventWithSelectedItem [
 	| selectedElement |
 	presenter
@@ -132,7 +134,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChang
 	self assert: selectedElement equals: 20
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChangeEventWithSelectedPath [
 	| selectedPath |
 
@@ -143,7 +145,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionChang
 	self assert: selectedPath equals: #(1 1 3)
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionItemChangeEventWithSelectedItem [
 	| selectedItem |
 	presenter
@@ -152,7 +154,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionItemC
 	self assert: selectedItem equals: 10
 ]
 
-{ #category : #'tests - select-item' }
+{ #category : 'tests - select-item' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionPathChangeEventWithSelectedPath [
 	| selectedPath |
 	
@@ -163,7 +165,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectItemRaisesSelectionPathC
 	self assert: selectedPath equals: #(1 3)
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathOutsideRangeRaisesSelectionChangeEventWithUnsetItem [
 	| selectedItem |
 	presenter
@@ -173,7 +175,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathOutsideRangeRaisesSe
 	self assert: selectedItem equals: nil
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathOutsideRangeRaisesSelectionChangeEventWithUnsetPath [
 	| selectedPath |
 	presenter
@@ -183,7 +185,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathOutsideRangeRaisesSe
 	self assert: selectedPath equals: nil
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionChangeEventWithSelectedItem [
 	| selectedElement |
 
@@ -194,7 +196,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionChang
 	self assert: selectedElement equals: 10
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionChangeEventWithSelectedPath [
 	| selectedPath |
 	presenter
@@ -204,7 +206,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionChang
 	self assert: selectedPath equals: #(1 2).
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionItemChangeEventWithSelectedItem [
 	| selectedItem |
 	presenter
@@ -216,7 +218,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionItemC
 		equals: 10
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionPathChangeEventWithSelectedPath [
 	| selectedPath |
 	presenter selection
@@ -226,7 +228,7 @@ SpTreeTablePresenterSingleSelectionTest >> testSetSelectPathRaisesSelectionPathC
 	self assert: selectedPath equals: #(1 2)
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectAllRaisesSelectionEventOnce [
 	"Because it does nothing in single selection mode"
 	| events |
@@ -238,7 +240,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectAllRaisesSelectionEventOn
 	self assert: events equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectAllUnselectsSingleSelection [
 
 	presenter
@@ -247,7 +249,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectAllUnselectsSingleSelecti
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedItemDoesNotRemovesSelection [
 	presenter
 		selectItem: 10;
@@ -258,7 +260,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedItemDoesNotRem
 		equals: 10
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedItemRaisesNoEvent [
 	
 	| counter |
@@ -271,7 +273,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedItemRaisesNoEv
 	self assert: counter equals: 0
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedPathDoesNotRemovesSelection [
 	presenter
 		selectPath: #(1 1);
@@ -282,7 +284,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedPathDoesNotRem
 		equals: #(1 1)
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedPathRaisesNoEvent [
 	
 	| counter |
@@ -295,7 +297,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectNonSelectedPathRaisesNoEv
 	self assert: counter equals: 0
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedItemRaisesSingleEvent [
 	
 	| counter |
@@ -308,7 +310,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedItemRaisesSingleE
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-item' }
+{ #category : 'tests - unselect-item' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedItemRemovesSelection [
 
 	presenter
@@ -318,7 +320,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedItemRemovesSelect
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedPathRaisesSingleEvent [
 	
 	| counter |
@@ -331,7 +333,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedPathRaisesSingleE
 	self assert: counter equals: 1
 ]
 
-{ #category : #'tests - unselect-index' }
+{ #category : 'tests - unselect-index' }
 SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedPathRemovesSelection [
 	presenter
 		selectPath: #(1 1);
@@ -340,7 +342,7 @@ SpTreeTablePresenterSingleSelectionTest >> testUnselectSelectedPathRemovesSelect
 	self assert: presenter selection isEmpty
 ]
 
-{ #category : #'tests - select-index' }
+{ #category : 'tests - select-index' }
 SpTreeTablePresenterSingleSelectionTest >> testWhenSelectPathTwiceThenIsListedOnceInSelectedPaths [
 	presenter
 		selectPath: #(3 1);

--- a/src/Spec2-Tests/SpTreeTablePresenterTest.class.st
+++ b/src/Spec2-Tests/SpTreeTablePresenterTest.class.st
@@ -1,11 +1,41 @@
 Class {
-	#name : #SpTreeTablePresenterTest,
-	#superclass : #SpAbstractTreePresenterTest,
-	#category : #'Spec2-Tests-Core-Widgets'
+	#name : 'SpTreeTablePresenterTest',
+	#superclass : 'SpAbstractTreePresenterTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpTreeTablePresenterTest >> classToTest [
 
 	^ SpTreeTablePresenter
+]
+
+{ #category : 'tests' }
+SpTreeTablePresenterTest >> testAlternateRowsColor [
+
+	[ 
+		| widgetAdapter |
+		presenter
+			alternateRowsColor;
+			addColumn: (SpStringTableColumn 
+				title: 'Name' 
+				evaluated: [ : val | val asString ]);
+			addColumn: (SpStringTableColumn 
+				title: 'Description' 
+				evaluated: [ : val | val asString ]);
+			children: [ : cls | cls allSubclasses ];
+			roots: { Object };
+			open.
+		widgetAdapter := presenter adapter widget.
+		self 
+			assert: (widgetAdapter container instVarNamed: #rowColors) size
+			equals: 2 
+	] 
+	ensure: [ presenter delete ].
+
+
+
+
 ]

--- a/src/Spec2-Tests/SpValidationReportTest.class.st
+++ b/src/Spec2-Tests/SpValidationReportTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #SpValidationReportTest,
-	#superclass : #TestCase,
+	#name : 'SpValidationReportTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'report'
 	],
-	#category : #'Spec2-Tests-Validation'
+	#category : 'Spec2-Tests-Validation',
+	#package : 'Spec2-Tests',
+	#tag : 'Validation'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SpValidationReportTest >> setUp [
 	super setUp.
 	report := SpValidationReport new.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpValidationReportTest >> testCanAddValidationFailure [
 	report add: SpRequiredFieldValidation new.
 	

--- a/src/Spec2-Tests/SpVerticalBoxLayoutTest.class.st
+++ b/src/Spec2-Tests/SpVerticalBoxLayoutTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #SpVerticalBoxLayoutTest,
-	#superclass : #SpBoxLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpVerticalBoxLayoutTest',
+	#superclass : 'SpBoxLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpVerticalBoxLayoutTest >> initializeTestedInstance [
 
 	layout := SpBoxLayout newTopToBottom.
 	presenter layout: layout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpVerticalBoxLayoutTest >> testPresenterExtentFollowsChildrenExtent [
 	| label button |
 
@@ -25,7 +27,7 @@ SpVerticalBoxLayoutTest >> testPresenterExtentFollowsChildrenExtent [
 	self assert: (self heightOf: presenter) >= ((self heightOf: label) + (self heightOf: button))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpVerticalBoxLayoutTest >> testReplaceWithFixedHeight [
 	| p1 toReplace p3 replacement |
 
@@ -43,7 +45,7 @@ SpVerticalBoxLayoutTest >> testReplaceWithFixedHeight [
 	self assert: layout children equals: { p1. replacement. p3 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpVerticalBoxLayoutTest >> testReplaceWithFixedHeightAllFixed [
 	| p1 toReplace p3 replacement |
 
@@ -61,7 +63,7 @@ SpVerticalBoxLayoutTest >> testReplaceWithFixedHeightAllFixed [
 	self assert: layout children equals: { p1. replacement. p3 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpVerticalBoxLayoutTest >> testReplaceWithFixedHeightComposed [
 	| p1 layoutToReplace toReplace p3 replacement |
 

--- a/src/Spec2-Tests/SpVerticalPanedLayoutTest.class.st
+++ b/src/Spec2-Tests/SpVerticalPanedLayoutTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SpVerticalPanedLayoutTest,
-	#superclass : #SpPanedLayoutTest,
-	#category : #'Spec2-Tests-Layout'
+	#name : 'SpVerticalPanedLayoutTest',
+	#superclass : 'SpPanedLayoutTest',
+	#category : 'Spec2-Tests-Layout',
+	#package : 'Spec2-Tests',
+	#tag : 'Layout'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpVerticalPanedLayoutTest >> initializeTestedInstance [
 
 	layout := SpPanedLayout newTopToBottom.

--- a/src/Spec2-Tests/SpWindowPresenterTest.class.st
+++ b/src/Spec2-Tests/SpWindowPresenterTest.class.st
@@ -1,29 +1,31 @@
 Class {
-	#name : #SpWindowPresenterTest,
-	#superclass : #SpSpecTest,
-	#category : #'Spec2-Tests-Core'
+	#name : 'SpWindowPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core',
+	#package : 'Spec2-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpWindowPresenterTest >> classToTest [
 
 	^ SpWindowPresenter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SpWindowPresenterTest >> initializeTestedInstance [
 
 	presenter presenter: SpLabelPresenter new
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SpWindowPresenterTest >> openInstance [
 
 	window ifNil: [ 
 		window := presenter openWithLayout: SpLabelPresenter defaultLayout ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testBeNotResizeable [
 	
 	self openInstance.
@@ -34,14 +36,14 @@ SpWindowPresenterTest >> testBeNotResizeable [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testInitialPosition [
 	presenter initialPosition: 100 @ 100.
 	self openInstance.
 	self assert: window adapter widget position equals: 100 @ 100
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testIsClosed [
 	self assert: presenter isClosed.
 	self openInstance.
@@ -50,7 +52,7 @@ SpWindowPresenterTest >> testIsClosed [
 	self assert: presenter isClosed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testIsTopWindow [
 
 	self deny: presenter isTopWindow.
@@ -61,7 +63,7 @@ SpWindowPresenterTest >> testIsTopWindow [
 	self deny: presenter isTopWindow
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testRebuildPresenterDoNotLetReferencesInAnnouncer [
 	| oldSize newSize |
 	
@@ -74,7 +76,7 @@ SpWindowPresenterTest >> testRebuildPresenterDoNotLetReferencesInAnnouncer [
 	self assert: oldSize equals: newSize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testResize [
 	
 	self openInstance.
@@ -88,7 +90,7 @@ SpWindowPresenterTest >> testResize [
 		equals: 600@600
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testUsingAsWindowCanOverrideTitle [
 	| windowPresenter |
 	
@@ -105,7 +107,7 @@ SpWindowPresenterTest >> testUsingAsWindowCanOverrideTitle [
 	self assert: windowPresenter title equals: 'Title Test'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testWhenClosedDo [
 	| closed |
 	closed := false.
@@ -115,7 +117,7 @@ SpWindowPresenterTest >> testWhenClosedDo [
 	self assert: closed
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testWhenOpenedDo [
 	| opened |
 	opened := false.
@@ -124,7 +126,7 @@ SpWindowPresenterTest >> testWhenOpenedDo [
 	self assert: opened
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowPresenterTest >> testWhenWillCloseDo [
 	| willClose closed |
 

--- a/src/Spec2-Tests/SpWindowTest.class.st
+++ b/src/Spec2-Tests/SpWindowTest.class.st
@@ -2,15 +2,17 @@
 SUnit tests for SpecWindow
 "
 Class {
-	#name : #SpWindowTest,
-	#superclass : #TestCase,
+	#name : 'SpWindowTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'windowPresenter'
 	],
-	#category : #'Spec2-Tests-Core-Support'
+	#category : 'Spec2-Tests-Core-Support',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Support'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowTest >> testAboutText [
 
 	| presenter window |
@@ -27,7 +29,7 @@ SpWindowTest >> testAboutText [
 		window ifNotNil: #delete ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowTest >> testAllowedToClose [
 
 	| application appWindow |
@@ -53,7 +55,7 @@ SpWindowTest >> testAllowedToClose [
 	self assert: application windows isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowTest >> testCloseWindowRemovesItFromApplicationWindowCollection [
 
 	| application |
@@ -64,7 +66,7 @@ SpWindowTest >> testCloseWindowRemovesItFromApplicationWindowCollection [
 	self assert: application windows isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowTest >> testIsDisplayed [
 
 	"Test for case: 16800 -> ask a SpecWindow for #isDisplayed always returns true"
@@ -79,7 +81,7 @@ SpWindowTest >> testIsDisplayed [
 	self assert: windowPresenter isDisplayed not
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SpWindowTest >> testTitle [
 
 	| presenter window |

--- a/src/Spec2-Tests/package.st
+++ b/src/Spec2-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Spec2-Tests' }
+Package { #name : 'Spec2-Tests' }


### PR DESCRIPTION
# Summary

This PR proposes adding row color alternation support to the SpTreeTablePresenter to bring its functionality in line with the similar SpTablePresenter.

# Details

The SpTreeTablePrccesenter currently lacks a method for alternating row colors, a feature that is available in the SpTablePresenter. This enhancement aims to bring consistency between these two widgets by adding a new method, **alternateRowsColor**, to SpTreeTablePresenter.

# Testing:

A unit test have been added to ensure the correct behavior of the alternateRowsColor method.
Manual testing has been performed to validate the feature's functionality within the SpTreeTablePresenter.

Why is this change needed?

This change is useful to maintain consistency across Spec. Users who are familiar with the SpTablePresenter widget expect similar functionality in the SpTreeTablePresenter.


# Screenshots

<img width="1130" alt="Screenshot 2023-09-25 at 12 10 10" src="https://github.com/pharo-spec/Spec/assets/4825959/fa707322-693a-4552-9348-ac90cec6d420">
