### PR TITLE
Set the minWidth and the minHeight of the endPanel created for a box layout

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -208,6 +208,7 @@ SpMorphicBoxAdapter >> newHorizontal [
 			listDirection: #leftToRight;
 			hResizing: #shrinkWrap;
 			width: 0;
+			minWidth: 0; "Otherwise an empty endPanel has a width of 2 pixels due to Morph>>#minWidth."
 			yourself);
 	  yourself
 ]
@@ -232,6 +233,7 @@ SpMorphicBoxAdapter >> newVertical [
 			listDirection: #topToBottom;
 			vResizing: #shrinkWrap;
 			height: 0;
+			minHeight: 0; "Otherwise an empty endPanel has a height of 2 pixels due to Morph>>#minHeight."
 			yourself);
 		yourself
 ]


### PR DESCRIPTION
See issue https://github.com/pharo-project/pharo/issues/15830. As described there, this PR:
* Sets the `minWidth` of an `endPanel` in a horizontal box layout
*  Sets the `minHeight` of an `endPanel` in a vertical box layout

Please apply this fix to Pharo 11 as well. Thank you!