### PR TITLE
Add nil guard to fix random debugger

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpWindow.class.st
+++ b/src/Spec2-Adapters-Morphic/SpWindow.class.st
@@ -75,9 +75,11 @@ SpWindow >> okToChange [
 
 { #category : 'private' }
 SpWindow >> taskbarIcon [
+	"If we close the window programatically while the taskbar is been updated the model can be nil in some cases."
 
-	^ self model windowIcon 
-		ifNil: [ super taskbarIcon ]
+	(self model isNil or: [ self model windowIcon isNil ]) ifTrue: [ ^ super taskbarIcon ].
+
+	^ self model windowIcon
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
It happens to me that I get a debugger while closing some windows programatically so I'm proposing to add a nil guard to not have the problem