### PR TITLE
Announce willclose and resizing in modals

### DIFF
--- a/src/Spec2-Adapters-Morphic-Tests/SpDialogWindowPresenterTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpDialogWindowPresenterTest.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : 'SpDialogWindowPresenterTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'spec'
+	],
+	#category : 'Spec2-Adapters-Morphic-Tests',
+	#package : 'Spec2-Adapters-Morphic-Tests'
+}
+
+{ #category : 'running' }
+SpDialogWindowPresenterTest >> setUp [
+	super setUp.
+
+	spec := SpDialogWindowPresenter new.
+	spec presenter: ((SpPresenter newApplication: SpApplication new) newLabel label: '123')
+]
+
+{ #category : 'running' }
+SpDialogWindowPresenterTest >> tearDown [
+	
+
+	spec close.
+	spec := nil.
+	super tearDown
+	
+
+]
+
+{ #category : 'tests' }
+SpDialogWindowPresenterTest >> testWhenResizingDo [
+
+	| resizingEventWasActivated |
+	resizingEventWasActivated := false.
+	spec := SpDialogWindowPresenter new.
+	spec presenter:((SpPresenter newApplication: SpApplication new) newLabel).
+	spec initialExtent: 10 @ 10.
+	spec
+		whenResizingDo: [ resizingEventWasActivated := true ];
+		whenOpenedDo: [
+				spec withAdapterDo: [ :anAdapter |
+						anAdapter widget extent: 15 @ 15 ].
+				spec
+					beOk;
+					close ].
+	spec open.
+	self assert: resizingEventWasActivated
+]
+
+{ #category : 'tests' }
+SpDialogWindowPresenterTest >> testWhenWillCloseDo [
+
+	| willCloseEventWasActivated |
+	
+	willCloseEventWasActivated := false.
+	spec
+		whenWillCloseDo: [ willCloseEventWasActivated := true ];
+		whenOpenedDo: [ 
+			spec beOk; close ];
+		open.
+	self assert: willCloseEventWasActivated
+	
+
+]

--- a/src/Spec2-Adapters-Morphic/SpDialogWindowMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpDialogWindowMorph.class.st
@@ -19,6 +19,18 @@ SpDialogWindowMorph >> addInitialPanel [
 	"Do nothing here because Spec will take care of adding the content"
 ]
 
+{ #category : 'private' }
+SpDialogWindowMorph >> announceWillClose [
+	| announcement |
+
+	announcement := SpWindowWillClose new
+		window: self;
+		yourself.
+	self announce: announcement.
+	self currentWorld announcer announce: announcement.
+	^ announcement canClose
+]
+
 { #category : 'protocol' }
 SpDialogWindowMorph >> cancelAction: aBlock [
 
@@ -31,10 +43,34 @@ SpDialogWindowMorph >> cancelled [
 	^ self toolbar cancelled
 ]
 
+{ #category : 'private' }
+SpDialogWindowMorph >> deleteDiscardingChanges [
+
+	self announceWillClose ifFalse: [ ^ self ].
+	^ super deleteDiscardingChanges
+]
+
 { #category : 'actions' }
 SpDialogWindowMorph >> escapePressed [
 
 	self model triggerCancelAction
+]
+
+{ #category : 'resize/collapse' }
+SpDialogWindowMorph >> extent: aPoint [ 
+	| announcement oldExtent |
+	
+	oldExtent := self extent. 
+	super extent: aPoint.
+	
+	oldExtent = aPoint ifFalse: [  	
+		announcement := SpWindowResizing new
+			window: self;
+			oldSize: oldExtent;
+			newSize: aPoint;
+			yourself.
+		self announce: announcement.
+		self currentWorld announcer announce: announcement ]
 ]
 
 { #category : 'focus' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
@@ -66,7 +66,7 @@ SpMorphicWindowAdapter >> beep [
 { #category : 'factory' }
 SpMorphicWindowAdapter >> buildWidget [
 
-	^ SpWindow new
+	^ SpWindowMorph new
 		model: model;
 		isResizeable: self isResizable;
 		in: [ :this | self subscribeToAnnouncements: this ];

--- a/src/Spec2-Adapters-Morphic/SpTickingSpecWindow.class.st
+++ b/src/Spec2-Adapters-Morphic/SpTickingSpecWindow.class.st
@@ -3,7 +3,7 @@ TickingSpecWindow new openInWorld
 "
 Class {
 	#name : 'SpTickingSpecWindow',
-	#superclass : 'SpWindow',
+	#superclass : 'SpWindowMorph',
 	#category : 'Spec2-Adapters-Morphic-Support',
 	#package : 'Spec2-Adapters-Morphic',
 	#tag : 'Support'

--- a/src/Spec2-Adapters-Morphic/SpWindowMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpWindowMorph.class.st
@@ -4,7 +4,7 @@ I am a window used by WindowSpec.
 I have been introduced since it's currently the best solution to prevent to add dozen of respondsTo: in StandardWindow or add dirty extensions to Object (because all models are not subclasses of Model)
 "
 Class {
-	#name : 'SpWindow',
+	#name : 'SpWindowMorph',
 	#superclass : 'StandardWindow',
 	#category : 'Spec2-Adapters-Morphic-Support',
 	#package : 'Spec2-Adapters-Morphic',
@@ -12,13 +12,13 @@ Class {
 }
 
 { #category : 'protocol' }
-SpWindow >> aboutText [
+SpWindowMorph >> aboutText [
 
 	^ self model aboutText
 ]
 
 { #category : 'closing' }
-SpWindow >> allowedToClose [
+SpWindowMorph >> allowedToClose [
 
 	super allowedToClose ifFalse: [ ^ false ].
 	self model ifNil: [ ^ true ].
@@ -28,7 +28,7 @@ SpWindow >> allowedToClose [
 ]
 
 { #category : 'private' }
-SpWindow >> announceWillClose [
+SpWindowMorph >> announceWillClose [
 	| announcement |
 
 	announcement := SpWindowWillClose new
@@ -40,43 +40,42 @@ SpWindow >> announceWillClose [
 ]
 
 { #category : 'open/close' }
-SpWindow >> deleteDiscardingChanges [
+SpWindowMorph >> deleteDiscardingChanges [
 
 	self announceWillClose ifFalse: [ ^ self ].
 	^ super deleteDiscardingChanges
 ]
 
 { #category : 'open/close' }
-SpWindow >> extent: aPoint [ 
+SpWindowMorph >> extent: aPoint [ 
 	| announcement oldExtent |
 	oldExtent := self extent. 
 	super extent: aPoint.
 	
-	oldExtent = aPoint
-		ifFalse: [  	
-			announcement := SpWindowResizing new
-				window: self;
-				oldSize: oldExtent;
-				newSize: aPoint;
-				yourself.
-			self announce: announcement.
-			self currentWorld announcer announce: announcement ]
+	oldExtent = aPoint ifFalse: [  	
+		announcement := SpWindowResizing new
+			window: self;
+			oldSize: oldExtent;
+			newSize: aPoint;
+			yourself.
+		self announce: announcement.
+		self currentWorld announcer announce: announcement ]
 ]
 
 { #category : 'testing' }
-SpWindow >> hasWidget: aMorph [ 
+SpWindowMorph >> hasWidget: aMorph [ 
 	
 	^ self allMorphs includes: aMorph
 ]
 
 { #category : 'updating' }
-SpWindow >> okToChange [
+SpWindowMorph >> okToChange [
 
 	^ self model okToChange
 ]
 
 { #category : 'private' }
-SpWindow >> taskbarIcon [
+SpWindowMorph >> taskbarIcon [
 	"If we close the window programatically while the taskbar is been updated the model can be nil in some cases."
 
 	(self model isNil or: [ self model windowIcon isNil ]) ifTrue: [ ^ super taskbarIcon ].
@@ -85,7 +84,7 @@ SpWindow >> taskbarIcon [
 ]
 
 { #category : 'accessing' }
-SpWindow >> taskbarTask [
+SpWindowMorph >> taskbarTask [
 	"Answer a taskbar task for the receiver.
 	 Answer nil if not required."
 

--- a/src/Spec2-Tests/SpWindowMorphTest.class.st
+++ b/src/Spec2-Tests/SpWindowMorphTest.class.st
@@ -2,7 +2,7 @@
 SUnit tests for SpecWindow
 "
 Class {
-	#name : 'SpWindowTest',
+	#name : 'SpWindowMorphTest',
 	#superclass : 'TestCase',
 	#instVars : [
 		'windowPresenter'
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : 'tests' }
-SpWindowTest >> testAboutText [
+SpWindowMorphTest >> testAboutText [
 
 	| presenter window |
 	windowPresenter := SpWindowPresenter new.
@@ -30,7 +30,7 @@ SpWindowTest >> testAboutText [
 ]
 
 { #category : 'tests' }
-SpWindowTest >> testAllowedToClose [
+SpWindowMorphTest >> testAllowedToClose [
 
 	| application appWindow |
 	application := SpApplication new.
@@ -56,7 +56,7 @@ SpWindowTest >> testAllowedToClose [
 ]
 
 { #category : 'tests' }
-SpWindowTest >> testCloseWindowRemovesItFromApplicationWindowCollection [
+SpWindowMorphTest >> testCloseWindowRemovesItFromApplicationWindowCollection [
 
 	| application |
 	application := SpApplication new.
@@ -67,7 +67,7 @@ SpWindowTest >> testCloseWindowRemovesItFromApplicationWindowCollection [
 ]
 
 { #category : 'tests' }
-SpWindowTest >> testIsDisplayed [
+SpWindowMorphTest >> testIsDisplayed [
 
 	"Test for case: 16800 -> ask a SpecWindow for #isDisplayed always returns true"
 
@@ -82,7 +82,7 @@ SpWindowTest >> testIsDisplayed [
 ]
 
 { #category : 'tests' }
-SpWindowTest >> testTitle [
+SpWindowMorphTest >> testTitle [
 
 	| presenter window |
 	windowPresenter := SpTextPresenter new open.


### PR DESCRIPTION
-Fixed Resize and SpWindowWillClose event not being triggered for modals or dialogs and added tests.
-Renaming SpWindow to SpWindowMorph because its name was confusing.
-Refactoring SpWindowTests to SpWindowMorphTests.