### PR TITLE
Defer tests to the morphic ui thread

### DIFF
--- a/src/Spec2-Code-Tests/SpCodeInteractionModelTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodeInteractionModelTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SpCodeInteractionModelTest',
-	#superclass : 'TestCase',
+	#superclass : 'SpBaseTest',
 	#instVars : [
 		'interactionModel'
 	],

--- a/src/Spec2-Code-Tests/SpCodePopoverPrintPresenterTest.class.st
+++ b/src/Spec2-Code-Tests/SpCodePopoverPrintPresenterTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SpCodePopoverPrintPresenterTest',
-	#superclass : 'TestCase',
+	#superclass : 'SpBaseTest',
 	#instVars : [
 		'presenter'
 	],

--- a/src/Spec2-Tests/SpBasePresenterTest.class.st
+++ b/src/Spec2-Tests/SpBasePresenterTest.class.st
@@ -1,0 +1,161 @@
+Class {
+	#name : 'SpBasePresenterTest',
+	#superclass : 'SpBaseTest',
+	#instVars : [
+		'presenter',
+		'window'
+	],
+	#category : 'Spec2-Tests-Utils',
+	#package : 'Spec2-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'testing' }
+SpBasePresenterTest class >> isAbstract [
+
+	^ self = SpBasePresenterTest
+]
+
+{ #category : 'accessing' }
+SpBasePresenterTest >> adapter [
+
+	^ self subclassResponsibility
+]
+
+{ #category : 'assertions' }
+SpBasePresenterTest >> assertEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: aBlock [
+	
+	self
+		assertWith: [ :times | times > 0 ]
+		timesRaisedEvent: anEventName
+		inPresenter: aPresenter
+		whenDoing: aBlock
+]
+
+{ #category : 'assertions' }
+SpBasePresenterTest >> assertWith: assertionBlock timesRaisedEvent: anEventName inPresenter: aPresenter whenDoing: actionBlock [
+	
+	| timesCalled |
+	timesCalled := 0.
+	aPresenter perform: anEventName with: [ timesCalled := timesCalled + 1 ].
+	actionBlock value.
+	assertionBlock value: timesCalled
+]
+
+{ #category : 'accessing' }
+SpBasePresenterTest >> classToTest [
+	self subclassResponsibility
+]
+
+{ #category : 'assertions' }
+SpBasePresenterTest >> denyEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: aBlock [
+	
+	self
+		assertWith: [ :times | times = 0 ]
+		timesRaisedEvent: anEventName
+		inPresenter: aPresenter
+		whenDoing: aBlock
+]
+
+{ #category : 'initialization' }
+SpBasePresenterTest >> initializeTestedInstance [
+]
+
+{ #category : 'utilities' }
+SpBasePresenterTest >> openInstance [
+
+	window ifNil: [ window := presenter open ]
+]
+
+{ #category : 'accessing' }
+SpBasePresenterTest >> presenter [
+	^ presenter
+]
+
+{ #category : 'running' }
+SpBasePresenterTest >> setUp [
+	super setUp.
+	presenter := self classToTest newApplication: self application.
+	self initializeTestedInstance
+]
+
+{ #category : 'running' }
+SpBasePresenterTest >> tearDown [
+	window ifNotNil: [ window delete ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testNewPresenterIsNotBuilt [
+	self deny: presenter isBuilt
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testNewPresenterIsNotDisplayed [
+	self deny: presenter isDisplayed
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testNonOpenPresenterDoesNotRaiseBuiltEvent [
+	| built |
+	built := false.
+	presenter whenBuiltDo: [ built := true ].
+	self deny: built
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testNonOpenPresenterDoesNotRaiseDisplayedEvent [
+	| displayed |
+	displayed := false.
+	presenter whenDisplayDo: [ displayed := true ].
+	self deny: displayed
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testOpenPresenterIsBuilt [
+	self openInstance.
+	self assert: presenter isBuilt
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testOpenPresenterIsDisplayed [
+	self openInstance.
+	self assert: presenter isDisplayed
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testOpenPresenterRaisesBuiltEvent [
+	| built |
+	built := false.
+	presenter whenBuiltDo: [ built := true ].
+	self openInstance.
+	self assert: built
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testOpenPresenterRaisesDisplayEvent [
+	| displayed |
+	displayed := false.
+	presenter whenDisplayDo: [ displayed := true ].
+	self openInstance.
+	self assert: displayed
+]
+
+{ #category : 'tests' }
+SpBasePresenterTest >> testRebuildPresenterDoNotLetReferencesInAnnouncer [
+
+	| oldSize newSize |
+	presenter build.
+	oldSize := presenter announcer subscriptions subscriptions size.
+	"rebuild"
+	presenter build.
+	newSize := presenter announcer subscriptions subscriptions size.
+
+	self assert: oldSize equals: newSize
+]
+
+{ #category : 'accessing' }
+SpBasePresenterTest >> widget [
+	
+	^ self adapter widget
+]

--- a/src/Spec2-Tests/SpBaseTest.class.st
+++ b/src/Spec2-Tests/SpBaseTest.class.st
@@ -13,7 +13,7 @@ Class {
 SpBaseTest >> application [
 
 	^ SpApplication new
-		  useMorphic;
+		  useBackend: #Morphic with: StPharoMorphicConfiguration new;
 		  yourself
 ]
 

--- a/src/Spec2-Tests/SpBaseTest.class.st
+++ b/src/Spec2-Tests/SpBaseTest.class.st
@@ -1,167 +1,48 @@
+"
+I am an abstract test class that makes all my subclass' test run on the UI thread to avoid concurrency issues.
+"
 Class {
 	#name : 'SpBaseTest',
 	#superclass : 'TestCase',
-	#instVars : [
-		'presenter',
-		'window'
-	],
 	#category : 'Spec2-Tests-Utils',
 	#package : 'Spec2-Tests',
 	#tag : 'Utils'
 }
 
-{ #category : 'testing' }
-SpBaseTest class >> isAbstract [
-
-	^ self = SpBaseTest
-]
-
-{ #category : 'accessing' }
-SpBaseTest >> adapter [
-
-	^ self subclassResponsibility
-]
-
 { #category : 'running' }
 SpBaseTest >> application [
-	
+
 	^ SpApplication new
-]
-
-{ #category : 'assertions' }
-SpBaseTest >> assertEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: aBlock [
-	
-	self
-		assertWith: [ :times | times > 0 ]
-		timesRaisedEvent: anEventName
-		inPresenter: aPresenter
-		whenDoing: aBlock
-]
-
-{ #category : 'assertions' }
-SpBaseTest >> assertWith: assertionBlock timesRaisedEvent: anEventName inPresenter: aPresenter whenDoing: actionBlock [
-	
-	| timesCalled |
-	timesCalled := 0.
-	aPresenter perform: anEventName with: [ timesCalled := timesCalled + 1 ].
-	actionBlock value.
-	assertionBlock value: timesCalled
-]
-
-{ #category : 'accessing' }
-SpBaseTest >> classToTest [
-	self subclassResponsibility
-]
-
-{ #category : 'assertions' }
-SpBaseTest >> denyEvent: anEventName isRaisedInPresenter: aPresenter whenDoing: aBlock [
-	
-	self
-		assertWith: [ :times | times = 0 ]
-		timesRaisedEvent: anEventName
-		inPresenter: aPresenter
-		whenDoing: aBlock
-]
-
-{ #category : 'initialization' }
-SpBaseTest >> initializeTestedInstance [
-]
-
-{ #category : 'utilities' }
-SpBaseTest >> openInstance [
-
-	window ifNil: [ window := presenter open ]
-]
-
-{ #category : 'accessing' }
-SpBaseTest >> presenter [
-	^ presenter
+		  useMorphic;
+		  yourself
 ]
 
 { #category : 'running' }
-SpBaseTest >> setUp [
-	super setUp.
-	presenter := self classToTest newApplication: self application.
-	self initializeTestedInstance
+SpBaseTest >> run [
+
+	| finished result |
+	UIManager default uiProcess == Processor activeProcess ifTrue: [
+		^ super run ].
+
+	finished := Semaphore new.
+	self application defer: [
+		result := super run.
+		finished signal ].
+	finished wait.
+	^ result
 ]
 
 { #category : 'running' }
-SpBaseTest >> tearDown [
-	window ifNotNil: [ window delete ].
-	super tearDown
-]
+SpBaseTest >> run: aResult [
 
-{ #category : 'tests' }
-SpBaseTest >> testNewPresenterIsNotBuilt [
-	self deny: presenter isBuilt
-]
+	| finished result |
+	UIManager default uiProcess == Processor activeProcess ifTrue: [
+		^ super run: aResult ].
 
-{ #category : 'tests' }
-SpBaseTest >> testNewPresenterIsNotDisplayed [
-	self deny: presenter isDisplayed
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testNonOpenPresenterDoesNotRaiseBuiltEvent [
-	| built |
-	built := false.
-	presenter whenBuiltDo: [ built := true ].
-	self deny: built
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testNonOpenPresenterDoesNotRaiseDisplayedEvent [
-	| displayed |
-	displayed := false.
-	presenter whenDisplayDo: [ displayed := true ].
-	self deny: displayed
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testOpenPresenterIsBuilt [
-	self openInstance.
-	self assert: presenter isBuilt
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testOpenPresenterIsDisplayed [
-	self openInstance.
-	self assert: presenter isDisplayed
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testOpenPresenterRaisesBuiltEvent [
-	| built |
-	built := false.
-	presenter whenBuiltDo: [ built := true ].
-	self openInstance.
-	self assert: built
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testOpenPresenterRaisesDisplayEvent [
-	| displayed |
-	displayed := false.
-	presenter whenDisplayDo: [ displayed := true ].
-	self openInstance.
-	self assert: displayed
-]
-
-{ #category : 'tests' }
-SpBaseTest >> testRebuildPresenterDoNotLetReferencesInAnnouncer [
-
-	| oldSize newSize |
-	presenter build.
-	oldSize := presenter announcer subscriptions subscriptions size.
-	"rebuild"
-	presenter build.
-	newSize := presenter announcer subscriptions subscriptions size.
-
-	self assert: oldSize equals: newSize
-]
-
-{ #category : 'accessing' }
-SpBaseTest >> widget [
-	
-	^ self adapter widget
+	finished := Semaphore new.
+	self application backend defer: [
+		result := super run: aResult.
+		finished signal ].
+	finished wait.
+	^ result
 ]

--- a/src/Spec2-Tests/SpSpecTest.class.st
+++ b/src/Spec2-Tests/SpSpecTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SpSpecTest',
-	#superclass : 'SpBaseTest',
+	#superclass : 'SpBasePresenterTest',
 	#category : 'Spec2-Tests-Utils',
 	#package : 'Spec2-Tests',
 	#tag : 'Utils'


### PR DESCRIPTION
Make Spec tests run in the UI thread to avoid concurrency issues.

The problem is more detailed in here: https://github.com/pharo-project/pharo/issues/12502

Problem summary: during the test run in the CI, tests and morphic run in separate tests.
Thus, a test might change a graphic element during the morphic ui draw and break it.
If an exception happens in a thread other than the test thread, the process quits and stops the test run with an unexpected outcome.