### PR TITLE
missing methods from last fix:  re-add code presenter missing actions

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
@@ -17,6 +17,12 @@ SpMorphicTextAdapter >> accept: aString notifying: aNotifyier [
 		notifying: aNotifyier
 ]
 
+{ #category : 'widget API' }
+SpMorphicTextAdapter >> addExtraActionsTo: actionGroup [
+		
+	"override to add extra actions between user defined and edition"
+]
+
 { #category : 'initialization' }
 SpMorphicTextAdapter >> addFocusRotationKeyBindings [
 	"Text areas needs to be able to process tab. Cancel the binding."
@@ -91,9 +97,10 @@ SpMorphicTextAdapter >> codePaneMenu: aMenu shifted: shifted [
 	
 	self presenter internalActions ifNotNil: [ :group |
 		actionGroup add: group beRoot ].
+	self addExtraActionsTo: actionGroup.
 	self presenter actions ifNotNil: [ :group |
 		actionGroup add: group beRoot ].
-	self presenter hasEditionContextMenu ifTrue: [ 
+	self presenter hasEditionContextMenu ifTrue: [
 		actionGroup add: self presenter editionCommandsGroup beRoot ].
 
 	menuPresenter := self presenter newMenu.


### PR DESCRIPTION
I forgot this and it will not do anything without it.