### PR TITLE
Making SpCodePresenter reactive to setting change

### DIFF
--- a/src/Spec2-Code/CodeShowLineNumbersChanged.class.st
+++ b/src/Spec2-Code/CodeShowLineNumbersChanged.class.st
@@ -1,0 +1,10 @@
+"
+I am announced by the system announcer when the codeShowLineNumbers setting from StPharoSettings has changed.
+"
+Class {
+	#name : 'CodeShowLineNumbersChanged',
+	#superclass : 'Announcement',
+	#category : 'Spec2-Code-Announcements',
+	#package : 'Spec2-Code',
+	#tag : 'Announcements'
+}

--- a/src/Spec2-Code/SpApplication.extension.st
+++ b/src/Spec2-Code/SpApplication.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'SpApplication' }
+
+{ #category : '*Spec2-Code' }
+SpApplication >> codeShowLineNumbers [
+
+	^ self
+		  propertyAt: #codeShowLineNumbers
+		  ifAbsentPut: [ self class defaultCodeShowLineNumbers ]
+]
+
+{ #category : '*Spec2-Code' }
+SpApplication class >> defaultCodeShowLineNumbers [
+
+	^ true
+]

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -462,17 +462,17 @@ SpCodePresenter >> hasSyntaxHighlight [
 ]
 
 { #category : 'initialization' }
-SpCodePresenter >> initialize [ 
+SpCodePresenter >> initialize [
 
 	super initialize.
 
 	"Use the default menu"
 	overrideContextMenu := false.
-	
+
 	self withSyntaxHighlight.
 	self withSmartCharacters.
-	self withLineNumbers.
-	
+	self lineNumbers: self application codeShowLineNumbers.
+
 	self registerEventsForStyling.
 	self clearInteractionModel
 ]

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -471,7 +471,8 @@ SpCodePresenter >> initialize [
 
 	self withSyntaxHighlight.
 	self withSmartCharacters.
-	self lineNumbers: self application codeShowLineNumbers.
+	self showLineNumbers.
+	self subscribeToSettingsChangesAnnouncements.
 
 	self registerEventsForStyling.
 	self clearInteractionModel
@@ -649,6 +650,12 @@ SpCodePresenter >> selectedTextOrLine [
 ]
 
 { #category : 'private' }
+SpCodePresenter >> showLineNumbers [
+
+	self lineNumbers: self application codeShowLineNumbers
+]
+
+{ #category : 'private' }
 SpCodePresenter >> smartCharacters: aBoolean [
 
 	smartCharacters := aBoolean
@@ -674,6 +681,15 @@ SpCodePresenter >> styleScheme: aSymbol [
 	 to define a scheme)"
 
 	 styleScheme := aSymbol
+]
+
+{ #category : 'initialization' }
+SpCodePresenter >> subscribeToSettingsChangesAnnouncements [
+
+	self announcer
+		when: CodeShowLineNumbersChanged
+		send: #showLineNumbers
+		to: self
 ]
 
 { #category : 'private' }

--- a/src/Spec2-Core/SpNullApplication.class.st
+++ b/src/Spec2-Core/SpNullApplication.class.st
@@ -18,3 +18,8 @@ SpNullApplication class >> reset [
 		DefaultApplication reset ].
 	DefaultApplication := nil
 ]
+
+{ #category : 'settings' }
+SpNullApplication >> codeShowLineNumbers [
+	self flag: 'that should not be here'
+]

--- a/src/Spec2-Core/SpNullApplication.class.st
+++ b/src/Spec2-Core/SpNullApplication.class.st
@@ -18,8 +18,3 @@ SpNullApplication class >> reset [
 		DefaultApplication reset ].
 	DefaultApplication := nil
 ]
-
-{ #category : 'settings' }
-SpNullApplication >> codeShowLineNumbers [
-	self flag: 'that should not be here'
-]


### PR DESCRIPTION
- When "code show line numbers" settings is changed, an announcement is sent and code presenters automatically update
- The settings is presenter specific, but known by the presenter's application
- The application is responsible to trigger the announcement (in spec, it is not by default but the StPharoApplication from NewTools does)