### PR TITLE
Guard removals of morphs in layouts

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -30,12 +30,6 @@ SpMorphicBoxAdapter >> add: aPresenter [
 	self add: aPresenter constraints: SpBoxConstraints new
 ]
 
-{ #category : 'adding' }
-SpMorphicBoxAdapter >> add: aPresenter constraints: constraints [
-
-	super add: aPresenter constraints: constraints
-]
-
 { #category : 'private' }
 SpMorphicBoxAdapter >> addConstraints: constraints toChild: childMorph [
 	"Adds constraits by child"
@@ -254,12 +248,12 @@ SpMorphicBoxAdapter >> newWrapMorph [
 { #category : 'accessing' }
 SpMorphicBoxAdapter >> remove: aPresenter [
 
-	| morph |
-	morph := aPresenter adapter widget.	
-	startPanel removeMorph: morph.
-	endPanel removeMorph: morph.
-	self verifyBoxExtent
-	
+	aPresenter adapter ifNotNil: [ :adapter |
+		| morph |
+		morph := adapter widget.
+		startPanel removeMorph: morph.
+		endPanel removeMorph: morph.
+		self verifyBoxExtent ]
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicFrameLayoutAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicFrameLayoutAdapter.class.st
@@ -24,12 +24,6 @@ SpMorphicFrameLayoutAdapter >> add: aPresenter [
 	self add: aPresenter constraints: SpBoxConstraints new
 ]
 
-{ #category : 'adding' }
-SpMorphicFrameLayoutAdapter >> add: aPresenter constraints: constraints [
-
-	super add: aPresenter constraints: constraints
-]
-
 { #category : 'factory' }
 SpMorphicFrameLayoutAdapter >> addConstraints: constraints toChild: childMorph [
 
@@ -161,11 +155,9 @@ SpMorphicFrameLayoutAdapter >> newPanelWith: aLayout label: aLabel [
 { #category : 'accessing' }
 SpMorphicFrameLayoutAdapter >> remove: aPresenter [
 
-	| morph |
-	morph := aPresenter adapter widget.	
-	framePanel removeMorph: morph.
-	self verifyBoxExtent
-	
+	aPresenter adapter ifNotNil: [ :adapter |
+		framePanel removeMorph: adapter widget.
+		self verifyBoxExtent ]
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicGridAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicGridAdapter.class.st
@@ -113,7 +113,5 @@ SpMorphicGridAdapter >> newPanel [
 { #category : 'removing' }
 SpMorphicGridAdapter >> remove: aPresenter [
 
-	| morph |
-	morph := aPresenter adapter widget.
-	widget removeMorph: morph
+	aPresenter adapter ifNotNil: [ :adapter | widget removeMorph: adapter widget ]
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicMillerAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicMillerAdapter.class.st
@@ -203,10 +203,9 @@ SpMorphicMillerAdapter >> recalculatePages [
 { #category : 'accessing' }
 SpMorphicMillerAdapter >> remove: aPresenter [
 
-	| morph |
-	needRecalculatePages := true.
-	morph := aPresenter adapter widget.	
-	innerWidget removeMorph: morph
+	aPresenter adapter ifNotNil: [ :adapter |
+		needRecalculatePages := true.
+		innerWidget removeMorph: adapter widget ]
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicTabAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTabAdapter.class.st
@@ -63,6 +63,8 @@ SpMorphicTabAdapter >> layout: aLayout [
 { #category : 'removing' }
 SpMorphicTabAdapter >> remove: aPresenter [
 
-	widget removePage: (widget pages 
-		detect: [ :each | each actualPageMorph = aPresenter adapter widget ])
+	aPresenter adapter ifNotNil: [ :adapter |
+		| morph |
+		morph := adapter widget.
+		widget removePage: (widget pages detect: [ :each | each actualPageMorph = morph ]) ]
 ]


### PR DESCRIPTION
We have a lot of crashes in the Pharo CI because of the UI. @MarcusDenker removed a catch to let us find the root of the problems. We found out that a test end up trying to remove a presenter from a layout but the presenter has no adapter.  Guille told us that it was probably because in non interactive things might happens in different order because of the different threads. 

Here I'm adding nil guards to prevent those crashes (around 1/3 of each Pharo build end up crashing because of this)

I don't know if this is a good solution to fix the root of the problem, but I have no idea how to fix better.

I also removed some methods that just called super methods