### PR TITLE
Fix adapter tests, that should access the widget via the adapter, not directly.

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTextInputFieldAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextInputFieldAdapter.class.st
@@ -105,6 +105,12 @@ SpMorphicTextInputFieldAdapter >> isPassword [
 	^ self widget font isKindOf: FixedFaceFont
 ]
 
+{ #category : 'accessing' }
+SpMorphicTextInputFieldAdapter >> maxLength [
+	
+	^ widget maxLength
+]
+
 { #category : 'private' }
 SpMorphicTextInputFieldAdapter >> setEditable: aBoolean to: aWidget [
 

--- a/src/Spec2-Backend-Tests/SpCheckboxAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpCheckboxAdapterTest.class.st
@@ -49,7 +49,7 @@ SpCheckboxAdapterTest >> testChangeDeactivatedAfterOpenCheckboxDectivatesIt [
 SpCheckboxAdapterTest >> testChangingLabelAffectTheWidget [
 	
 	presenter label: 'ALabel'.
-	self assert: self widget label equals: 'ALabel'
+	self assert: self adapter label equals: 'ALabel'
 ]
 
 { #category : 'tests' }

--- a/src/Spec2-Backend-Tests/SpRadioButtonAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpRadioButtonAdapterTest.class.st
@@ -16,7 +16,7 @@ SpRadioButtonAdapterTest >> classToTest [
 SpRadioButtonAdapterTest >> testChangingLabelAffectTheWidget [
 	
 	presenter label: 'ALabel'.
-	self assert: self widget label equals: 'ALabel'
+	self assert: self adapter label equals: 'ALabel'
 ]
 
 { #category : 'tests' }

--- a/src/Spec2-Backend-Tests/SpTextInputFieldAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpTextInputFieldAdapterTest.class.st
@@ -44,5 +44,5 @@ SpTextInputFieldAdapterTest >> testPasswordIsSetInWidget [
 SpTextInputFieldAdapterTest >> testPresenterTextIsSetInWidget [
 
 	presenter text: 'something'.
-	self assert: self widget text equals: 'something'
+	self assert: self adapter getText equals: 'something'
 ]

--- a/src/Spec2-Backend-Tests/SpTextInputFieldAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpTextInputFieldAdapterTest.class.st
@@ -23,7 +23,7 @@ SpTextInputFieldAdapterTest >> testChangeWidgetTextUpdatesPresenter [
 SpTextInputFieldAdapterTest >> testMaxLengthIsSetInWidget [
 
 	presenter maxLength: 10.
-	self assert: self widget maxLength equals: 10
+	self assert: self adapter maxLength equals: 10
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Fixes #1598 