### PR TITLE
Fixed ChooserPresenter moving and filtering items

### DIFF
--- a/src/Spec2-CommonWidgets-Tests/SpChooserPresenterTest.class.st
+++ b/src/Spec2-CommonWidgets-Tests/SpChooserPresenterTest.class.st
@@ -1,11 +1,15 @@
+"
+A SpChooserPresenterTest is a test class for testing the behavior of SpChooserPresenter
+"
 Class {
 	#name : 'SpChooserPresenterTest',
 	#superclass : 'TestCase',
 	#instVars : [
 		'chooserPresenter'
 	],
-	#category : 'Spec2-CommonWidgets-Tests',
-	#package : 'Spec2-CommonWidgets-Tests'
+	#category : 'Spec2-CommonWidgets-Tests-Core',
+	#package : 'Spec2-CommonWidgets-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }
@@ -40,6 +44,47 @@ SpChooserPresenterTest >> testAddAll [
 ]
 
 { #category : 'tests' }
+SpChooserPresenterTest >> testAddAllOfFiltered [
+
+	| sourceItemsToAdd sourceItems targetItems allItems presenter |
+	sourceItemsToAdd := #( ToAdd1 ToAdd2 ).
+	sourceItems := { 'S1' } , sourceItemsToAdd.
+	targetItems := { 'T1'. 'T2' }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	presenter sourceList filterInputPresenter text: 'ToAdd'.
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItemsToAdd.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter addAll.
+
+	self
+		assert: presenter sourceList filterInputPresenter text
+		equals: ''.
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItems \ sourceItemsToAdd.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems \ sourceItemsToAdd
+]
+
+{ #category : 'tests' }
 SpChooserPresenterTest >> testAddItemUsingFilter [
 
 chooserPresenter sourceList applyFilter: 'HashedCollection'.
@@ -71,11 +116,303 @@ SpChooserPresenterTest >> testAddSelected [
 ]
 
 { #category : 'tests' }
+SpChooserPresenterTest >> testAddSelectedAllOfFiltered [
+
+	| sourceItemsToAdd sourceItems targetItems allItems presenter |
+	sourceItemsToAdd := #( ToAdd1 ToAdd2 ).
+	sourceItems := { 'S1' } , sourceItemsToAdd.
+	targetItems := { 'T1'. 'T2' }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	presenter sourceList filterInputPresenter text: 'ToAdd'.
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItemsToAdd.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter sourceList selectItems: sourceItemsToAdd.
+	presenter addSelected.
+
+	self
+		assert: presenter sourceList filterInputPresenter text
+		equals: ''.
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItems \ sourceItemsToAdd.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems \ sourceItemsToAdd
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testAddSelectedPartOfFiltered [
+
+	| sourceItemToAdd sourceItems targetItems allItems presenter |
+	sourceItemToAdd := 'ToAdd'.
+	sourceItems := {
+		               'S1'.
+		               'ToNotAdd'.
+		               sourceItemToAdd }.
+	targetItems := { 'T1'. 'T2' }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	presenter sourceList filterInputPresenter text: 'To'.
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: #( ToAdd ToNotAdd ).
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter sourceList selectItem: sourceItemToAdd.
+	presenter addSelected.
+
+	self
+		assert: presenter sourceList filterInputPresenter text
+		equals: 'To'.
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: { 'ToNotAdd' }.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: (sourceItems copyWithout: sourceItemToAdd)
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testAllRemoveThenAdd [
+
+	| targetItemToRemove sourceItemToAdd sourceItems targetItems allItems presenter |
+	targetItemToRemove := 'TargetToRemove'.
+	sourceItemToAdd := 'SourceToAdd'.
+	sourceItems := {
+		               'S1'.
+		               'S2'.
+		               sourceItemToAdd }.
+	targetItems := {
+		               'T1'.
+		               'T2'.
+		               targetItemToRemove }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter targetList selectItem: targetItemToRemove.
+	presenter removeAll.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: allItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: #(  ).
+
+	presenter sourceList selectItem: sourceItemToAdd.
+	presenter addAll.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: #(  ).
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: allItems
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testFilterBothThenRemove [
+
+	| targetItemToRemove sourceItemToAdd sourceItems targetItems allItems presenter |
+	targetItemToRemove := 'TargetToRemove'.
+	sourceItemToAdd := 'SourceToAdd'.
+	sourceItems := {
+		               'S1'.
+		               'S2'.
+		               sourceItemToAdd }.
+	targetItems := {
+		               'T1'.
+		               'T2'.
+		               targetItemToRemove }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter sourceList filterInputPresenter text: 'ToAdd'.
+	presenter targetList filterInputPresenter text: 'ToRemove'.
+
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: { sourceItemToAdd }.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter removeAll.
+
+	self
+		assert: presenter sourceList filterInputPresenter text
+		equals: 'ToAdd'.
+	self
+		assert: presenter targetList filterInputPresenter text
+		equals: ''.
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: { sourceItemToAdd }.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems , { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: (targetItems copyWithout: targetItemToRemove).
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: (targetItems copyWithout: targetItemToRemove)
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testFilteredRemoveThenAdd [
+
+	| targetItemToRemove sourceItemToAdd sourceItems targetItems allItems presenter |
+	targetItemToRemove := 'TargetToRemove'.
+	sourceItemToAdd := 'SourceToAdd'.
+	sourceItems := {
+		               'S1'.
+		               'S2'.
+		               sourceItemToAdd }.
+	targetItems := {
+		               'T1'.
+		               'T2'.
+		               targetItemToRemove }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter targetList filterInputPresenter text: 'ToRemove'.
+	presenter removeAll.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems , { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: (targetItems copyWithout: targetItemToRemove).
+
+	presenter sourceList filterInputPresenter text: 'ToAdd'.
+	presenter addAll.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements:
+		(sourceItems copyWithout: sourceItemToAdd) , { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements:
+		(targetItems copyWithout: targetItemToRemove) , { sourceItemToAdd }
+]
+
+{ #category : 'tests' }
 SpChooserPresenterTest >> testRemoveAll [
 
 	chooserPresenter removeAll.
 	self assert: chooserPresenter sourceList unfilteredItems isNotEmpty.
 	self assert: chooserPresenter targetList unfilteredItems isEmpty
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testRemoveAllOfFiltered [
+
+	| targetItemsToRemove sourceItems targetItems allItems presenter |
+	targetItemsToRemove := #( ToRemove1 ToRemove2 ).
+	sourceItems := { 'S1'. 'S2' }.
+	targetItems := { 'T1' } , targetItemsToRemove.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	presenter targetList filterInputPresenter text: 'ToRemove'.
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItemsToRemove.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter removeAll.
+
+	self
+		assert: presenter targetList filterInputPresenter text
+		equals: ''.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItems \ targetItemsToRemove.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems \ targetItemsToRemove
 ]
 
 { #category : 'tests' }
@@ -108,6 +445,193 @@ SpChooserPresenterTest >> testRemoveSelected [
 	self
 		assert: chooserPresenter targetList unfilteredItems size
 		equals: self items size - 1
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testRemoveSelectedAllOfFiltered [
+
+	| targetItemsToRemove sourceItems targetItems allItems presenter |
+	targetItemsToRemove := #( ToRemove1 ToRemove2 ).
+	sourceItems := { 'S1'. 'S2' }.
+	targetItems := { 'T1' } , targetItemsToRemove.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	presenter targetList filterInputPresenter text: 'ToRemove'.
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItemsToRemove.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter targetList selectItems: targetItemsToRemove.
+	presenter removeSelected.
+
+	self
+		assert: presenter targetList filterInputPresenter text
+		equals: ''.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: targetItems \ targetItemsToRemove.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems \ targetItemsToRemove
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testRemoveSelectedPartOfFiltered [
+
+	| targetItemToRemove sourceItems targetItems allItems presenter |
+	targetItemToRemove := 'ToRemove'.
+	sourceItems := { 'S1'. 'S2' }.
+	targetItems := {
+		               'T1'.
+		               'ToNotRemove'.
+		               targetItemToRemove }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	presenter targetList filterInputPresenter text: 'To'.
+
+	self
+		assertCollection: presenter sourceList items
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: #( ToNotRemove ToRemove ).
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter targetList selectItem: targetItemToRemove.
+	presenter removeSelected.
+
+	self
+		assert: presenter targetList filterInputPresenter text
+		equals: 'To'.
+	self
+		assertCollection: presenter targetList items
+		hasSameElements: #( ToNotRemove ).
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: (targetItems copyWithout: targetItemToRemove)
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testSelectedAddThenRemove [
+
+	| targetItemToRemove sourceItemToAdd sourceItems targetItems allItems presenter |
+	targetItemToRemove := 'TargetToRemove'.
+	sourceItemToAdd := 'SourceToAdd'.
+	sourceItems := {
+		               'S1'.
+		               'S2'.
+		               sourceItemToAdd }.
+	targetItems := {
+		               'T1'.
+		               'T2'.
+		               targetItemToRemove }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter sourceList selectItem: sourceItemToAdd.
+	presenter addSelected.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: (sourceItems copyWithout: sourceItemToAdd).
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems , { sourceItemToAdd }.
+
+	presenter targetList selectItem: targetItemToRemove.
+	presenter removeSelected.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements:
+		(sourceItems copyWithout: sourceItemToAdd) , { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements:
+		(targetItems copyWithout: targetItemToRemove) , { sourceItemToAdd }
+]
+
+{ #category : 'tests' }
+SpChooserPresenterTest >> testSelectedRemoveThenAdd [
+
+	| targetItemToRemove sourceItemToAdd sourceItems targetItems allItems presenter |
+	targetItemToRemove := 'TargetToRemove'.
+	sourceItemToAdd := 'SourceToAdd'.
+	sourceItems := {
+		               'S1'.
+		               'S2'.
+		               sourceItemToAdd }.
+	targetItems := {
+		               'T1'.
+		               'T2'.
+		               targetItemToRemove }.
+	allItems := sourceItems , targetItems.
+
+	presenter := SpChooserPresenter
+		             sourceItems: sourceItems copy
+		             chosenItems: targetItems copy.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: targetItems.
+
+	presenter targetList selectItem: targetItemToRemove.
+	presenter removeSelected.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements: sourceItems , { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements: (targetItems copyWithout: targetItemToRemove).
+
+	presenter sourceList selectItem: sourceItemToAdd.
+	presenter addSelected.
+
+	self
+		assertCollection: presenter sourceList unfilteredItems
+		hasSameElements:
+		(sourceItems copyWithout: sourceItemToAdd) , { targetItemToRemove }.
+	self
+		assertCollection: presenter targetList unfilteredItems
+		hasSameElements:
+		(targetItems copyWithout: targetItemToRemove) , { sourceItemToAdd }
 ]
 
 { #category : 'tests' }

--- a/src/Spec2-CommonWidgets-Tests/SpFilteringListPresenterTest.class.st
+++ b/src/Spec2-CommonWidgets-Tests/SpFilteringListPresenterTest.class.st
@@ -7,8 +7,9 @@ Class {
 	#instVars : [
 		'listWithFilter'
 	],
-	#category : 'Spec2-CommonWidgets-Tests',
-	#package : 'Spec2-CommonWidgets-Tests'
+	#category : 'Spec2-CommonWidgets-Tests-Core',
+	#package : 'Spec2-CommonWidgets-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'accessing' }
@@ -76,7 +77,7 @@ SpFilteringListPresenterTest >> testEnableItemSubstringFilter [
 SpFilteringListPresenterTest >> testFilterListItems [
 
 	| listItems |
-	listItems := { 
+	listItems := {
 		             OrderedCollection.
 		             Array.
 		             SequenceableCollection.
@@ -84,7 +85,7 @@ SpFilteringListPresenterTest >> testFilterListItems [
 		             Dictionary }.
 	listWithFilter items: listItems.
 	listWithFilter filterListItems: 'collection'.
-	self assertCollection: listWithFilter items hasSameElements: { 
+	self assertCollection: listWithFilter items hasSameElements: {
 			OrderedCollection.
 			SequenceableCollection }.
 	listWithFilter filterListItems: 'xyz'.
@@ -108,7 +109,7 @@ SpFilteringListPresenterTest >> testFilterListItems [
 		assertCollection: listWithFilter items
 		hasSameElements: listItems.
 	listItems := #( 'a' 'e' 'i' 'o' 'u' ).
-	listWithFilter listPresenter items: listItems.
+	listWithFilter items: listItems.
 	listWithFilter filterListItems: '5'.
 	self assertEmpty: listWithFilter items.
 	listWithFilter filterListItems: 'a'.

--- a/src/Spec2-CommonWidgets-Tests/SpFilteringListSelectableAdapterTest.class.st
+++ b/src/Spec2-CommonWidgets-Tests/SpFilteringListSelectableAdapterTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'SpFilteringListSelectableAdapterTest',
 	#superclass : 'SpAbstractAdapterTest',
-	#category : 'Spec2-CommonWidgets-Tests',
-	#package : 'Spec2-CommonWidgets-Tests'
+	#category : 'Spec2-CommonWidgets-Tests-Core',
+	#package : 'Spec2-CommonWidgets-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'accessing' }

--- a/src/Spec2-CommonWidgets-Tests/SpFilteringListSelectablePresenterTest.class.st
+++ b/src/Spec2-CommonWidgets-Tests/SpFilteringListSelectablePresenterTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'SpFilteringListSelectablePresenterTest',
 	#superclass : 'SpFilteringListPresenterTest',
-	#category : 'Spec2-CommonWidgets-Tests',
-	#package : 'Spec2-CommonWidgets-Tests'
+	#category : 'Spec2-CommonWidgets-Tests-Core',
+	#package : 'Spec2-CommonWidgets-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'accessing' }

--- a/src/Spec2-CommonWidgets/SpChooserPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpChooserPresenter.class.st
@@ -10,9 +10,7 @@ Class {
 		'sourceLabel',
 		'sourceList',
 		'targetLabel',
-		'targetList',
-		'displayBlock',
-		'sourceItems'
+		'targetList'
 	],
 	#category : 'Spec2-CommonWidgets-Core',
 	#package : 'Spec2-CommonWidgets',
@@ -102,26 +100,13 @@ SpChooserPresenter class >> title [
 { #category : 'actions' }
 SpChooserPresenter >> addAll [
 
-	| newSourceItems |
-	targetList items: targetList unfilteredItems , sourceList items.
-	newSourceItems := sourceItems asOrderedCollection.
-	newSourceItems removeAllFoundIn: targetList unfilteredItems.
-	sourceList items: newSourceItems.
-	self resetSelectedItems.
-	self sortLists
+	self moveAllFrom: sourceList to: targetList
 ]
 
 { #category : 'actions' }
 SpChooserPresenter >> addSelected [
 
-	| newSourceItems |
-	targetList items:
-		targetList unfilteredItems , sourceList selectedItems.
-	newSourceItems := sourceItems copy asOrderedCollection.
-	newSourceItems removeAllFoundIn: targetList unfilteredItems.
-	sourceList items: newSourceItems.
-	self resetSelectedItems.
-	self sortLists
+	self moveSelectedFrom: sourceList to: targetList
 ]
 
 { #category : 'accessing' }
@@ -133,12 +118,8 @@ SpChooserPresenter >> chosenItems [
 { #category : 'accessing' }
 SpChooserPresenter >> defaultChosenItems: aCollection [
 
-	| newItems |
 	targetList items: aCollection.
-	newItems := sourceList unfilteredItems copy asOrderedCollection.
-	newItems removeAllFoundIn: aCollection.
-	sourceList items: newItems.
-	self sortLists
+	sourceList items: sourceList unfilteredItems \ aCollection
 ]
 
 { #category : 'layout' }
@@ -163,9 +144,9 @@ SpChooserPresenter >> defaultLayout [
 { #category : 'accessing' }
 SpChooserPresenter >> displayBlock: aBlock [
 
-	displayBlock := aBlock.
 	sourceList display: aBlock.
-	targetList display: aBlock
+	targetList display: aBlock.
+	self initializeSortingBlocks
 ]
 
 { #category : 'initialization' }
@@ -214,7 +195,7 @@ SpChooserPresenter >> initializeLists [
 
 	sourceList := self instantiate: SpFilteringSelectableListPresenter.
 	targetList := self instantiate: SpFilteringSelectableListPresenter.
-	displayBlock := sourceList display
+	self initializeSortingBlocks
 ]
 
 { #category : 'initialization' }
@@ -226,29 +207,47 @@ SpChooserPresenter >> initializePresenters [
 	self initializeButtonBarLayout
 ]
 
+{ #category : 'initialization' }
+SpChooserPresenter >> initializeSortingBlocks [
+
+	| sortingBlock |
+	sortingBlock := sourceList display ascending.
+	sourceList sortingBlock: sortingBlock.
+	targetList sortingBlock: sortingBlock
+]
+
+{ #category : 'private' }
+SpChooserPresenter >> moveAllFrom: fromList to: toList [
+
+	| newFromListItems |
+	toList items: toList unfilteredItems , fromList items.
+	newFromListItems := OrderedCollection withAll:
+		                    fromList unfilteredItems.
+	newFromListItems removeAllFoundIn: fromList items.
+	fromList items: newFromListItems
+]
+
+{ #category : 'private' }
+SpChooserPresenter >> moveSelectedFrom: fromList to: toList [
+
+	| newFromListItems |
+	toList items: toList unfilteredItems , fromList selectedItems.
+	newFromListItems := OrderedCollection withAll:
+		                    fromList unfilteredItems.
+	newFromListItems removeAllFoundIn: fromList selectedItems.
+	fromList items: newFromListItems
+]
+
 { #category : 'actions' }
 SpChooserPresenter >> removeAll [
 
-	| newTargetItems |
-	sourceList items: targetList items , sourceList unfilteredItems.
-	newTargetItems := targetList unfilteredItems copy asOrderedCollection.
-	newTargetItems removeAllFoundIn: sourceList unfilteredItems.
-	targetList items: newTargetItems.
-	self resetSelectedItems.
-	self sortLists
+	self moveAllFrom: targetList to: sourceList
 ]
 
 { #category : 'actions' }
 SpChooserPresenter >> removeSelected [
 
-	| newTargetItems |
-	sourceList items:
-		sourceList unfilteredItems , targetList selectedItems.
-	newTargetItems := targetList unfilteredItems copy asOrderedCollection.
-	newTargetItems removeAllFoundIn: targetList selectedItems.
-	targetList items: newTargetItems.
-	self resetSelectedItems.
-	self sortLists
+	self moveSelectedFrom: targetList to: sourceList
 ]
 
 { #category : 'actions' }
@@ -258,31 +257,10 @@ SpChooserPresenter >> resetSelectedItems [
 	targetList selectItems: #().
 ]
 
-{ #category : 'actions' }
-SpChooserPresenter >> sortLists [
-
-	self sortSourceList.
-	self sortTargetList
-]
-
-{ #category : 'actions' }
-SpChooserPresenter >> sortSourceList [
-
-	sourceList items: (sourceList items sorted: displayBlock ascending)
-]
-
-{ #category : 'actions' }
-SpChooserPresenter >> sortTargetList [
-
-	targetList items: (targetList items sorted: displayBlock ascending)
-]
-
 { #category : 'accessing' }
 SpChooserPresenter >> sourceItems: aCollection [
 
-	sourceItems := aCollection.
-	sourceList items: aCollection.
-	self sortLists
+	sourceList items: aCollection
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -105,11 +105,8 @@ SpFilteringListPresenter >> filterInputPresenter [
 SpFilteringListPresenter >> filterListItems: pattern [
 	| filteredItems |
 	
-	unfilteredItems ifNil: [ 
-		unfilteredItems := self items ].
-	
 	pattern ifEmpty: [ 
-		self items: unfilteredItems.
+		listPresenter items: unfilteredItems.
 		^ self ].
 
 	filteredItems := unfilteredItems select: [ :item |
@@ -130,9 +127,10 @@ SpFilteringListPresenter >> filterText [
 SpFilteringListPresenter >> initializePresenters [
 
 	filterInputPresenter := self newTextInput
-		placeholder: 'Filter...';
-		yourself.
+		                        placeholder: 'Filter...';
+		                        yourself.
 	listPresenter := self newListToFilter.
+	unfilteredItems := #(  ).
 	self matchSubstring
 ]
 
@@ -164,7 +162,8 @@ SpFilteringListPresenter >> items [
 SpFilteringListPresenter >> items: aCollection [
 
 	listPresenter items: aCollection.
-	unfilteredItems := nil
+	unfilteredItems := aCollection.
+	self reapplyOrResetFilter
 ]
 
 { #category : 'accessing' }
@@ -205,6 +204,19 @@ SpFilteringListPresenter >> outputSelectionPort [
 ]
 
 { #category : 'api' }
+SpFilteringListPresenter >> reapplyOrResetFilter [
+
+	self filterListItems: self filterText.
+	self items ifEmpty: [ self resetFilter ]
+]
+
+{ #category : 'api' }
+SpFilteringListPresenter >> resetFilter [
+
+	self applyFilter: ''
+]
+
+{ #category : 'api' }
 SpFilteringListPresenter >> selectItem: anObject [
 	
 	listPresenter selectItem: anObject
@@ -217,9 +229,15 @@ SpFilteringListPresenter >> selectedItem [
 ]
 
 { #category : 'accessing' }
+SpFilteringListPresenter >> sortingBlock: aBlockOrNil [
+
+	listPresenter sortingBlock: aBlockOrNil
+]
+
+{ #category : 'accessing' }
 SpFilteringListPresenter >> unfilteredItems [
 
-	^ unfilteredItems ifNil: [ unfilteredItems := self items ]
+	^ unfilteredItems
 ]
 
 { #category : 'api - events' }


### PR DESCRIPTION
Fixes https://github.com/pharo-spec/Spec/issues/1340, https://github.com/pharo-project/pharo/issues/13907 and https://github.com/pharo-spec/Spec/issues/1493.
* In order to fix losing items, instead of remembering original sourceItems then trying to re-calculate from these after every move, use actual items in both lists
* Merged duplicite parts of code for moving items
* In order to fix filtering after moves: If the filter would result in empty list, clear the filter. if the filter would result in at least some shown items, reapply the filter. Always match filter field text with actually applied filter.
* Moved sorting responsibility to ListPresenters (use SpAbstractListPresenter sortingBlock) instead of Chooser replacing lists items after sorting "manually" (the chooser now only provides sortingBlock during initialization)