### PR TITLE
Remove fast table search by default

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicListAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicListAdapter.class.st
@@ -136,18 +136,6 @@ SpAbstractMorphicListAdapter >> triggerActivationAction [
 ]
 
 { #category : 'factory' }
-SpAbstractMorphicListAdapter >> updateItemFilterBlockWith: block [
-
-	^ block
-		ifNotNil: [ 
-			widget
-				enableFilter: (SpFTSpecFilter block: block);
-				explicitFunction ]
-		ifNil: [ 
-			self updateSearch ]
-]
-
-{ #category : 'factory' }
 SpAbstractMorphicListAdapter >> updateSearch [
 
 	self presenter isSearchEnabled

--- a/src/Spec2-Adapters-Morphic/SpMorphicListAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicListAdapter.class.st
@@ -135,7 +135,7 @@ SpMorphicListAdapter >> newTableWith: datasource [
 	^ SpFTTableMorph new
 		dataSource: datasource;
 		hideColumnHeaders;
-		enableSearch;
+		disableFunction;
 		beResizable;
 		columns: { self newListColumn };
 		setMultipleSelection: self model isMultipleSelection;

--- a/src/Spec2-Adapters-Morphic/SpMorphicTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableAdapter.class.st
@@ -79,6 +79,7 @@ SpMorphicTableAdapter >> buildWidget [
 		intercellSpacing: self class intercellSpacing;
 		dragEnabled: self dragEnabled;
 		dropEnabled: self dropEnabled;
+		disableFunction;
 		yourself.
 
 	self addModelTo: widget.


### PR DESCRIPTION
It often happens is a table or list has the focus that we start to type and a search popover appears but it filters nothing. And in multiple UIs, we have a filter done with an input field under the list and both are overlapping and it becomes really confusing.

I propose to disable the FastTable search by default and I also remove a dead method