### PR TITLE
Make #transferFor:from: on SpMorphicTreeTableDataSource delegate to the adapter

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableDataSource.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableDataSource.class.st
@@ -223,3 +223,14 @@ SpMorphicTreeTableDataSource >> toString: anItem [
 
 	^ super toString: anItem data
 ]
+
+{ #category : 'drag and drop' }
+SpMorphicTreeTableDataSource >> transferFor: passenger from: aMorph [
+
+	^ (self model adapter 
+		transferFor: passenger 
+		from: self table) 
+		build
+		  dragHand: aMorph currentHand;
+		  yourself
+]


### PR DESCRIPTION
This pull request makes `#transferFor:from:` on SpMorphicTreeTableDataSource delegate to the adapter as is done in the corresponding method on SpMorphicListDataSource.