### PR TITLE
Fix SpMorphicBoxAdapter>>#verifyBoxExtentOf:withChild: to only add border width/height when adding the first child morph instead of adding border width/height for every child morph

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -332,8 +332,12 @@ SpMorphicBoxAdapter >> verifyBoxExtent [
 SpMorphicBoxAdapter >> verifyBoxExtentOf: aPanel withChild: childMorph [
 	| width height newPanelWidth newPanelHeight |
 
-	width := childMorph width + (widget borderWidth * 2).
-	height := childMorph height + (widget borderWidth * 2).
+	width := childMorph width.
+	height := childMorph height.
+	startPanel submorphCount + endPanel submorphCount = 0
+		ifTrue: [
+			width := width + (widget borderWidth * 2).
+			height := height + (widget borderWidth * 2) ].
 
 	layout isVertical 
 		ifTrue: [ height := height + aPanel height + aPanel cellInset ]

--- a/src/Spec2-Backend-Tests/SpBoxLayoutAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpBoxLayoutAdapterTest.class.st
@@ -12,6 +12,12 @@ SpBoxLayoutAdapterTest class >> isAbstract [
 	^ self == SpBoxLayoutAdapterTest
 ]
 
+{ #category : 'helpers' }
+SpBoxLayoutAdapterTest >> add16By16ImageTo: aLayout [
+
+	aLayout add: (presenter newImage image: (presenter iconNamed: 'box')) withConstraints: [ :constraints | constraints height: 16; width: 16 ]
+]
+
 { #category : 'tests' }
 SpBoxLayoutAdapterTest >> testAdapterElementsAreInSameOrderThanLayout [
 

--- a/src/Spec2-Backend-Tests/SpHorizontalBoxLayoutAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpHorizontalBoxLayoutAdapterTest.class.st
@@ -13,6 +13,55 @@ SpHorizontalBoxLayoutAdapterTest >> newLayout [
 ]
 
 { #category : 'tests' }
+SpHorizontalBoxLayoutAdapterTest >> testAdapterWidthIsSumOfElementWidthsAndBorderWhenItHasABorder [
+
+	| iconBarLayout iconBar layoutWidget borderWidth numberOfNestedImages |
+	borderWidth := 5.
+	iconBarLayout := SpBoxLayout newLeftToRight
+		borderWidth: borderWidth;
+		yourself.
+	numberOfNestedImages := 3.
+	1 to: numberOfNestedImages do: [ :index | self add16By16ImageTo: iconBarLayout ].
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + (numberOfNestedImages * 16) + borderWidth.
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
+SpHorizontalBoxLayoutAdapterTest >> testAdapterWidthIsWidthOfSingleElementAndBorderWhenItHasABorder [
+
+	| iconBarLayout iconBar layoutWidget borderWidth |
+	borderWidth := 5.
+	iconBarLayout := SpBoxLayout newLeftToRight
+		borderWidth: borderWidth;
+		yourself.
+	self add16By16ImageTo: iconBarLayout.
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth.
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
 SpHorizontalBoxLayoutAdapterTest >> testAddingElementsToFixedWidthLayoutDoesNotImpactTheWidthOfTheAdapter [
 
 	| firstButton secondButton nestedLayout nestedPresenter layoutWidget fixedWidth |

--- a/src/Spec2-Backend-Tests/SpVerticalBoxLayoutAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpVerticalBoxLayoutAdapterTest.class.st
@@ -13,6 +13,55 @@ SpVerticalBoxLayoutAdapterTest >> newLayout [
 ]
 
 { #category : 'tests' }
+SpVerticalBoxLayoutAdapterTest >> testAdapterWidthIsSumOfElementWidthsAndBorderWhenItHasABorder [
+
+	| iconBarLayout iconBar layoutWidget borderWidth numberOfNestedImages |
+	borderWidth := 5.
+	iconBarLayout := SpBoxLayout newTopToBottom
+		borderWidth: borderWidth;
+		yourself.
+	numberOfNestedImages := 3.
+	1 to: numberOfNestedImages do: [ :index | self add16By16ImageTo: iconBarLayout ].
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget height equals: borderWidth + (numberOfNestedImages * 16) + borderWidth.
+	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
+SpVerticalBoxLayoutAdapterTest >> testAdapterWidthIsWidthOfSingleElementAndBorderWhenItHasABorder [
+
+	| iconBarLayout iconBar layoutWidget borderWidth |
+	borderWidth := 5.
+	iconBarLayout := SpBoxLayout newTopToBottom
+		borderWidth: borderWidth;
+		yourself.
+	self add16By16ImageTo: iconBarLayout.
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth.
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
 SpVerticalBoxLayoutAdapterTest >> testAddingElementsToFixedHeightLayoutDoesNotImpactTheHeightOfTheAdapter [
 
 	| firstButton secondButton nestedLayout nestedPresenter layoutWidget fixedHeight |


### PR DESCRIPTION
This PR fixes bug 1 as reported by  https://github.com/pharo-spec/Spec/issues/1818

In the screenshots, we see a border of 3 pixels. We use presenters with a fixed size, i.e. an image of 16 by 16 pixels. See the added unit tests.

### Before situation

For a layout with one presenter, the calculation of the extent is ok:

<img width="375" height="244" alt="Image" src="https://github.com/user-attachments/assets/e2057170-4fe2-4b26-acb7-6fa391ea30f1" />

For a horizontal layout with more than one presenter, the calculation of the extent is wrong, as described in https://github.com/pharo-spec/Spec/issues/1818. Here is the situation when the layout holds three presenters:

<img width="375" height="244" alt="Image" src="https://github.com/user-attachments/assets/6b96f463-e830-47ff-ba1f-b9da0159d547" />

For a verical layout with more than one presenter, the calculation of the extent is also wrong. Here is the situation when the layout holds three presenters:

<img width="375" height="244" alt="Screenshot 2025-09-12 at 08 36 57" src="https://github.com/user-attachments/assets/c0878c37-2ca5-479d-88fe-02c49e7a5f40" />

### After situation

This PR fixes the bug so that we have these results:

<img width="375" height="244" alt="Screenshot 2025-09-12 at 08 37 35" src="https://github.com/user-attachments/assets/6592b10c-7e5f-4499-952e-9a11f593d1a6" />

<img width="375" height="244" alt="Screenshot 2025-09-12 at 08 37 42" src="https://github.com/user-attachments/assets/d28f3ccd-94db-4f1c-b1dd-bc7c31418d56" />

<img width="375" height="244" alt="Screenshot 2025-09-12 at 08 37 58" src="https://github.com/user-attachments/assets/af3f8c69-5d1b-46c3-9413-59ada171a588" />

All Spec tests have been run. 3 tests failed, but they already failed before the changes in this PR:

<img width="800" height="600" alt="Screenshot 2025-09-12 at 09 08 30" src="https://github.com/user-attachments/assets/d7e7285c-0c4f-4a1a-ab65-6638de91105c" />


