### PR TITLE
Adapt whenNumberChangedDo: to use two argument block

### DIFF
--- a/src/Spec2-Core/SpNumberInputFieldPresenter.class.st
+++ b/src/Spec2-Core/SpNumberInputFieldPresenter.class.st
@@ -227,7 +227,7 @@ SpNumberInputFieldPresenter >> whenNumberChangedDo: aBlock [
 	 - old value
 	 - the announcement triggering this action"
 
-	self whenTextChangedDo: [ :txt | aBlock value: self number ]
+	self whenTextChangedDo: [ :newValue :oldValue | aBlock cull: self number cull: newValue ]
 ]
 
 { #category : 'api - events' }

--- a/src/Spec2-Tests/SpNumberInputFieldPresenterTest.class.st
+++ b/src/Spec2-Tests/SpNumberInputFieldPresenterTest.class.st
@@ -77,6 +77,16 @@ SpNumberInputFieldPresenterTest >> testWhenNumberChangedDo [
 ]
 
 { #category : 'tests' }
+SpNumberInputFieldPresenterTest >> testWhenNumberChangedDo2Arguments [
+
+	presenter
+		number: 10;
+		whenNumberChangedDo: [ :newValue :oldValue |  self deny: newValue equals: oldValue ].
+	presenter number: 32.
+
+]
+
+{ #category : 'tests' }
 SpNumberInputFieldPresenterTest >> testWhenNumberTypeChangedDo [
 	| count result |
 	count := 0.


### PR DESCRIPTION
This PR adapts the method whenNumberChangedDo: to receive 1 or 2 argument blocks (test included).
Fixes #1661