### PR TITLE
Fix selection bug in SpFilteringSelectableListPresenter

### DIFF
--- a/src/Spec2-CommonWidgets/SpChooserPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpChooserPresenter.class.st
@@ -232,8 +232,7 @@ SpChooserPresenter >> moveSelectedFrom: fromList to: toList [
 
 	| newFromListItems |
 	toList items: toList unfilteredItems , fromList selectedItems.
-	newFromListItems := OrderedCollection withAll:
-		                    fromList unfilteredItems.
+	newFromListItems := OrderedCollection withAll: fromList unfilteredItems.
 	newFromListItems removeAllFoundIn: fromList selectedItems.
 	fromList items: newFromListItems
 ]

--- a/src/Spec2-CommonWidgets/SpFilteringSelectableListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringSelectableListPresenter.class.st
@@ -100,6 +100,14 @@ SpFilteringSelectableListPresenter >> initializePresenters [
 		toAction: [ self activateAll ]
 ]
 
+{ #category : 'api' }
+SpFilteringSelectableListPresenter >> items: aCollection [
+	"If the items are changing, we need to remove the items that are not present anymore from the collection."
+
+	super items: aCollection.
+	self selectedItems: (selectedItems select: [ :item | aCollection includes: item ])
+]
+
 { #category : 'private' }
 SpFilteringSelectableListPresenter >> listColumns [
 	| column |
@@ -187,6 +195,11 @@ SpFilteringSelectableListPresenter >> selectItems: aCollection [
 SpFilteringSelectableListPresenter >> selectedItems [
 
 	^ selectedItems sorted: [ :a :b | (self items indexOf: a) < (self items indexOf: b) ]
+]
+
+{ #category : 'accessing' }
+SpFilteringSelectableListPresenter >> selectedItems: anObject [
+	selectedItems := anObject
 ]
 
 { #category : 'private' }

--- a/src/Spec2-CommonWidgets/SpFilteringSelectableListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringSelectableListPresenter.class.st
@@ -105,7 +105,7 @@ SpFilteringSelectableListPresenter >> items: aCollection [
 	"If the items are changing, we need to remove the items that are not present anymore from the collection."
 
 	super items: aCollection.
-	self selectedItems: (selectedItems select: [ :item | aCollection includes: item ])
+	selectedItems := selectedItems select: [ :item | aCollection includes: item ]
 ]
 
 { #category : 'private' }
@@ -195,11 +195,6 @@ SpFilteringSelectableListPresenter >> selectItems: aCollection [
 SpFilteringSelectableListPresenter >> selectedItems [
 
 	^ selectedItems sorted: [ :a :b | (self items indexOf: a) < (self items indexOf: b) ]
-]
-
-{ #category : 'accessing' }
-SpFilteringSelectableListPresenter >> selectedItems: anObject [
-	selectedItems := anObject
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
SpFilteringSelectableListPresenter has items and a list of the selected items. But if we change the items while a selection exists, we end up with selected elements that are not in the list. 

I propose to filter out those selected elements when we update the items. This fixes a bug in the SpChooserPresenter when we could have duplicated elements in the target list if we clicked multiple times on the "move elements" button.