### PR TITLE
Make #selectAll work before opening the presenter

### DIFF
--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -237,8 +237,8 @@ SpAbstractTextPresenter >> registerEvents [
 { #category : 'api - selection' }
 SpAbstractTextPresenter >> selectAll [
 	"Select all text"
-	
-	self changed: #selectAll with: #()
+
+	self selectionInterval: (0 to: self text size)
 ]
 
 { #category : 'api - selection' }

--- a/src/Spec2-Tests/SpAbstractTextPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractTextPresenterTest.class.st
@@ -79,6 +79,17 @@ SpAbstractTextPresenterTest >> testPlaceholderIsSet [
 
 { #category : 'tests' }
 SpAbstractTextPresenterTest >> testSelectAll [
+
+	self initializationText.
+	"We should try to do the selectAll before opening the instance to be sure it will be taken into account."
+	presenter selectAll.
+	self openInstance.
+	self assert: presenter selectionInterval equals: (1 to: 15)
+]
+
+{ #category : 'tests' }
+SpAbstractTextPresenterTest >> testSelectAllAfterOpening [
+
 	self initializationText.
 	self openInstance.
 	presenter selectAll.


### PR DESCRIPTION
Fixes #1581

It was not possible to use #selectAll before opening the presenter before this fix