### PR TITLE
Adding entry completion setter to SpRequestDialog

### DIFF
--- a/src/Spec2-Dialogs/SpRequestDialog.class.st
+++ b/src/Spec2-Dialogs/SpRequestDialog.class.st
@@ -125,6 +125,12 @@ SpRequestDialog >> defaultTitle [
 	^ 'Request'
 ]
 
+{ #category : 'api' }
+SpRequestDialog >> entryCompletion: anEntryCompletion [
+
+	textInput entryCompletion: anEntryCompletion
+]
+
 { #category : 'initialization' }
 SpRequestDialog >> initializePresenters [
 


### PR DESCRIPTION
This would allow to remove a dependency to `UIManager` in the `StDebugger`:

 ```Smalltalk
requestProtocolIn: aClass

	| entryCompletion applicants choice |
	self class fastTDD ifTrue: [ ^ Protocol unclassified ].
	applicants := self protocolSuggestionsFor: aClass.
	entryCompletion := EntryCompletion new
		                   dataSourceBlock: [ :currText | applicants ];
		                   filterBlock: [ :currApplicant :currText | 
			                   currText size > 3 and: [ 
					                   currApplicant asLowercase includesSubstring:
							                   currText asString asLowercase ] ].

	choice := (UIManager default
		           request:
		           'Start typing for suggestions (3 characters minimum)'
		           initialAnswer: Protocol unclassified
		           title: 'Choose a protocol'
		           entryCompletion: entryCompletion) ifNil: [ Abort signal ].

	^ choice ifEmpty: [ Protocol unclassified ]
```

Plus, overall, I think this is a good addition to add entry completion in a dialog that asks the user to write text