### PR TITLE
Add a demo page for component list presenter

### DIFF
--- a/src/Spec2-Examples/SpDemoComponentListPage.class.st
+++ b/src/Spec2-Examples/SpDemoComponentListPage.class.st
@@ -1,0 +1,28 @@
+"
+Demo page for component list.
+
+"
+Class {
+	#name : 'SpDemoComponentListPage',
+	#superclass : 'SpDemoPage',
+	#category : 'Spec2-Examples-Demo-Labeled',
+	#package : 'Spec2-Examples',
+	#tag : 'Demo-Labeled'
+}
+
+{ #category : 'initialization' }
+SpDemoComponentListPage class >> pageName [
+
+	^ 'Component List'
+]
+
+{ #category : 'initialization' }
+SpDemoComponentListPage class >> priority [
+
+	^ 1310
+]
+
+{ #category : 'initialization' }
+SpDemoComponentListPage >> pageClass [
+	^ SpTransmissionComponentListExample
+]

--- a/src/Spec2-Examples/SpTransmissionComponentItemExample.class.st
+++ b/src/Spec2-Examples/SpTransmissionComponentItemExample.class.st
@@ -1,0 +1,39 @@
+"
+Represents an item example to display a class name and its comment in a Spec component list.
+"
+Class {
+	#name : 'SpTransmissionComponentItemExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'classNamePresenter',
+		'classCommentPresenter'
+	],
+	#category : 'Spec2-Examples-Demo-ComponentList',
+	#package : 'Spec2-Examples',
+	#tag : 'Demo-ComponentList'
+}
+
+{ #category : 'layout' }
+SpTransmissionComponentItemExample >> defaultLayout [ 
+
+	^ SpBoxLayout newTopToBottom 
+		add: classNamePresenter expand: false fill: false padding: 5;
+		add: classCommentPresenter expand: true fill: true padding: 5;
+		yourself.
+]
+
+{ #category : 'initialization' }
+SpTransmissionComponentItemExample >> initializePresenters [
+
+	classNamePresenter := self newLabel 
+		label: owner className;
+		addStyle: 'gray';
+		yourself.
+	classCommentPresenter := self newText text: owner comment.
+]
+
+{ #category : 'accessing - model' }
+SpTransmissionComponentItemExample >> setModelBeforeInitialization: aClass [
+
+	owner := aClass
+]

--- a/src/Spec2-Examples/SpTransmissionComponentListExample.class.st
+++ b/src/Spec2-Examples/SpTransmissionComponentListExample.class.st
@@ -98,7 +98,6 @@ SpTransmissionComponentListExample >> initializePresenters [
 		sortingBlock: [ :a :b | a name < b name ];
 		items: RPackageOrganizer default packages.
 
-	"classesPresenter := self instantiate: SpTransmissionComponentPageExample on: self"
 	classesPresenter := self newComponentList.
 ]
 

--- a/src/Spec2-Examples/SpTransmissionComponentListExample.class.st
+++ b/src/Spec2-Examples/SpTransmissionComponentListExample.class.st
@@ -1,0 +1,111 @@
+"
+This class defines the main entry point for running a Spec example of a two-pane ""browser"", however, it display the class comments on classes of the selected package. It defines a component list (`newComponentList`) to hold a list of presenters, instances of `SpTransmissionComponentItemExample`.
+
+- In the left side there are a list of system's pacakges.
+- When a package is clicked, in the right side will appear a list of presenters.
+- Each presenter is an instance of `SpTransmissionComponentItemExample`.
+- The ""glue"" between this main container and the presenter-items is implemented in `SpTransmissionComponentPageExample >> #setModel:`
+
+"
+Class {
+	#name : 'SpTransmissionComponentListExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'classesPresenter',
+		'packagesPresenter'
+	],
+	#category : 'Spec2-Examples-Demo-ComponentList',
+	#package : 'Spec2-Examples',
+	#tag : 'Demo-ComponentList'
+}
+
+{ #category : 'showing' }
+SpTransmissionComponentListExample class >> open [ 
+	<script>
+	
+	^ self new open
+]
+
+{ #category : 'initialization' }
+SpTransmissionComponentListExample >> connectPresenters [
+
+	packagesPresenter
+		transmitTo: classesPresenter
+		transform: [ :aPackage | 
+			aPackage
+				ifNotNil: [ 
+					aPackage definedClasses asArray collect: [ : packageClass |
+						self
+							instantiate: SpTransmissionComponentItemExample
+							on: packageClass ] ]
+				ifNil: [ #(  ) ] ].
+
+]
+
+{ #category : 'transmission' }
+SpTransmissionComponentListExample >> defaultInputPort [ 
+
+	^ SpListItemsPort newPresenter: classesPresenter
+
+]
+
+{ #category : 'layout' }
+SpTransmissionComponentListExample >> defaultLayout [
+
+	| packagesLayout classesLayout |
+	packagesLayout := SpBoxLayout newTopToBottom
+		add: 'Packages' expand: false;
+		add: packagesPresenter;
+		yourself.
+	
+	classesLayout := SpBoxLayout newTopToBottom
+		add: 'Classes' expand: false;
+		add: classesPresenter;
+		yourself.
+		
+	^ SpBoxLayout newTopToBottom
+		spacing: 5;
+		add: (SpPanedLayout newLeftToRight
+			add: packagesLayout;
+			add: classesLayout;
+			yourself);	
+		yourself
+]
+
+{ #category : 'ports' }
+SpTransmissionComponentListExample >> defaultOutputPort [ 
+
+	^ packagesPresenter
+]
+
+{ #category : 'initialization' }
+SpTransmissionComponentListExample >> initialize [ 
+
+	super initialize.
+	self application addStyleSheetFromString: '.application [
+        .gray [ Draw { #backgroundColor: #veryLightGray } ],
+        .red [ Draw { #backgroundColor: #red } ]
+]'.
+]
+
+{ #category : 'initialization' }
+SpTransmissionComponentListExample >> initializePresenters [
+
+	packagesPresenter := self newList.
+	packagesPresenter
+		display: [ :package | package name ];
+		displayIcon: [ self iconNamed: #package ];
+		sortingBlock: [ :a :b | a name < b name ];
+		items: RPackageOrganizer default packages.
+
+	"classesPresenter := self instantiate: SpTransmissionComponentPageExample on: self"
+	classesPresenter := self newComponentList.
+]
+
+{ #category : 'initialization' }
+SpTransmissionComponentListExample >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: 'Transmission example with component list example';
+		initialExtent: 800 @ 600
+]


### PR DESCRIPTION
This example adds a demo page in the Spec 2 demo window, to demonstrate the use of the Component List presenter. The example shows a list of packages on the left, and selecting a package updates the list on the right with user-defined items (presenters). The example shows how to use the `defaultInputPort` and `defaultOutputPort` methods.

<img width="923" alt="Screenshot 2023-10-16 at 14 26 46" src="https://github.com/pharo-spec/Spec/assets/4825959/5e173fac-4916-4d7b-b6f2-a6adbbd97a85">
