### PR TITLE
enhancement(tables): split formatting vs evaluation

### DIFF
--- a/src/Spec2-Core/SpTableColumn.class.st
+++ b/src/Spec2-Core/SpTableColumn.class.st
@@ -12,7 +12,8 @@ Class {
 		'evaluation',
 		'expandable',
 		'sortFunction',
-		'width'
+		'width',
+		'formattingBlock'
 	],
 	#category : 'Spec2-Core-Widgets-Table',
 	#package : 'Spec2-Core',
@@ -92,6 +93,18 @@ SpTableColumn >> beNotExpandable [
 	expandable := false
 ]
 
+{ #category : 'private' }
+SpTableColumn >> evaluateObject: anObject [
+
+	"Apply the evaluation to the object of the table row.
+	If no evaluation is set, evaluate to the object itself.
+	
+	IMPORTANT: Sorting happens on the results of evaluation and not formatting"
+
+	self evaluation ifNil: [ ^ anObject ].
+	^ self evaluation cull: anObject
+]
+
 { #category : 'api' }
 SpTableColumn >> evaluated: aBlock [
 	"Define how the column will evaluate the element of the table/tree model 
@@ -109,6 +122,22 @@ SpTableColumn >> evaluation [
 	 into a value to display in this column"
 
 	^ evaluation
+]
+
+{ #category : 'private' }
+SpTableColumn >> formatObject: anObject [
+	"Returns the string representation of the argument to display in the table cell"
+
+	formattingBlock ifNil: [ ^ anObject ].
+	^ formattingBlock value: anObject
+]
+
+{ #category : 'api' }
+SpTableColumn >> formatted: aBlock [
+	"Defines how each element is formatted to be shown.
+	By default items will be shown using #asString"
+
+	formattingBlock := aBlock
 ]
 
 { #category : 'testing' }
@@ -161,7 +190,7 @@ SpTableColumn >> isSortable [
 { #category : 'private' }
 SpTableColumn >> readObject: anObject [ 
 
-	^ self evaluation cull: anObject
+	^ self formatObject: (self evaluateObject: anObject)
 ]
 
 { #category : 'api' }

--- a/src/Spec2-Tests/SpStringTableColumnTest.class.st
+++ b/src/Spec2-Tests/SpStringTableColumnTest.class.st
@@ -10,6 +10,34 @@ Class {
 }
 
 { #category : 'tests' }
+SpStringTableColumnTest >> testDisplayObjectRespectsFormatting [
+
+	| column dateToShow |
+	column := SpStringTableColumn new.
+	column formatted: [ :e | e displayString ].
+
+	dateToShow := Date today.
+
+	self
+		assert: (column readObject: dateToShow)
+		equals: dateToShow displayString
+]
+
+{ #category : 'tests' }
+SpStringTableColumnTest >> testDisplayObjectWithoutFormattingReturnsTheObjectItself [
+
+	| column dateToShow |
+	column := SpStringTableColumn new.
+
+	dateToShow := Date today.
+
+	"It's up to the table to stringify the object later"
+	self
+		assert: (column readObject: dateToShow)
+		equals: dateToShow
+]
+
+{ #category : 'tests' }
 SpStringTableColumnTest >> testIsSortable [
 	|widget|
 	widget := SpStringTableColumn new.


### PR DESCRIPTION
add formatting block to columns.
Evaluation resolves the projection of the object to show.
Formatting returns the string representation to show.

# Why is this important
This is important because sorting works on top of the evaluation.
Otherwise, if the sorting works on the string representation, the sort blocks should (re) parse and rebuild the original object to sort.

Otherwise, the (alphabetic) sorting of numerals or other will have the following sorting:

```
"Invalid alphabetic sorting of numeric values from the string representation"
1KB
10KB
100KB
2KB
20KB
200KB
```

Instead of the expected:

```
"Valid sorting of numeric values independently of their formatting"
1KB
2KB
10KB
20KB
100KB
200KB
```