### PR TITLE
1477-Doing-an-informduring-in-SpApplication-call-twice-the-during-block

### DIFF
--- a/src/Spec2-Dialogs-Tests/SpDialogTest.class.st
+++ b/src/Spec2-Dialogs-Tests/SpDialogTest.class.st
@@ -20,6 +20,28 @@ SpDialogTest >> testInformUserDuringExecutesItsBlock [
 	self assert: executed.
 ]
 
+{ #category : 'tests - progress bar' }
+SpDialogTest >> testInformUserDuringExecutesTheBlockOnlyOnce [
+
+	| count |
+	count := 0.
+	SpInformUserDialog new 
+		informUser: 'I am a text' during: [ count := count + 1 ].
+		
+	self assert: count equals: 1
+]
+
+{ #category : 'tests - progress bar' }
+SpDialogTest >> testInformUserDuringInSpApplicationExecutesTheBlockOnlyOnce [
+
+	| count |
+	count := 0.
+	SpApplication new 
+		informUser: 'I am a text' during: [ count := count + 1 ].
+		
+	self assert: count equals: 1
+]
+
 { #category : 'tests - informUserDuring' }
 SpDialogTest >> testInformUserDuringViaApplication [
 

--- a/src/Spec2-Dialogs/SpApplication.extension.st
+++ b/src/Spec2-Dialogs/SpApplication.extension.st
@@ -36,8 +36,7 @@ SpApplication >> informUser: aString during: aBlock [
 
 	^ self newInformUser
 		title: aString; 
-		informUserDuring: aBlock;
-		 openModal
+		informUserDuring: aBlock
 ]
 
 { #category : '*Spec2-Dialogs' }


### PR DESCRIPTION
Fixing the SpApplication>>#informUser:during: was calling twice openModal and running the during block twice.
Fix #1477