### PR TITLE
Improve SpSelectDialog for handling line splitting texts

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyle.class.st
@@ -129,6 +129,7 @@ SpStyle class >> defaultStyleSheetData [
 		.lines8 [ Geometry { #minHeight: 160, #height: 160 } ] ],
 	.textInputField [ Geometry { #height: 24, #minHeight: 24 } ],
 	.textSearchField [ Geometry { #height: 24, #minHeight: 24 } ],
+	.textDisabled [ Draw { #backgroundColor: EnvironmentColor(#window) } ],
 	.code [ Font { #name: EnvironmentFont(#code) } ], 
 	.codeLight [ Draw { #backgroundColor: #white } ],
 	.codeDark [ Draw { #backgroundColor: #212121 } ],

--- a/src/Spec2-Dialogs/SpSelectDialog.class.st
+++ b/src/Spec2-Dialogs/SpSelectDialog.class.st
@@ -22,17 +22,6 @@ SpSelectDialog class >> defaultExtent [
 	^ 450@300
 ]
 
-{ #category : 'layout' }
-SpSelectDialog class >> defaultLayout [
-
-	^ SpBoxLayout newTopToBottom
-		borderWidth: 5;
-		spacing: 5;
-		add: #label expand: false;
-		add: #list;
-		yourself
-]
-
 { #category : 'documentation' }
 SpSelectDialog class >> documentFactoryMethodSelector [
 	
@@ -84,6 +73,18 @@ SpSelectDialog >> acceptLabel: aString [
 	acceptLabel := aString
 ]
 
+{ #category : 'private' }
+SpSelectDialog >> calculateLabelHeight [
+
+	| labelText  |
+	labelText := label text.
+
+	labelText ifEmpty: [ ^ TextStyle defaultFont height ].
+
+	^ (labelText lineHeightsWrappingAtWidth: self extent y - 20) sum + 20
+	
+]
+
 { #category : 'api' }
 SpSelectDialog >> cancelLabel [
 
@@ -94,6 +95,17 @@ SpSelectDialog >> cancelLabel [
 SpSelectDialog >> cancelLabel: aString [
 
 	cancelLabel := aString
+]
+
+{ #category : 'layout' }
+SpSelectDialog >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		borderWidth: 5;
+		spacing: 5;
+		add: #label height: self calculateLabelHeight;
+		add: #list;
+		yourself
 ]
 
 { #category : 'api' }
@@ -139,7 +151,12 @@ SpSelectDialog >> initializeDialogWindow: aDialogWindowPresenter [
 { #category : 'initialization' }
 SpSelectDialog >> initializePresenters [
 
-	label := self newLabel.
+	label := self newText
+		beNotEditable;
+		withoutScrollBars;
+		addStyle: 'textDisabled';
+		yourself.
+		
 	list := self newList.
 	
 	list addStyle: 'spSelectList'.
@@ -172,7 +189,7 @@ SpSelectDialog >> items: aCollection [
 { #category : 'api' }
 SpSelectDialog >> label: aString [
 
-	label label: aString
+	label text: aString asText trim
 ]
 
 { #category : 'api - showing' }

--- a/src/Spec2-Dialogs/Text.extension.st
+++ b/src/Spec2-Dialogs/Text.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : 'Text' }
+
+{ #category : '*Spec2-Dialogs' }
+Text >> lineHeightsWrappingAtWidth: aMaxWidth [ 
+	
+	| lineWidth maxLineHeight font |
+	
+	lineWidth := 0.
+	maxLineHeight := 0.
+		
+	^ Array streamContents: [ :stream | 
+		self withIndexDo: [ :aCharacter :anIndex |
+				font := self fontAt: anIndex.
+				lineWidth := lineWidth + (font widthOf: aCharacter).
+				
+				(lineWidth > aMaxWidth or: [ aCharacter = Character cr ])
+					ifTrue: [ 
+						stream nextPut: maxLineHeight.
+						lineWidth := font widthOf: aCharacter.
+					].
+				
+				maxLineHeight := maxLineHeight max: font height.
+			 ].
+		
+		stream nextPut: maxLineHeight
+		]
+]


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/16403

- Adding style for disabled text presenter
- Adding extension method to text to calculate line heights with wrapping.
- SpSelectDialog layout the label using a text taking in account the wrapping and height.