### PR TITLE
Add helper method to setup the filtering list header title

### DIFF
--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -141,6 +141,13 @@ SpFilteringListPresenter >> filterText [
 	^  self filterInputPresenter text
 ]
 
+{ #category : 'api' }
+SpFilteringListPresenter >> headerTitle: aString [
+	"Set the receiver's header title to aString"
+
+	listPresenter headerTitle: aString
+]
+
 { #category : 'initialization' }
 SpFilteringListPresenter >> initializePresenters [
 

--- a/src/Spec2-Examples/SpFilteringListPresenter.extension.st
+++ b/src/Spec2-Examples/SpFilteringListPresenter.extension.st
@@ -6,11 +6,11 @@ SpFilteringListPresenter class >> example [
 	<sampleInstance>
 	| example |
 	example := self new.
-	example items: RBBrowserEnvironment default classes asArray.
-	example open.
-	example withWindowDo: [ :window | 
-		window title: self name asString , ' example' ].
-
+	example 
+		items: RBBrowserEnvironment default classes asArray;
+		headerTitle: 'Classes';
+		open;
+		withWindowDo: [ :window | window title: self name asString , ' example' ].
 	^ example
 ]
 


### PR DESCRIPTION
A very small PR to have a convenience method to easily configure the filtering list header title.
