### PR TITLE
Set enablement of button in SpCommand>>#configureAsButtonOfClass:

### DIFF
--- a/src/Spec2-Commander2-Tests/SpCommandTest.class.st
+++ b/src/Spec2-Commander2-Tests/SpCommandTest.class.st
@@ -141,6 +141,7 @@ SpCommandTest >> testConfigureAsToolBarButton [
 	self assert: button label equals: command name.
 	self assert: button help equals: command description.
 	self assert: button icon isNil.
+	self assert: button isEnabled.
 	self assert: button action value equals: command execute
 ]
 
@@ -230,4 +231,28 @@ SpCommandTest >> testShortcutKey [
 	command shortcutKey: $a asKeyCombination.
 	
 	self assert: command shortcutKey equals:  $a asKeyCombination
+]
+
+{ #category : 'tests' }
+SpCommandTest >> testToolBarButtonEnablement [
+
+	| button context |
+	context := OrderedCollection new.
+	command := (CmBlockCommand new
+		name: 'foo';
+		description: 'bar';
+		canBeExecutedBlock: [:collection | collection isNotEmpty ];
+		context: context;
+		yourself) asSpecCommand.
+
+	button := command
+					configureAsToolbarButton;
+					buildPresenter.
+	self deny: button isEnabled.
+
+	context add: 1.
+	button := command
+					configureAsToolbarButton;
+					buildPresenter.
+	self assert: button isEnabled.
 ]

--- a/src/Spec2-Commander2/SpCommand.class.st
+++ b/src/Spec2-Commander2/SpCommand.class.st
@@ -58,6 +58,7 @@ SpCommand >> configureAsButtonOfClass: aButtonClass [
 					specCommand hasIcon
 						ifTrue: [ button icon: specCommand icon ] ];
 				action: [ specCommand execute ];
+				enabled: specCommand canBeExecuted;
 				yourself ]
 ]
 


### PR DESCRIPTION
This PR is for Pharo 13. The PR for Pharo 12 was https://github.com/pharo-spec/Spec/pull/1621.

It fixes the missing enablement in SpCommand>>#configureAsButtonOfClass:. See https://github.com/pharo-spec/Spec/issues/1618.