### PR TITLE
Fix `SpCodePresenter>>#evaluate:onCompileError:onError:` that does not consider interaction model's bindings when evaluating code

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -425,7 +425,7 @@ SpCodePresenter >> environment: anEnvironment [
 ]
 
 { #category : 'command support' }
-SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: errorBlock [ 
+SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: errorBlock [
 	"evaluate aString. 
 	 evaluate compileErrorBlock if there are compilation errors. 
 	 evaluate errorBlock is anything happens *during* evaluation (code compiled, but it does not 
@@ -438,28 +438,32 @@ SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: 
 	 anything. 
 	 Instead, the on:do: will catch all errors happening while executing the code once it is 
 	 compiled. "
+
 	| result oldBindings |
-	
 	^ [
-		self announcer announce: (SpCodeWillBeEvaluatedAnnouncement newContent: aString).
-		oldBindings := self interactionModel bindings copy.
-		result := self interactionModel compiler
-			source: aString;
-			environment: self environment;
-			failBlock:  [ 
-				self announcer announce: (SpCodeEvaluationFailedAnnouncement newContent: aString).
-				^ compileErrorBlock value ];
-			evaluate.
-		oldBindings size = self interactionModel bindings size 
-			ifFalse: [ self withAdapterDo: [ :anAdapter | anAdapter refreshStyling ] ].
-		self announcer announce: (SpCodeEvaluationSucceedAnnouncement newContent: aString).
-		result ]
-	on: Error 
-	do: [ :e |
-		self announcer announce: (SpCodeEvaluationFailedAnnouncement 
-			newContent: aString
-			error: e).
-		errorBlock value: e ]
+	  self announcer announce:
+		  (SpCodeWillBeEvaluatedAnnouncement newContent: aString).
+	  oldBindings := self interactionModel bindings copy.
+	  result := self interactionModel compiler
+		            source: aString;
+		            environment: self environment;
+		            bindings: self interactionModel bindings;
+		            failBlock: [
+			            self announcer announce:
+					            (SpCodeEvaluationFailedAnnouncement newContent:
+							             aString).
+			            ^ compileErrorBlock value ];
+		            evaluate.
+	  oldBindings size = self interactionModel bindings size ifFalse: [
+		  self withAdapterDo: [ :anAdapter | anAdapter refreshStyling ] ].
+	  self announcer announce:
+		  (SpCodeEvaluationSucceedAnnouncement newContent: aString).
+	  result ]
+		  on: Error
+		  do: [ :e |
+			  self announcer announce:
+				  (SpCodeEvaluationFailedAnnouncement newContent: aString error: e).
+			  errorBlock value: e ]
 ]
 
 { #category : 'private - bindings' }


### PR DESCRIPTION
Fixes #1506 

I do not understand why the problem does not appear when evaluating code in the playground for example, but still, it is wrong not to use the bindings of the interaction model when evaluating code