### PR TITLE
Make #recalculatePageWidths and #recalculatePageHeights on SpMorphicMillerAdapter set the coordinates and dimensions to integral numbers

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicMillerAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicMillerAdapter.class.st
@@ -155,17 +155,19 @@ SpMorphicMillerAdapter >> newVertical [
 { #category : 'private' }
 SpMorphicMillerAdapter >> recalculatePageHeights [
 
-	| newHeight widgets height |
+	| newHeight widgets height bottom |
 	height := self widget height.
 	widgets := self childrenWidgets.
 	newHeight := widgets size = 1
 		ifTrue: [ height ]
 		ifFalse: [ height / (layout visiblePages min: widgets size) - (layout spacing / (layout visiblePages min: widgets size)) ].
 		
+	bottom := (widgets size * newHeight) floor.
 	widgets reverseWithIndexDo: [ :each :index |
-		each 
-			top: (index - 1) * newHeight;
-			height: newHeight ]
+		| top |
+		top := ((index - 1) * newHeight) floor.
+		each top: top; height: bottom - top.
+		bottom := top ]
 ]
 
 { #category : 'private' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicMillerAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicMillerAdapter.class.st
@@ -170,7 +170,7 @@ SpMorphicMillerAdapter >> recalculatePageHeights [
 
 { #category : 'private' }
 SpMorphicMillerAdapter >> recalculatePageWidths [
-	| newWidth widgets width |
+	| newWidth widgets width right |
 
 	widgets := self childrenWidgets.	
 	width := self widget width.
@@ -181,10 +181,12 @@ SpMorphicMillerAdapter >> recalculatePageWidths [
 			visiblePages := layout visiblePages min: widgets size.
 			(width / visiblePages) - (layout spacing / visiblePages) ].
 		
+	right := (widgets size * newWidth) floor.
 	widgets reverseWithIndexDo: [ :each :index |
-		each 
-			left: (index - 1) * newWidth;
-			width: newWidth ]
+		| left |
+		left := ((index - 1) * newWidth) floor.
+		each left: left; width: right - left.
+		right := left ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
This pull request makes #recalculatePageWidths and #recalculatePageHeights on SpMorphicMillerAdapter set the coordinates and dimensions to integral numbers which fixes [Pharo issue #17384](https://github.com/pharo-project/pharo/issues/17384). Note that the widgets will no longer necessarily all have the same width or height, they may differ by 1.