### PR TITLE
[Backport] Fix Filtering list ports

### DIFF
--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -92,13 +92,13 @@ SpFilteringListPresenter >> contextMenu: aValuable [
 { #category : 'transmission' }
 SpFilteringListPresenter >> defaultInputPort [
 
-	^ listPresenter defaultInputPort
+	^ self inputItemsPort
 ]
 
 { #category : 'transmission' }
 SpFilteringListPresenter >> defaultOutputPort [
 
-	^ listPresenter defaultOutputPort
+	^ self outputSelectionPort
 ]
 
 { #category : 'api' }
@@ -176,8 +176,8 @@ SpFilteringListPresenter >> initializePresenters [
 
 { #category : 'transmission' }
 SpFilteringListPresenter >> inputItemsPort [
-	
-	^ listPresenter inputItemsPort
+
+	^ SpListItemsPort newPresenter: self
 ]
 
 { #category : 'private' }
@@ -234,13 +234,13 @@ SpFilteringListPresenter >> newListToFilter [
 { #category : 'transmission' }
 SpFilteringListPresenter >> outputActivationPort [
 	
-	^ listPresenter outputActivationPort
+	^ SpActivationPort newPresenter: self
 ]
 
 { #category : 'transmission' }
 SpFilteringListPresenter >> outputSelectionPort [
 	
-	^ listPresenter outputSelectionPort
+	^ SpSelectionPort newPresenter: self
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
Currently the Filtering list is forwarding the ports to the ports of the wrapped list but this is wrong. The Filtering list needs to go itself into the #items: method, else we cannot save the items to filter.  Currently if you use transmissions on a filtering list, the list ends up empty because the unflitered items list will be an empty array