### PR TITLE
Add a Spec component list example

### DIFF
--- a/src/Spec2-Tests/SpComponentListSelectionExample.class.st
+++ b/src/Spec2-Tests/SpComponentListSelectionExample.class.st
@@ -1,0 +1,60 @@
+"
+Spec presenter example entry point which contains a component list:
+
+- A left-side component list acts as a ""selector"" (class `SpComponentListSelectorExample`) and it can hold Spec presenters as items in its list.
+- A right-side list acts as a ""destination"" which is a normal list, configured in `#connectPresenters` to be updated when the selected item changes
+
+"
+Class {
+	#name : 'SpComponentListSelectionExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'selectorPresenter',
+		'destinationPresenter'
+	],
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'instance creation' }
+SpComponentListSelectionExample class >> open [
+	<example>
+	^ self new open
+]
+
+{ #category : 'initialization' }
+SpComponentListSelectionExample >> connectPresenters [ 
+
+	selectorPresenter
+		transmitTo: destinationPresenter 
+		transform: [ : item | { item label asNumber . (item label asNumber * 2) }  ]
+]
+
+{ #category : 'layout' }
+SpComponentListSelectionExample >> defaultLayout [ 
+
+	^ SpBoxLayout newLeftToRight 
+		add: selectorPresenter;
+		add: destinationPresenter;
+		yourself
+]
+
+{ #category : 'accessing' }
+SpComponentListSelectionExample >> destinationPresenter [
+
+	^ destinationPresenter
+]
+
+{ #category : 'initialization' }
+SpComponentListSelectionExample >> initializePresenters [
+
+	selectorPresenter := self instantiate: SpComponentListSelectorExample on: self.
+	destinationPresenter := self newList.
+]
+
+{ #category : 'accessing' }
+SpComponentListSelectionExample >> selectorPresenter [
+
+	^ selectorPresenter
+]

--- a/src/Spec2-Tests/SpComponentListSelectorExample.class.st
+++ b/src/Spec2-Tests/SpComponentListSelectorExample.class.st
@@ -1,0 +1,41 @@
+"
+This example acts as a selector of presenter items, this is, each of the items is a Spec component obtained through `#asPresenter`.
+"
+Class {
+	#name : 'SpComponentListSelectorExample',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'componentListPresenter'
+	],
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'layout' }
+SpComponentListSelectorExample >> defaultLayout [ 
+
+	^ SpBoxLayout newTopToBottom 
+		add: componentListPresenter expand: true;
+		yourself.
+]
+
+{ #category : 'ports' }
+SpComponentListSelectorExample >> defaultOutputPort [ 
+
+	^ componentListPresenter defaultOutputPort
+]
+
+{ #category : 'initialization' }
+SpComponentListSelectorExample >> initializePresenters [
+
+	componentListPresenter := self newComponentList
+		items: ((10 to: 20) asArray collect: #asPresenter);
+		yourself.
+]
+
+{ #category : 'api' }
+SpComponentListSelectorExample >> selectIndex: anIndex [
+
+	componentListPresenter selectIndex: anIndex
+]

--- a/src/Spec2-Tests/SpTransmissionWithComponentListTest.class.st
+++ b/src/Spec2-Tests/SpTransmissionWithComponentListTest.class.st
@@ -1,0 +1,43 @@
+Class {
+	#name : 'SpTransmissionWithComponentListTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'Spec2-Tests-Examples',
+	#package : 'Spec2-Tests',
+	#tag : 'Examples'
+}
+
+{ #category : 'accessing' }
+SpTransmissionWithComponentListTest >> classToTest [
+
+	^ SpComponentListSelectionExample
+]
+
+{ #category : 'running' }
+SpTransmissionWithComponentListTest >> setUp [
+
+	super setUp.
+	presenter := SpComponentListSelectionExample new.
+
+]
+
+{ #category : 'running' }
+SpTransmissionWithComponentListTest >> tearDown [ 
+
+	presenter delete.
+	super tearDown.
+]
+
+{ #category : 'tests' }
+SpTransmissionWithComponentListTest >> testOpen [
+
+	self shouldnt: [ presenter open ] raise: MessageNotUnderstood.
+]
+
+{ #category : 'tests' }
+SpTransmissionWithComponentListTest >> testSelection [
+
+	presenter selectorPresenter selectIndex: 1.
+	self 
+		assertCollection: presenter destinationPresenter items
+		hasSameElements: #(10 20)
+]


### PR DESCRIPTION
This PR add a presenter example in Pharo 12 to show the basic usage of a component list. The component list holds items which are collected as presenters, each time an item is clicked a detail list is updated.

Add also tests for opening and selection.