### PR TITLE
Fix: #1547: whenWillCloseDo: block is evaluated twice when closing a window 

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpWindow.class.st
+++ b/src/Spec2-Adapters-Morphic/SpWindow.class.st
@@ -47,13 +47,6 @@ SpWindow >> close [
 ]
 
 { #category : 'open/close' }
-SpWindow >> deleteDiscardingChanges [
-
-	self announceWillClose.
-	^ super deleteDiscardingChanges
-]
-
-{ #category : 'open/close' }
 SpWindow >> extent: aPoint [ 
 	| announcement oldExtent |
 


### PR DESCRIPTION
We decided to remove the closeDiscardingChanges from Spec