### PR TITLE
Fixes: #1732

### DIFF
--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -195,8 +195,10 @@ SpPresenter class >> owner: anOwningPresenter on: aDomainObject [
 
 { #category : 'accessing' }
 SpPresenter class >> preferredExtent [
+	"Note that we do not store here the defaultPreferredExtent because this way this is only when resizing is happening that we store the new size. 
+	It means in particular that if the defaultPreferredExtent is dynamically computed we honore it and not blindly returns the first value."
 	
-	^ customExtent ifNil: [ customExtent := self defaultPreferredExtent ]
+	^ customExtent ifNil: [ self defaultPreferredExtent ]
 ]
 
 { #category : 'accessing' }
@@ -670,7 +672,12 @@ SpPresenter >> initializeWindow: aWindowPresenter [
 		title: self windowTitle;
 		initialExtent: self class preferredExtent;
 		windowIcon: self windowIcon;
-		whenResizingDo: [ :ann | self preferredExtent: ann newSize ].
+		"Pay attention preferredExtent: is used here because it is stateful
+		in the sense that it will set the preferred extent to be remembered.
+		Of course only when resizable allows it."
+
+		whenResizingDo: [ :ann | aWindowPresenter isResizable 
+									ifTrue: [ self preferredExtent: ann newSize ]].
 ]
 
 { #category : 'inspector - extensions' }

--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -542,9 +542,14 @@ SpWindowPresenter >> resizable: aBoolean [
 
 { #category : 'api' }
 SpWindowPresenter >> resize: anExtent [
-
+	"Resize the receiver if it isResizable."
+	
+	"Note that we use the preferredExtent: because this is the API to get the resized extent being remembered."
+	
 	self withAdapterPerformOrDefer: [ :anAdapter | 
-		anAdapter resize: anExtent ]
+		resizable ifTrue: [
+			presenter preferredExtent: anExtent.   
+			anAdapter resize: anExtent ] ]
 ]
 
 { #category : 'api' }

--- a/src/Spec2-Tests/SpPresenterTest.class.st
+++ b/src/Spec2-Tests/SpPresenterTest.class.st
@@ -68,8 +68,8 @@ SpPresenterTest >> testLayoutIsDefaultLayoutWhenDefaultLayoutAndDefaultSpecDefin
 
 { #category : 'tests - layout' }
 SpPresenterTest >> testLayoutIsNotSetWhenAlreadyInitialized [
-	| presenterClass |
 	
+	| presenterClass |
 	presenterClass := SpPresenter newAnonymousSubclass.
 	presenterClass compile: 'defaultLayout ^ SpGridLayout new'.
 	presenterClass compile: 'initializePresenters self layout: SpBoxLayout newLeftToRight'.
@@ -78,6 +78,90 @@ SpPresenterTest >> testLayoutIsNotSetWhenAlreadyInitialized [
 	self 
 		assert: presenter layout class 
 		equals: SpBoxLayout
+]
+
+{ #category : 'tests - extent' }
+SpPresenterTest >> testPreferredExtentIsDynamicallyComputed [
+	"This test shows that the defaultPreferredExtent is computed dynamically.
+	It is not stored. 
+	
+	This is only on resize (if resize is allowed) that the last size is stored.
+	See companion test."
+	
+	| presenterClass |
+	presenterClass := SpPresenter newAnonymousSubclass.
+	presenterClass compile: 'defaultLayout ^ SpGridLayout new'.
+	presenterClass compile: 'initializePresenters self layout: SpBoxLayout newLeftToRight'.
+	presenterClass class compile: 'defaultPreferredExtent ^ 500@600'.
+	
+	presenter := presenterClass new.
+	self assert: presenter preferredExtent equals: 500@600.
+	
+	presenterClass class compile: 'defaultPreferredExtent ^ 1000@600'.
+	self assert: presenter preferredExtent equals: 1000@600.
+	
+	
+	
+	
+]
+
+{ #category : 'tests - extent' }
+SpPresenterTest >> testPreferredExtentIsNotStoredOnResizeWhenNotResizable [
+	"This test shows that resize and its effect on the extent being remembered is only 
+	available when resize is true"
+	
+	| presenterClass window |
+	presenterClass := SpPresenter newAnonymousSubclass.
+	presenterClass compile: 'defaultLayout ^ SpGridLayout new'.
+	presenterClass compile: 'initializePresenters self layout: SpBoxLayout newLeftToRight'.
+	presenterClass class compile: 'defaultPreferredExtent ^ 500@600'.
+	
+	presenter := presenterClass new.
+	self assert: presenter preferredExtent equals: 500@600.
+	window := presenter asWindow.
+	window resizable: false. 
+	self deny: window isResizable.
+	window open.
+	
+	window resize: 666@6666.
+	self assert: presenter preferredExtent equals: 500@600.
+	
+	presenterClass class compile: 'defaultPreferredExtent ^ 1000@600'.
+	
+	self assert: presenter class preferredExtent equals: 1000@600.
+	window close.
+	
+	
+	
+	
+]
+
+{ #category : 'tests - extent' }
+SpPresenterTest >> testPreferredExtentIsStoredOnResize [
+	| presenterClass window |
+	presenterClass := SpPresenter newAnonymousSubclass.
+	presenterClass compile: 'defaultLayout ^ SpGridLayout new'.
+	presenterClass compile: 'initializePresenters self layout: SpBoxLayout newLeftToRight'.
+	presenterClass class compile: 'defaultPreferredExtent ^ 500@600'.
+	
+	presenter := presenterClass new.
+	self assert: presenter preferredExtent equals: 500@600.
+	window := presenter asWindow.
+	self assert: window isResizable.
+	window open.
+	window resize: 666@6666.
+	self assert: presenter preferredExtent equals: 666@6666.
+	
+	presenterClass class compile: 'defaultPreferredExtent ^ 1000@600'.
+	"here even if the defaultPreferredExtent changes, it is not taken into account
+	because the resize takes precedence."
+	
+	self assert: presenter class preferredExtent equals: 666@6666.
+	window close.
+	
+	
+	
+	
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
- This is only when the change of extent is done via resize that it should be remembered. Else the extent is dynamic (not stored).
- Added nice tests covering this behavior.