### PR TITLE
Fix implementors of #transferFrom:event: that no longer add #shouldCopy from the TransferMorph to the SpDragAndDropTransfer

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableAdapter.class.st
@@ -271,6 +271,7 @@ SpMorphicTableAdapter >> transferFrom: aTransferMorph event: anEvent [
 	rowAndColumn := self widget container rowAndColumnIndexContainingPoint: anEvent position.
 	^ SpDragAndDropTransferToTable new
 		passenger: aTransferMorph passenger;
+		shouldCopy: aTransferMorph shouldCopy;
 		row: (rowAndColumn first ifNil: [ 0 ]);
 		column: (rowAndColumn second ifNil: [ 0 ]);
 		yourself

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -493,6 +493,7 @@ SpMorphicTreeTableAdapter >> transferFrom: aTransferMorph event: anEvent [
 	^ SpDragAndDropTransferToTree new
 		passenger: aTransferMorph passenger;
 		row: (rowAndColumn first ifNil: [ 0 ]);
+		shouldCopy: aTransferMorph shouldCopy;
 		column: (rowAndColumn second ifNil: [ 0 ]);
 		target: aTarget;
 		yourself


### PR DESCRIPTION
This pull request fixes the implementors of `#transferFrom:event:` that no longer add `#shouldCopy` from the TransferMorph to the SpDragAndDropTransfer (added in pull request #1588 but removed in pull request #1628).