### PR TITLE
move towards removing morphic dependencies

### DIFF
--- a/src/Spec2-Commands/SpBrowseInstancesCommand.class.st
+++ b/src/Spec2-Commands/SpBrowseInstancesCommand.class.st
@@ -23,5 +23,5 @@ SpBrowseInstancesCommand class >> shortName [
 { #category : 'executing' }
 SpBrowseInstancesCommand >> execute [
 
-	self target instanceSide inspectAllInstances
+	self target instanceSide allInstances inspect
 ]

--- a/src/Spec2-Commands/SpBrowseSubInstancesCommand.class.st
+++ b/src/Spec2-Commands/SpBrowseSubInstancesCommand.class.st
@@ -23,5 +23,5 @@ SpBrowseSubInstancesCommand class >> shortName [
 { #category : 'executing' }
 SpBrowseSubInstancesCommand >> execute [
 
-	self target instanceSide inspectSubInstances
+	self target instanceSide allSubInstances inspect
 ]

--- a/src/Spec2-ListView/SpListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpListViewPresenter.class.st
@@ -143,8 +143,10 @@ SpListViewPresenter class >> exampleWithIconsAndMorph [
 	 It shows also the fact you can put any presenter inside, giving a huge power 
 	 to your lists."
 
+	| application |
+	application := SpApplication new useBackend: #Gtk.
 	^ self new
-		application: (SpApplication new useBackend: #Gtk);
+		application: application;
 		items: self environment allClasses;
 		setup: [ :aPresenter |
 			| presenter morph |
@@ -157,7 +159,7 @@ SpListViewPresenter class >> exampleWithIconsAndMorph [
 						morph: ((morph := SimpleButtonMorph new)
 							color: Color blue;
 							target: [ 
-								self inform: 'Clicked: ', morph label ];
+								application inform: 'Clicked: ', morph label ];
 							actionSelector: #value;
 							yourself);
 						yourself);


### PR DESCRIPTION
Use inform from the application in the example

Do not use #inspectSubInstances and co, that allow escaping from spec.
Eventually in the future these calls to inspect should pass through the application too?