### PR TITLE
Fixed ntb page selection change announcement if built without pages

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicNotebookAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicNotebookAdapter.class.st
@@ -27,20 +27,31 @@ SpMorphicNotebookAdapter >> addFocusRotationKeyBindings [
 			toAction: [ self focusPrevious ]
 ]
 
-{ #category : 'factory' }
-SpMorphicNotebookAdapter >> addModelTo: aNotebook [
-	
+{ #category : 'private' }
+SpMorphicNotebookAdapter >> addInitialPagesTo: aNotebook [
+
 	self presenter pages ifEmpty: [ ^ self ].
+
 	self presenter pages do: [ :each | 
 		"Since I do not have the page added, I need to take it from the list. 
-		 But I know this will be the last added :)" 
+		 But I know this will be the last added :)"
 		self addPage: each to: aNotebook ].
+	
 	"force first page to be drawn"
-	self presenter selectedPage ifNil: [ self presenter selectPageIndex: 1 ].
-	aNotebook selectedPageIndex: self presenter selectedPageIndex.
-	aNotebook announcer 
-		when: SpNotebookPageChanged 
-		send: #pageChanged: 
+	self presenter selectedPage ifNil: [
+		self presenter selectPageIndex: 1 ].
+	
+	aNotebook selectedPageIndex: self presenter selectedPageIndex
+]
+
+{ #category : 'factory' }
+SpMorphicNotebookAdapter >> addModelTo: aNotebook [
+
+	self addInitialPagesTo: aNotebook.
+
+	aNotebook announcer
+		when: SpNotebookPageChanged
+		send: #pageChanged:
 		to: self
 ]
 

--- a/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
@@ -104,3 +104,21 @@ SpNotebookAdapterTest >> testSelectingPageShouldAnnounceChangeEvent [
 	self assert: change oldPage model title equals: 'Mock'.
 	self assert: change page model title equals: 'Mock2'
 ]
+
+{ #category : 'tests' }
+SpNotebookAdapterTest >> testSelectingPageShouldAnnounceChangeEventWithNoInitialPages [
+
+	| changed |
+	"start with no pages"
+	presenter removeAll.
+	presenter whenSelectedPageChangedDo: [ changed := true ].
+	"build without any pages"
+	self widget.
+	"add pages after build"
+	self initializeTestedInstance.
+	presenter selectPageIndex: 1.
+	changed := false.
+	"this should trigger the page change"
+	self widget updatePageIndex: 2 oldIndex: 1.
+	self assert: changed
+]


### PR DESCRIPTION
Subscribes to notebook morph page selection even if there are no pages during the build (as pages can be added later).

Fixes https://github.com/pharo-spec/Spec/issues/1541