### PR TITLE
Make implementors of #transferFrom:event: add #shouldCopy from the TransferMorph to the SpDragAndDropTransfer

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicListAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicListAdapter.class.st
@@ -125,6 +125,7 @@ SpAbstractMorphicListAdapter >> transferFrom: aTransferMorph event: anEvent [
 	rowAndColumn := self widget container rowAndColumnIndexContainingPoint: anEvent position.
 	^ SpDragAndDropTransferToList new
 		passenger: aTransferMorph passenger;
+		shouldCopy: aTransferMorph shouldCopy;
 		index: (rowAndColumn first ifNil: [ 0 ]);
 		yourself
 ]

--- a/src/Spec2-Adapters-Morphic/SpDragAndDropTransfer.class.st
+++ b/src/Spec2-Adapters-Morphic/SpDragAndDropTransfer.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'SpDragAndDropTransfer',
 	#superclass : 'Object',
 	#instVars : [
-		'passenger'
+		'passenger',
+		'shouldCopy'
 	],
 	#category : 'Spec2-Adapters-Morphic-Support',
 	#package : 'Spec2-Adapters-Morphic',
@@ -19,4 +20,16 @@ SpDragAndDropTransfer >> passenger [
 SpDragAndDropTransfer >> passenger: anObject [
 
 	passenger := anObject
+]
+
+{ #category : 'accessing' }
+SpDragAndDropTransfer >> shouldCopy [
+
+	^ shouldCopy
+]
+
+{ #category : 'accessing' }
+SpDragAndDropTransfer >> shouldCopy: anObject [
+
+	shouldCopy := anObject
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableAdapter.class.st
@@ -272,6 +272,7 @@ SpMorphicTableAdapter >> transferFrom: aTransferMorph event: anEvent [
 	rowAndColumn := self widget container rowAndColumnIndexContainingPoint: anEvent position.
 	^ SpDragAndDropTransferToTable new
 		passenger: aTransferMorph passenger;
+		shouldCopy: aTransferMorph shouldCopy;
 		row: (rowAndColumn first ifNil: [ 0 ]);
 		column: (rowAndColumn second ifNil: [ 0 ]);
 		yourself

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -493,6 +493,7 @@ SpMorphicTreeTableAdapter >> transferFrom: aTransferMorph event: anEvent [
 		
 	^ SpDragAndDropTransferToTree new
 		passenger: aTransferMorph passenger;
+		shouldCopy: aTransferMorph shouldCopy;
 		row: (rowAndColumn first ifNil: [ 0 ]);
 		column: (rowAndColumn second ifNil: [ 0 ]);
 		target: aTarget;


### PR DESCRIPTION
This pull request makes the implementors of `#transferFrom:event:` add `#shouldCopy` from the TransferMorph to the SpDragAndDropTransfer. This is related to [Pharo issue #15233](https://github.com/pharo-project/pharo/issues/15233) for which the ability to hold the Shift key while dragging to indicate that the object should be copied when dropped would seem useful.