### PR TITLE
Use the receiver on debug-it commands if possible

### DIFF
--- a/src/Spec2-Code-Commands/SpCodeSelectionCommand.class.st
+++ b/src/Spec2-Code-Commands/SpCodeSelectionCommand.class.st
@@ -44,16 +44,18 @@ SpCodeSelectionCommand >> asSpecCommand [
 { #category : 'private' }
 SpCodeSelectionCommand >> compile: aStream for: anObject in: evalContext [
 
-	| methodClass |
-	methodClass := evalContext
-		               ifNil: [ anObject class ]
-		               ifNotNil: [ evalContext methodClass ].
+	| compiler |
+	compiler := context class compiler
+		            source: aStream;
+		            yourself.
 
-	^ context class compiler
-		  source: aStream;
-		  class: methodClass;
-		  context: evalContext;
-		  requestor: context; "it should enable a visibility of current tool variables in new debugger"
+	evalContext
+		ifNil: [ compiler receiver: anObject ]
+		ifNotNil: [ compiler context: evalContext ].
+
+	^ compiler
+		  requestor: context;
+		  "it should enable a visibility of current tool variables in new debugger"
 		  isScripting: true;
 		  failBlock: [ ^ nil ];
 		  compile


### PR DESCRIPTION
The debug it command fails when executing it in an inspector and the selected expression contains instance variables.

This happens because the compiler is not properly configured.

I would have liked to write a test but there were none before