### PR TITLE
fix search of element in SpCollectionListModel.

### DIFF
--- a/src/Spec2-Core/SpCollectionListModel.class.st
+++ b/src/Spec2-Core/SpCollectionListModel.class.st
@@ -81,7 +81,7 @@ SpCollectionListModel >> hasElementAt: index [
 { #category : 'accessing' }
 SpCollectionListModel >> indexOf: anItem ifAbsent: aBlock [
 
-	^ collection identityIndexOf: anItem ifAbsent: aBlock
+	^ collection indexOf: anItem ifAbsent: aBlock
 ]
 
 { #category : 'initialization' }

--- a/src/Spec2-Core/SpDropListItem.class.st
+++ b/src/Spec2-Core/SpDropListItem.class.st
@@ -40,7 +40,7 @@ SpDropListItem >> = anObject [
 
 	self == anObject ifTrue: [ ^ true ].
 	self class = anObject class ifFalse: [ ^ false ].
-	^ self label = anObject label and: [ action = anObject action ]
+	^ self model = anObject model
 ]
 
 { #category : 'protocol' }


### PR DESCRIPTION
It should use equality. Bug introduced in commit 3967790c4be27aab48d6c61596f90f4a5ca201a9.
It has already been fixed in Pharo 13. see https://github.com/pharo-spec/Spec/commit/1b48d5a8fd20b88223b635c1620c7f2c4ec3b9f1 and https://github.com/pharo-spec/Spec/commit/23bc559e5f43954409fabda30c89daaaf6f18c6d