### PR TITLE
Update taskbar on open / close windows

### DIFF
--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -215,7 +215,10 @@ SpWindowPresenter >> close [
 	"Only manage closing if the presenter is really open"
 	self isOpen ifFalse: [ ^ self ].
 	self withAdapterDo: [ :anAdapter | 
-		anAdapter close ]
+		anAdapter close ].
+	
+	"Always that a new window is closed it must disappear from the taskbar"
+	self window worldTaskbar ifNotNil: [:taskbar | taskbar updateTasks]
 ]
 
 { #category : 'private' }
@@ -511,7 +514,10 @@ SpWindowPresenter >> openWithLayout: aSpecLayout [
 	self withAdapterDo: [ :anAdapter | 
 		anAdapter openWithDeferredAction: [ 
 			self allPresenters do: [ :each | each announceDisplayed ].
-			self updateTitle ] ]
+			self updateTitle ] ].
+	
+	"Always that a new window is opened it must appear in the taskbar"
+	self window worldTaskbar ifNotNil: [:taskbar | taskbar updateTasks]
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
### Before

![Screen Recording 2025-04-25 at 17 13 37](https://github.com/user-attachments/assets/0df26b00-4c08-4f92-9041-4811b42cd6e2)

In this video I open and close many windows using the shortcuts. However, the taskbar on bottom is not updated _until the cursor is moved_.

### After

![Screen Recording 2025-04-25 at 17 20 52](https://github.com/user-attachments/assets/4f07fe43-c9b4-4387-bac5-c5f10c2ad9ed)

Now it is updated when the windows are opened or closed.

-------

I'm not sure about the implementation, but I was trying other alternatives a lot. Mainly, I wanted to hook some announcement, but they does not work as I expected, and the code comes more complex.