### PR TITLE
Improve setting the paths of a tree

### DIFF
--- a/src/Spec2-Core/SpTreeMultipleSelectionMode.class.st
+++ b/src/Spec2-Core/SpTreeMultipleSelectionMode.class.st
@@ -65,17 +65,15 @@ SpTreeMultipleSelectionMode >> selectPath: aPath [
 
 { #category : 'selection' }
 SpTreeMultipleSelectionMode >> selectPaths: pathArray [
-	(pathArray isEmpty 
-		or: [ 
-			pathArray size = 1 
-			and: [ pathArray first isEmpty] ]) 
-		ifTrue: [ ^ self unselectAll ].
 
-	pathArray
-		do: [ :path | presenter itemAtPath: path ifAbsent: [ ^ self ] ].
-	selection = pathArray ifTrue: [ ^ self ].
-	
-	selection := pathArray
+	| paths |
+	paths := pathArray asArray.
+	(paths isEmpty or: [ paths size = 1 and: [ paths first isEmpty ] ]) ifTrue: [ ^ self unselectAll ].
+
+	paths do: [ :path | presenter itemAtPath: path ifAbsent: [ ^ self ] ].
+	selection = paths ifTrue: [ ^ self ].
+
+	selection := paths
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Core/SpTreeSingleSelectionMode.class.st
+++ b/src/Spec2-Core/SpTreeSingleSelectionMode.class.st
@@ -24,10 +24,12 @@ SpTreeSingleSelectionMode >> selectPath: aPath [
 
 	"If the path is out of range, keep the selection."
 
-	aPath ifEmpty: [ ^ self unselectAll ].
-	presenter itemAtPath: aPath ifAbsent: [ ^ self ].
-	selection = aPath ifTrue: [ ^ self ].
-	selection := aPath
+	| path |
+	path := aPath asArray.
+	path ifEmpty: [ ^ self unselectAll ].
+	presenter itemAtPath: path ifAbsent: [ ^ self ].
+	selection = path ifTrue: [ ^ self ].
+	selection := path
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Core/SpTreeSingleSelectionMode.class.st
+++ b/src/Spec2-Core/SpTreeSingleSelectionMode.class.st
@@ -23,12 +23,11 @@ SpTreeSingleSelectionMode >> selectPath: aPath [
 	"Check comment in my superclass to know how to use selectPath:"
 
 	"If the path is out of range, keep the selection."
-	aPath ifEmpty: [ ^ self unselectAll ].
-	presenter 
-		itemAtPath: aPath 
-		ifAbsent: [ ^ self ].
-	selection := aPath
 
+	aPath ifEmpty: [ ^ self unselectAll ].
+	presenter itemAtPath: aPath ifAbsent: [ ^ self ].
+	selection = aPath ifTrue: [ ^ self ].
+	selection := aPath
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Tests/SpTreePresenterTest.class.st
+++ b/src/Spec2-Tests/SpTreePresenterTest.class.st
@@ -15,31 +15,47 @@ SpTreePresenterTest >> classToTest [
 { #category : 'tests' }
 SpTreePresenterTest >> testWhenSelectedItemChangedDoNotFiredIfWeSelectTheSameElementsInMultipleSelection [
 
-	| count |
-	count := 0.
 	presenter beMultipleSelection.
 
 	presenter selectPaths: #( #( 1 ) #( 2 1 ) ).
 
-	presenter whenSelectedItemChangedDo: [ :item | count := count + 1 ].
+	presenter whenSelectedItemChangedDo: [ :item | self fail: 'We should not trigger this block if we set the same paths' ].
 
-	presenter selectPaths: #( #( 1 ) #( 2 1 ) ).
+	presenter selectPaths: #( #( 1 ) #( 2 1 ) )
+]
 
-	self assert: count equals: 0
+{ #category : 'tests' }
+SpTreePresenterTest >> testWhenSelectedItemChangedDoNotFiredIfWeSelectTheSameElementsInSingleSelection [
+
+	presenter beSingleSelection.
+
+	presenter selectPath: #( 1 ).
+
+	presenter whenSelectedItemChangedDo: [ :item | self fail: 'We should not trigger this block if we set the same paths' ].
+
+	presenter selectPath: #( 1 )
 ]
 
 { #category : 'tests' }
 SpTreePresenterTest >> testWhenSelectedItemChangedDoNotFiredIfWeSelectTheSameElementsWithDifferentCollectionInMultipleSelection [
 
-	| count |
-	count := 0.
 	presenter beMultipleSelection.
 
 	presenter selectPaths: #( #( 1 ) #( 2 1 ) ).
 
-	presenter whenSelectedItemChangedDo: [ :item | count := count + 1 ].
+	presenter whenSelectedItemChangedDo: [ :item | self fail: 'We should not trigger this block if we set the same paths' ].
 
-	presenter selectPaths: #( #( 1 ) #( 2 1 ) ) asOrderedCollection.
+	presenter selectPaths: #( #( 1 ) #( 2 1 ) ) asOrderedCollection
+]
 
-	self assert: count equals: 0
+{ #category : 'tests' }
+SpTreePresenterTest >> testWhenSelectedItemChangedDoNotFiredIfWeSelectTheSameElementsWithDifferentCollectionInSingleSelection [
+
+	presenter beSingleSelection.
+
+	presenter selectPath: #( 1 ).
+
+	presenter whenSelectedItemChangedDo: [ :item | self fail: 'We should not trigger this block if we set the same paths' ].
+
+	presenter selectPath: #( 1 ) asOrderedCollection
 ]

--- a/src/Spec2-Tests/SpTreePresenterTest.class.st
+++ b/src/Spec2-Tests/SpTreePresenterTest.class.st
@@ -11,3 +11,35 @@ SpTreePresenterTest >> classToTest [
 
 	^ SpTreePresenter
 ]
+
+{ #category : 'tests' }
+SpTreePresenterTest >> testWhenSelectedItemChangedDoNotFiredIfWeSelectTheSameElementsInMultipleSelection [
+
+	| count |
+	count := 0.
+	presenter beMultipleSelection.
+
+	presenter selectPaths: #( #( 1 ) #( 2 1 ) ).
+
+	presenter whenSelectedItemChangedDo: [ :item | count := count + 1 ].
+
+	presenter selectPaths: #( #( 1 ) #( 2 1 ) ).
+
+	self assert: count equals: 0
+]
+
+{ #category : 'tests' }
+SpTreePresenterTest >> testWhenSelectedItemChangedDoNotFiredIfWeSelectTheSameElementsWithDifferentCollectionInMultipleSelection [
+
+	| count |
+	count := 0.
+	presenter beMultipleSelection.
+
+	presenter selectPaths: #( #( 1 ) #( 2 1 ) ).
+
+	presenter whenSelectedItemChangedDo: [ :item | count := count + 1 ].
+
+	presenter selectPaths: #( #( 1 ) #( 2 1 ) ) asOrderedCollection.
+
+	self assert: count equals: 0
+]


### PR DESCRIPTION
This changes has multiple effets:
- In single selection mode, update the selected path only if we do not have this path selected already. We are already doing that in other selection modes. Like this, if the value does not change, we do not launch an update of the observable slot
- In multiple selection mode, we compare the current selection with the one provided as argument of #selectPaths: to not set the variable if the content is the same. But if the user is providing, for example, an ordered collection, then we still set the variable since it contains an array. Now we add an explicit #asArray to be sure to compare the same kind of collection
- Allow in multiple selection to give more kinds of collections (array, ordered collection, set, ...) by using an #asArray. I had multiple times the case of a set been used to set selections and the presenter breaking because it expects a sequenceable collection