### PR TITLE
Fix MNU when using component list as input port in custom presenter

### DIFF
--- a/src/Spec2-Core/SpComponentListPresenter.class.st
+++ b/src/Spec2-Core/SpComponentListPresenter.class.st
@@ -83,6 +83,14 @@ SpComponentListPresenter >> presenters: aSequenceableCollection [
 	^ self items: aSequenceableCollection
 ]
 
+{ #category : 'transmitting' }
+SpComponentListPresenter >> transmitTo: aPresenter transform: aValuable [
+	
+	^ self defaultOutputPort
+		transmitTo: aPresenter
+		transform: aValuable
+]
+
 { #category : 'api - events' }
 SpComponentListPresenter >> whenPresentersChangedDo: aBlock [
 	"Inform when the presenter list changed (See `SpComponentListPresenter>>#presenters:`.

--- a/src/Spec2-Tests/SpComplexComponentListExample.class.st
+++ b/src/Spec2-Tests/SpComplexComponentListExample.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : 'SpComplexComponentListExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'leftPresenter',
+		'rightPresenter',
+		'toolbarPresenter'
+	],
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'instance creation' }
+SpComplexComponentListExample class >> open [
+	<example>
+	^ self new open
+]
+
+{ #category : 'initialization' }
+SpComplexComponentListExample >> connectPresenters [ 
+
+	leftPresenter
+		transmitTo: rightPresenter 
+		transform: [ : item | { item label asNumber . (item label asNumber * 2) }  ]
+]
+
+{ #category : 'layout' }
+SpComplexComponentListExample >> defaultLayout [ 
+
+	^ SpBoxLayout newTopToBottom 
+		add: toolbarPresenter expand: false;
+		add: (SpBoxLayout newLeftToRight 
+			add: leftPresenter;
+			add: rightPresenter;
+			yourself);
+		yourself.
+]
+
+{ #category : 'initialization' }
+SpComplexComponentListExample >> initializePresenters [
+
+	toolbarPresenter := self newToolbar.
+	leftPresenter := self instantiate: SpComplexComponentListLeftExample on: self.
+	rightPresenter := self instantiate: SpComplexComponentListRightExample on: self.
+]

--- a/src/Spec2-Tests/SpComplexComponentListLeftExample.class.st
+++ b/src/Spec2-Tests/SpComplexComponentListLeftExample.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : 'SpComplexComponentListLeftExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'componentListPresenter'
+	],
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'layout' }
+SpComplexComponentListLeftExample >> defaultLayout [ 
+
+	^ SpBoxLayout newTopToBottom 
+		add: componentListPresenter expand: true;
+		yourself.
+]
+
+{ #category : 'ports' }
+SpComplexComponentListLeftExample >> defaultOutputPort [ 
+
+	^ componentListPresenter 
+]
+
+{ #category : 'initialization' }
+SpComplexComponentListLeftExample >> initializePresenters [
+
+	componentListPresenter := self newComponentList
+		items: ((10 to: 20) asArray collect: #asPresenter);
+		yourself.
+]

--- a/src/Spec2-Tests/SpComplexComponentListRightExample.class.st
+++ b/src/Spec2-Tests/SpComplexComponentListRightExample.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : 'SpComplexComponentListRightExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'componentListPresenter',
+		'pageTitle'
+	],
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'transmission' }
+SpComplexComponentListRightExample >> defaultInputPort [ 
+
+	^ SpListItemsPort newPresenter: componentListPresenter
+
+]
+
+{ #category : 'layout' }
+SpComplexComponentListRightExample >> defaultLayout [ 
+
+	^ SpBoxLayout newTopToBottom 
+		add: pageTitle expand: false;
+		add: componentListPresenter;
+		yourself.
+
+
+]
+
+{ #category : 'initialization' }
+SpComplexComponentListRightExample >> initializePresenters [ 
+
+	pageTitle := self newLabel.
+	componentListPresenter := self newComponentList.
+
+]

--- a/src/Spec2-Tests/SpTransmissionWithComponentListTest.class.st
+++ b/src/Spec2-Tests/SpTransmissionWithComponentListTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'SpTransmissionWithComponentListTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
+}
+
+{ #category : 'accessing' }
+SpTransmissionWithComponentListTest >> classToTest [
+
+	^ SpComplexComponentListExample
+]
+
+{ #category : 'running' }
+SpTransmissionWithComponentListTest >> setUp [
+
+	super setUp.
+	presenter := SpComplexComponentListExample new.
+
+]
+
+{ #category : 'running' }
+SpTransmissionWithComponentListTest >> tearDown [ 
+
+	presenter delete.
+	super tearDown.
+]
+
+{ #category : 'tests' }
+SpTransmissionWithComponentListTest >> testOpen [
+
+	self shouldnt: [ presenter open ] raise: MessageNotUnderstood.
+]


### PR DESCRIPTION
This PR handles a case with transmissions along a component list in custom presenters. There is an issue in transmitTo:transform: method when connecting a transmission between presenters where the target presenter has defined an input port as a `SpListItemPort` with a component list . 

```smalltalk
defaultInputPort 

	^ SpListItemsPort newPresenter: componentListPresenter
```

The PR includes a case with a test to reproduce the problem:

```smalltalk
SpComplexComponentListExample open.
```

To fix it, the PR specializes `transmitTo:transform:` to handle problem with connecting presenters with component list.
