### PR TITLE
Reimplement the morphic layout of our SearchInputField,  Fixes #1687

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicSearchInputFieldAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicSearchInputFieldAdapter.class.st
@@ -12,11 +12,13 @@ Class {
 { #category : 'factory' }
 SpMorphicSearchInputFieldAdapter >> buildWidget [
 	| textMorph iconsContainer |
-	
+
 	textMorph := super buildWidget.
+	textMorph submorphsDo: [ :aMorph | 
+		aMorph setProperty: #constraints toValue: SpOverlayConstraints new ].
 
 	iconsContainer := Morph new
-		extent: 12 @ 12;
+		extent: 14 @ 12;
 		color: Color transparent;
 		changeTableLayout;
 		listDirection: #topToBottom;
@@ -25,23 +27,19 @@ SpMorphicSearchInputFieldAdapter >> buildWidget [
 			actionSelector: #clearText;
 			labelGraphic: (self iconNamed: #windowCloseInactive);
 			color: Color transparent;
-			extent: 16 @ 8;
+			extent: 12 @ 12;
 			borderWidth: 0;
+			yourself);
+		setProperty: #constraints toValue: (SpOverlayConstraints new
+			beOverlay;
+			hAlignEnd;
+			vAlignStart;
 			yourself);
 		yourself.
 
-	"With the layout frame I set next it, the arrows will be at the top right of the 
-	 text morph. We should be able to make it vertically centered but I don't know 
-	 how to do that with morphs. If someone knows, please do :)"
 	textMorph
-		changeProportionalLayout;
-		addMorph: iconsContainer
-			fullFrame: (LayoutFrame identity
-				bottomFraction: 0;
-				leftFraction: 1;
-				topOffset: 4;
-				leftOffset: -25;
-				yourself).
+		layoutPolicy: SpMorphicOverlayLayout new;
+		addMorph: iconsContainer.
 
 	^ textMorph
 ]


### PR DESCRIPTION
The implementation is a bit cursed. Manually creates a Spec overlay in morphic and proceeds to properly place the "clear" button on the top right corner. There was a comment saying that the original author preferred the button to be centered. This is easy now but I disagree with the original author.