### PR TITLE
Use identity comparisons when looking for elements in a list

### DIFF
--- a/src/Spec2-Core/SpAbstractSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractSelectionMode.class.st
@@ -74,10 +74,8 @@ SpAbstractSelectionMode >> includesItem: anItem [
 
 { #category : 'private' }
 SpAbstractSelectionMode >> indexOfItem: anItem [
-	
-	^ self model
-		indexOf: anItem
-		ifAbsent: [ 0 ].
+
+	^ self model indexOf: anItem ifAbsent: 0
 ]
 
 { #category : 'initialization' }

--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -81,7 +81,7 @@ SpCollectionListModel >> hasElementAt: index [
 { #category : 'accessing' }
 SpCollectionListModel >> indexOf: anIndex ifAbsent: aBlock [
 
-	^ collection indexOf: anIndex ifAbsent: aBlock
+	^ collection identityIndexOf: anIndex ifAbsent: aBlock
 ]
 
 { #category : 'initialization' }

--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -79,9 +79,9 @@ SpCollectionListModel >> hasElementAt: index [
 ]
 
 { #category : 'accessing' }
-SpCollectionListModel >> indexOf: anIndex ifAbsent: aBlock [
+SpCollectionListModel >> indexOf: anItem ifAbsent: aBlock [
 
-	^ collection identityIndexOf: anIndex ifAbsent: aBlock
+	^ collection identityIndexOf: anItem ifAbsent: aBlock
 ]
 
 { #category : 'initialization' }

--- a/src/Spec2-Core/SpStringTableColumn.class.st
+++ b/src/Spec2-Core/SpStringTableColumn.class.st
@@ -125,7 +125,7 @@ SpStringTableColumn >> onAcceptEdition: aBlock [
 	acceptAction := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> onTextChanged: aBlock [
 	"Set the block to execute when cell edition is edited.
 	 `aBlock` receives two arguments:
@@ -135,7 +135,7 @@ SpStringTableColumn >> onTextChanged: aBlock [
 	textChanged := aBlock
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SpStringTableColumn >> sortFunction [
 
 	^ super sortFunction ifNil: [ self evaluation ascending ]
@@ -156,7 +156,7 @@ SpStringTableColumn >> sortFunction: aBlockOrSortFunction [
 	self isSortable: aBlockOrSortFunction isNotNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SpStringTableColumn >> textChanged [
 
 	^ textChanged

--- a/src/Spec2-Tests/SpDropListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpDropListPresenterTest.class.st
@@ -57,6 +57,37 @@ SpDropListPresenterTest >> testSelectItemAfterOpen [
 ]
 
 { #category : 'tests' }
+SpDropListPresenterTest >> testSelectionOfObjectsWithSamePrintOn [
+
+	| first second |
+	presenter items: { first := Object new. second := Object new }.
+	presenter selectItem: second.
+
+	[ 
+		presenter open. 
+		self assert: presenter selectedItem equals: second.
+		presenter selectItem: first.
+		self assert: presenter selectedItem equals: first.
+	] 
+	ensure: [ presenter withWindowDo: #close ]	
+]
+
+{ #category : 'tests' }
+SpDropListPresenterTest >> testSelectionOfObjectsWithSamePrintOnBeforeOpen [
+
+	| first second |
+	
+	presenter items: { first := Object new. second := Object new }.
+	presenter selectItem: second.
+	[ 
+		self assert: presenter selectedItem equals: second.
+		presenter selectItem: first.
+		self assert: presenter selectedItem equals: first.
+	] 
+	ensure: [ presenter withWindowDo: #close ]	
+]
+
+{ #category : 'tests' }
 SpDropListPresenterTest >> testSetItemsWithCollectionSmallerThanSelection [
 
 	| changed |


### PR DESCRIPTION
This fixes https://github.com/pharo-vcs/iceberg/issues/1831, which fails to update the drop down list because objects are wrapped in SpDropListItem that are badly configured (all have the same display block so chances are that they are all equal).