### PR TITLE
1790 fixing sp search input field presenter not appearing

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicSearchInputFieldAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicSearchInputFieldAdapter.class.st
@@ -42,7 +42,7 @@ SpMorphicSearchInputFieldAdapter >> buildWidget [
 		layoutPolicy: SpMorphicOverlayLayout new;
 		addMorph: iconsContainer.
  "This brings placeholder morph to the front. This is because it is behind the background morph, so if you change the background color from transparent it hides the placeholder"
-	textMorph privateAddMorph: textMorph submorphs last atIndex: 1.
+	textMorph addMorphInFrontOfLayer: textMorph submorphs last.
 	^ textMorph
 ]
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicSearchInputFieldAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicSearchInputFieldAdapter.class.st
@@ -41,7 +41,8 @@ SpMorphicSearchInputFieldAdapter >> buildWidget [
 	textMorph
 		layoutPolicy: SpMorphicOverlayLayout new;
 		addMorph: iconsContainer.
-
+ "This brings placeholder morph to the front. This is because it is behind the background morph, so if you change the background color from transparent it hides the placeholder"
+	textMorph privateAddMorph: textMorph submorphs last atIndex: 1.
 	^ textMorph
 ]
 

--- a/src/Spec2-Examples/SpSearchInputFieldPresenter.extension.st
+++ b/src/Spec2-Examples/SpSearchInputFieldPresenter.extension.st
@@ -8,3 +8,46 @@ SpSearchInputFieldPresenter class >> example [
 		placeholder: 'Search...';
 		open
 ]
+
+{ #category : '*Spec2-Examples' }
+SpSearchInputFieldPresenter class >> example2 [
+	<sampleInstance>
+	^ SpPresenter new
+		layout: (SpBoxLayout newTopToBottom 
+			add: (self new 
+					placeholder: 'example2';
+					yourself) 
+			expand: false;
+				add: (SpBoxLayout newLeftToRight
+					add: (SpBoxLayout newTopToBottom
+						add: (SpLabelPresenter new label: 'title') expand: false;
+						add: SpEasyListViewPresenter new;
+					yourself);
+				yourself);
+			yourself);
+		open
+
+]
+
+{ #category : '*Spec2-Examples' }
+SpSearchInputFieldPresenter class >> example3 [
+	<sampleInstance>
+	| searchbar |
+	SpPresenter new
+		layout: (SpOverlayLayout new
+			addOverlay: (SpLabelPresenter new label: 'overlay') 
+				withConstraints: [ :c | c vAlignEnd; hAlignStart ];
+			child: (SpBoxLayout newTopToBottom 
+				add: (searchbar := self new placeholder: 'example2') expand: false;
+					add: (SpBoxLayout newLeftToRight
+						add: (SpBoxLayout newTopToBottom
+							add: (SpLabelPresenter new label: 'title') expand: false;
+							add: SpEasyListViewPresenter new;
+						yourself);
+					yourself);
+				yourself);
+			yourself);
+		open.
+	searchbar placeholder: 'changing'
+
+]


### PR DESCRIPTION
changed the buildWidget: method of SpMorphicSearchInputFieldAdapter to make sure placeholder submorph is in the front. 
The bug was that the background submorph was on top of the placeholder morph. Usually it doesn't bother because the background of the presenter is transparent, but because we had changed it to a color when making st-pulse, we couldn't see it, so I fixed that :)