### PR TITLE
Allow passwords in SpRequestDialog,  Fixes #1705

### DIFF
--- a/src/Spec2-Dialogs/SpRequestDialog.class.st
+++ b/src/Spec2-Dialogs/SpRequestDialog.class.st
@@ -86,6 +86,18 @@ SpRequestDialog >> accept [
 	super accept
 ]
 
+{ #category : 'api' }
+SpRequestDialog >> bePassword [
+
+	textInput bePassword
+]
+
+{ #category : 'api' }
+SpRequestDialog >> beText [
+
+	textInput beText
+]
+
 { #category : 'initialization' }
 SpRequestDialog >> connectPresenters [ 
 
@@ -145,6 +157,12 @@ SpRequestDialog >> initializeWindow: aWindowPresenter [
 	
 	super initializeWindow: aWindowPresenter.
 	aWindowPresenter whenOpenedDo: [ textInput takeKeyboardFocus; selectAll  ]
+]
+
+{ #category : 'testing' }
+SpRequestDialog >> isPassword [
+	
+	^ textInput isPassword
 ]
 
 { #category : 'api - showing' }

--- a/src/Spec2-Dialogs/SpRequestDialog.class.st
+++ b/src/Spec2-Dialogs/SpRequestDialog.class.st
@@ -79,6 +79,20 @@ SpRequestDialog class >> exampleMultiLineLabel [
 		openDialog
 ]
 
+{ #category : 'examples' }
+SpRequestDialog class >> examplePassword [
+
+	self new
+		bePassword;
+		title: 'Secret request example';
+		label: 'The meaning of life?';
+		text: 'I am tempted to say 42...';
+		acceptLabel: 'I know!';
+		cancelLabel: 'Cancel';
+		onAccept: [ :dialog | dialog presenter inform: dialog presenter text ];
+		openDialog
+]
+
 { #category : 'private' }
 SpRequestDialog >> accept [
 


### PR DESCRIPTION
Small addition to allow a password SpRequestDialog. Add and forward `bePassword`, `beText` and `isPassword` to the text input