### PR TITLE
Add header title to filtering list

### DIFF
--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -123,6 +123,13 @@ SpFilteringListPresenter >> filterText [
 	^  self filterInputPresenter text
 ]
 
+{ #category : 'api' }
+SpFilteringListPresenter >> headerTitle: aString [ 
+	"Set the receiver's title to aString"
+
+	listPresenter headerTitle: aString
+]
+
 { #category : 'initialization' }
 SpFilteringListPresenter >> initializePresenters [
 


### PR DESCRIPTION
Simple PR to add a convenience method so we don't have to ask listPresenter to set the header title of a filtering list: