### PR TITLE
Add missing `selectedItems` method

### DIFF
--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -236,6 +236,13 @@ SpFilteringListPresenter >> selectedItem [
 ]
 
 { #category : 'accessing' }
+SpFilteringListPresenter >> selectedItems [
+	"Answer a <Collection> of receiver's selected objects"
+
+	^ listPresenter selectedItems
+]
+
+{ #category : 'accessing' }
 SpFilteringListPresenter >> sortingBlock: aBlockOrNil [
 
 	listPresenter sortingBlock: aBlockOrNil


### PR DESCRIPTION
Provides a simple method to get the selected items of a filtering list, as reported in #1623 
