### PR TITLE
Enable specification of a comparison strategy to compare list items

### DIFF
--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -11,7 +11,8 @@ Class {
 	#instVars : [
 		'#announcer',
 		'#collection',
-		'#sorting => ObservableSlot'
+		'#sorting => ObservableSlot',
+		'#comparisonStrategy'
 	],
 	#category : 'Spec2-Core-Widgets-Table',
 	#package : 'Spec2-Core',
@@ -72,6 +73,20 @@ SpCollectionListModel >> collection: anObject [
 		newValue: collection)
 ]
 
+{ #category : 'accessing' }
+SpCollectionListModel >> comparisonStrategy [
+	"Answer a <BlockClosure> that specifies how receiver's elements are compared"
+
+    ^ comparisonStrategy
+]
+
+{ #category : 'accessing' }
+SpCollectionListModel >> comparisonStrategy: aBlockClosure [
+	"Set the receiver's comparison strategy to a two argument's <BlockClosure>, that specifies how receiver's elements are compared"
+
+	comparisonStrategy := aBlockClosure
+]
+
 { #category : 'testing' }
 SpCollectionListModel >> hasElementAt: index [
 
@@ -80,14 +95,17 @@ SpCollectionListModel >> hasElementAt: index [
 
 { #category : 'accessing' }
 SpCollectionListModel >> indexOf: anItem ifAbsent: aBlock [
-
-	^ collection identityIndexOf: anItem ifAbsent: aBlock
+	"Answer the index of the first occurrence of anElement within the receiver. If the receiver does not contain anElement, answer the result of evaluating the argument, exceptionBlock."
+	
+	^ collection indexOf: anItem ifAbsent: aBlock using: self comparisonStrategy
 ]
 
 { #category : 'initialization' }
 SpCollectionListModel >> initialize [
+
 	self class initializeSlots: self.
-	super initialize
+	super initialize.
+	comparisonStrategy := [ :a :b | a == b].
 ]
 
 { #category : 'testing' }

--- a/src/Spec2-Core/SpTablePresenter.class.st
+++ b/src/Spec2-Core/SpTablePresenter.class.st
@@ -99,6 +99,13 @@ SpTablePresenter >> columns: aCollection [
 	columns := aCollection
 ]
 
+{ #category : 'accessing' }
+SpTablePresenter >> comparisonStrategy: aFullBlockClosure [ 
+	"See comment in SpAbstractSelectionMode >> #comparisonStrategy:"
+
+	self model comparisonStrategy: aFullBlockClosure 
+]
+
 { #category : 'api' }
 SpTablePresenter >> hideColumnHeaders [
 	"Hide the column headers"


### PR DESCRIPTION
This change allows for custom comparison strategies to `SpCollectionListModel`. The main changes are:

1. Added `comparisonStrategy` instance variable with getter and setter.
2. Changed `indexOf:ifAbsent:` method to use the comparison strategy.
3. Initialized `comparisonStrategy` with identity comparison in the `initialize` method.

