### PR TITLE
avoid presenter opening too late when using SpWindowForceOpenNonModal.

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicDialogWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicDialogWindowAdapter.class.st
@@ -54,12 +54,15 @@ SpMorphicDialogWindowAdapter >> buildWidget [
 
 { #category : 'private' }
 SpMorphicDialogWindowAdapter >> waitWhile: aBlock [
-	
-	SpWindowForceOpenNonModal value ifTrue: [ ^ self ].
+
+	SpWindowForceOpenNonModal value ifTrue: [ 
+			"ensure the window opening before returning"
+			self currentWorld doOneCycle.
+			^ self ].
 	SpWindowSimulateOpenModal value ifNotNil: [ :aValuable |
-		aValuable value: self presenter.
-		self presenter close.
-		^ self ].
-	
+			aValuable value: self presenter.
+			self presenter close.
+			^ self ].
+
 	MorphicRenderLoop new doOneCycleWhile: aBlock
 ]


### PR DESCRIPTION
This can lead to  application not able to close the presenter in the teardown