### PR TITLE
Add scroll to index to Lists

### DIFF
--- a/src/Spec2-Adapters-Morphic-Tests/SpMorphicListAdapterTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpMorphicListAdapterTest.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : 'SpMorphicListAdapterTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'presenter'
+	],
+	#category : 'Spec2-Adapters-Morphic-Tests',
+	#package : 'Spec2-Adapters-Morphic-Tests'
+}
+
+{ #category : 'private' }
+SpMorphicListAdapterTest >> configureList: aNumber [
+
+	presenter := SpListPresenter new
+		items: (1 to: aNumber);
+		yourself.
+
+]
+
+{ #category : 'running' }
+SpMorphicListAdapterTest >> tearDown [
+
+	presenter delete.
+	super tearDown.
+]
+
+{ #category : 'tests' }
+SpMorphicListAdapterTest >> testScrollToIndexInvisibleScrollbars [
+
+	self configureList: 5.
+	presenter open.
+	presenter scrollToIndex: 100.
+	self 
+		assert: presenter scrollIndex
+		equals: 1.
+]
+
+{ #category : 'tests' }
+SpMorphicListAdapterTest >> testScrollToIndexVisibleScrollbars [
+
+	self configureList: 100.
+	presenter open.
+	self 
+		assert: presenter scrollIndex
+		equals: 1.
+	
+	presenter scrollToIndex: 50.
+	
+	self 
+		assert: presenter scrollIndex 
+		equals: 39.
+		
+	presenter scrollToIndex: 100.
+
+	self 
+		assert: presenter scrollIndex 
+		equals: 89.
+]

--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -119,6 +119,15 @@ SpAbstractListPresenter >> doubleClickAtIndex: anIndex [
 	self doActivateAtIndex: anIndex
 ]
 
+{ #category : 'api' }
+SpAbstractListPresenter >> indexOf: anItem ifAbsent: aBlock [
+	"Answer the index of the first occurrence of anElement within the receiver. If the receiver does not contain anElement, answer the result of evaluating the argument, exceptionBlock."
+	
+	^ self model 
+		indexOf: anItem 
+		ifAbsent: aBlock
+]
+
 { #category : 'initialization' }
 SpAbstractListPresenter >> initialize [
 

--- a/src/Spec2-Core/SpListPresenter.class.st
+++ b/src/Spec2-Core/SpListPresenter.class.st
@@ -181,6 +181,20 @@ SpListPresenter >> resetListSelection [
 	self selectIndex: 0
 ]
 
+{ #category : 'scrolling' }
+SpListPresenter >> scrollIndex [
+	"Answer a <Number> representing the receiver's element scroll index"
+
+	^ self adapter widget showIndex.
+]
+
+{ #category : 'scrolling' }
+SpListPresenter >> scrollToIndex: anIndex [
+	"Scroll the receiver to the element whose index is anIndex."
+
+	self adapter widget scrollToIndex: anIndex
+]
+
 { #category : 'api' }
 SpListPresenter >> updateList [
 	"Update the list re taking the list defined in `SpAbstractListPresenter>>#model` and filling the list with 


### PR DESCRIPTION
This PR adds a method, `scrollToIndex:`, to support vertical list scrolling in Spec. Currently working in the Morphic backend. Its functionality is necessary to fix multiple issues, such as :

- https://github.com/pharo-spec/NewTools/issues/699 
- https://github.com/pharo-spec/NewTools/issues/808 
- https://github.com/pharo-spec/Spec/issues/1585
- https://github.com/hernanmd/class-diff/issues/1
and probably others

It also adds corresponding tests.
