### PR TITLE
Bug fix: Apply box layout spacing in SpMorphicBoxAdapter>>#verifyBoxExtentOf:withChild:

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -330,18 +330,22 @@ SpMorphicBoxAdapter >> verifyBoxExtent [
 
 { #category : 'private' }
 SpMorphicBoxAdapter >> verifyBoxExtentOf: aPanel withChild: childMorph [
-	| width height newPanelWidth newPanelHeight |
+	| width height newPanelWidth newPanelHeight spacing |
 
 	width := childMorph width.
 	height := childMorph height.
+	"The cellInset of the startPanel and the endPanel hold the spacing of the box layout.
+	 They are the same. See #layout."
+	spacing := startPanel cellInset.
 	startPanel submorphCount + endPanel submorphCount = 0
 		ifTrue: [
 			width := width + (widget borderWidth * 2).
-			height := height + (widget borderWidth * 2) ].
+			height := height + (widget borderWidth * 2).
+			spacing := 0 ].
 
 	layout isVertical 
-		ifTrue: [ height := height + aPanel height + aPanel cellInset ]
-		ifFalse: [ width := width + aPanel width + aPanel cellInset ].
+		ifTrue: [ height := height + aPanel height + spacing ]
+		ifFalse: [ width := width + aPanel width + spacing ].
 
 	newPanelWidth := aPanel hResizing = #rigid
 		ifTrue: [ aPanel width ]

--- a/src/Spec2-Backend-Tests/SpHorizontalBoxLayoutAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpHorizontalBoxLayoutAdapterTest.class.st
@@ -13,11 +13,38 @@ SpHorizontalBoxLayoutAdapterTest >> newLayout [
 ]
 
 { #category : 'tests' }
+SpHorizontalBoxLayoutAdapterTest >> testAdapterWidthIsSumOfElementWidthsAndBorderAndSpacingWhenItHasSpacing [
+
+	| iconBarLayout iconBar layoutWidget borderWidth numberOfNestedImages spacing |
+	borderWidth := 5.
+	spacing := 10.
+	iconBarLayout := self newLayout
+		borderWidth: borderWidth;
+		spacing: spacing;
+		yourself.
+	numberOfNestedImages := 3.
+	1 to: numberOfNestedImages do: [ :index | self add16By16ImageTo: iconBarLayout ].
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + (numberOfNestedImages * 16) + borderWidth + ((numberOfNestedImages - 1) * spacing).
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
 SpHorizontalBoxLayoutAdapterTest >> testAdapterWidthIsSumOfElementWidthsAndBorderWhenItHasABorder [
 
 	| iconBarLayout iconBar layoutWidget borderWidth numberOfNestedImages |
 	borderWidth := 5.
-	iconBarLayout := SpBoxLayout newLeftToRight
+	iconBarLayout := self newLayout
 		borderWidth: borderWidth;
 		yourself.
 	numberOfNestedImages := 3.
@@ -42,8 +69,33 @@ SpHorizontalBoxLayoutAdapterTest >> testAdapterWidthIsWidthOfSingleElementAndBor
 
 	| iconBarLayout iconBar layoutWidget borderWidth |
 	borderWidth := 5.
-	iconBarLayout := SpBoxLayout newLeftToRight
+	iconBarLayout := self newLayout
 		borderWidth: borderWidth;
+		yourself.
+	self add16By16ImageTo: iconBarLayout.
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth.
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
+SpHorizontalBoxLayoutAdapterTest >> testAdapterWidthIsWidthOfSingleElementAndBorderWhenItHasSpacing [
+
+	| iconBarLayout iconBar layoutWidget borderWidth |
+	borderWidth := 5.
+	iconBarLayout := self newLayout
+		borderWidth: borderWidth;
+		spacing: 10;
 		yourself.
 	self add16By16ImageTo: iconBarLayout.
 	iconBar := SpPresenter new

--- a/src/Spec2-Backend-Tests/SpVerticalBoxLayoutAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpVerticalBoxLayoutAdapterTest.class.st
@@ -13,11 +13,60 @@ SpVerticalBoxLayoutAdapterTest >> newLayout [
 ]
 
 { #category : 'tests' }
-SpVerticalBoxLayoutAdapterTest >> testAdapterWidthIsSumOfElementWidthsAndBorderWhenItHasABorder [
+SpVerticalBoxLayoutAdapterTest >> testAdapterHeightIsHeightOfSingleElementAndBorderWhenItHasABorder [
+
+	| iconBarLayout iconBar layoutWidget borderWidth |
+	borderWidth := 5.
+	iconBarLayout := self newLayout
+		borderWidth: borderWidth;
+		yourself.
+	self add16By16ImageTo: iconBarLayout.
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth.
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
+SpVerticalBoxLayoutAdapterTest >> testAdapterHeightIsHeightOfSingleElementAndBorderWhenItHasSpacing [
+
+	| iconBarLayout iconBar layoutWidget borderWidth |
+	borderWidth := 5.
+	iconBarLayout := self newLayout
+		borderWidth: borderWidth;
+		spacing: 10;
+		yourself.
+	self add16By16ImageTo: iconBarLayout.
+	iconBar := SpPresenter new
+		layout: iconBarLayout;
+		yourself.
+	layout
+		vAlignCenter;
+		hAlignCenter;
+		add: iconBar expand: false.
+	self openInstance.
+	
+	layoutWidget := iconBar adapter widget.
+	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
+	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth.
+	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+]
+
+{ #category : 'tests' }
+SpVerticalBoxLayoutAdapterTest >> testAdapterHeightIsSumOfElementHeightsAndBorderWhenItHasABorder [
 
 	| iconBarLayout iconBar layoutWidget borderWidth numberOfNestedImages |
 	borderWidth := 5.
-	iconBarLayout := SpBoxLayout newTopToBottom
+	iconBarLayout := self newLayout
 		borderWidth: borderWidth;
 		yourself.
 	numberOfNestedImages := 3.
@@ -38,14 +87,17 @@ SpVerticalBoxLayoutAdapterTest >> testAdapterWidthIsSumOfElementWidthsAndBorderW
 ]
 
 { #category : 'tests' }
-SpVerticalBoxLayoutAdapterTest >> testAdapterWidthIsWidthOfSingleElementAndBorderWhenItHasABorder [
+SpVerticalBoxLayoutAdapterTest >> testAdapterHeightIsSumOfElementWidthsAndBorderAndSpacingWhenItHasSpacing [
 
-	| iconBarLayout iconBar layoutWidget borderWidth |
+	| iconBarLayout iconBar layoutWidget borderWidth numberOfNestedImages spacing |
 	borderWidth := 5.
-	iconBarLayout := SpBoxLayout newTopToBottom
+	spacing := 10.
+	iconBarLayout := self newLayout
 		borderWidth: borderWidth;
+		spacing: spacing;
 		yourself.
-	self add16By16ImageTo: iconBarLayout.
+	numberOfNestedImages := 3.
+	1 to: numberOfNestedImages do: [ :index | self add16By16ImageTo: iconBarLayout ].
 	iconBar := SpPresenter new
 		layout: iconBarLayout;
 		yourself.
@@ -58,7 +110,7 @@ SpVerticalBoxLayoutAdapterTest >> testAdapterWidthIsWidthOfSingleElementAndBorde
 	layoutWidget := iconBar adapter widget.
 	layoutWidget borderColor: Color white. "In case the reader wants to inspect the result."
 	self assert: layoutWidget width equals: borderWidth + 16 + borderWidth.
-	self assert: layoutWidget height equals: borderWidth + 16 + borderWidth
+	self assert: layoutWidget height equals: borderWidth + (numberOfNestedImages * 16) + borderWidth + ((numberOfNestedImages - 1) * spacing).
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Fix for #1525.

The screenshots below are based on this code:
```smalltalk
application := SpApplication new
		addStyleSheetFromString: '.application [
			.bar [ Container { #borderWidth: 3, #borderColor: #FFFFFF } ] ]'.
mainPresenter := SpPresenter newApplication: application.
boxIcon := mainPresenter iconNamed: 'box'.
iconBarLayout := SpBoxLayout newLeftToRight
		spacing: 20;
		add: (mainPresenter newImage image: boxIcon) expand: false;
		add: (mainPresenter newImage image: boxIcon) expand: false;
		add: (mainPresenter newImage image: boxIcon) expand: false;
		yourself.
iconBar := (SpPresenter newApplication: application)
	layout: iconBarLayout;
	addStyle: 'bar';
	yourself.
mainLayout := SpBoxLayout newTopToBottom
	vAlignCenter;
	hAlignCenter;
	yourself.
mainLayout add: iconBar expand: false.
mainPresenter layout: mainLayout; open
```

Note the part `spacing: 20;`

## Horizontal box layout

### Before situation with 1, 2 and 3 images

<img width="269" height="164" alt="Screenshot 2025-10-01 at 23 15 17" src="https://github.com/user-attachments/assets/b8d44d23-4a03-4f78-8357-703be876d56f" />
<img width="269" height="164" alt="Screenshot 2025-10-01 at 23 15 26" src="https://github.com/user-attachments/assets/70262bdf-3d41-45f1-bcf3-83818ba4679a" />
<img width="269" height="164" alt="Screenshot 2025-10-01 at 23 15 40" src="https://github.com/user-attachments/assets/6b2d3189-3a16-4319-988a-98904cec7ed0" />


### After situation with 1, 2 and 3 images

<img width="269" height="164" alt="Screenshot 2025-10-01 at 22 50 31" src="https://github.com/user-attachments/assets/89bb8620-e1ed-4f70-a7ea-b420f0f8911d" />
<img width="269" height="164" alt="Screenshot 2025-10-01 at 22 50 44" src="https://github.com/user-attachments/assets/59b02e3e-b061-4cc3-9303-96717c1b7f22" />
<img width="269" height="164" alt="Screenshot 2025-10-01 at 22 50 52" src="https://github.com/user-attachments/assets/629edf04-12eb-4401-bcad-2a690691ebdc" />

## Vertical box layout

Now with `iconBarLayout := SpBoxLayout newTopToBottom`.

### Before situation with 1, 2 and 3 images

<img width="269" height="164" alt="Screenshot 2025-10-01 at 23 16 53" src="https://github.com/user-attachments/assets/29d8bf23-21ec-49f1-8975-2c145201f489" />
<img width="269" height="164" alt="Screenshot 2025-10-01 at 23 17 03" src="https://github.com/user-attachments/assets/ed785516-8fc4-44f7-bf57-8da0a108a9e6" />
<img width="269" height="164" alt="Screenshot 2025-10-01 at 23 17 09" src="https://github.com/user-attachments/assets/93f027c0-eac2-456a-9aa1-1748a3fde9d4" />


### After situation with 1, 2 and 3 images

<img width="269" height="164" alt="Screenshot 2025-10-01 at 22 51 22" src="https://github.com/user-attachments/assets/18d52e2d-73ae-405b-9734-caacdf8cdb10" /> <img width="269" height="164" alt="Screenshot 2025-10-01 at 22 51 12" src="https://github.com/user-attachments/assets/13f7a2e7-8eb3-4332-b988-1fafc2430607" /> <img width="269" height="164" alt="Screenshot 2025-10-01 at 22 51 04" src="https://github.com/user-attachments/assets/b431d880-66db-4bf3-8921-2f2a87087db1" />

## Example from #1525

### Before

<img width="160" height="100" alt="Screenshot 2025-10-01 at 23 25 17" src="https://github.com/user-attachments/assets/1b2afd45-bb6d-4a2f-bdb8-ef4ff646abed" />

### After
<img width="160" height="100" alt="Screenshot 2025-10-01 at 23 24 42" src="https://github.com/user-attachments/assets/6e69b0c5-38fd-45ab-ab75-09a014ea929e" />



## Tests are green
<img width="800" height="600" alt="Screenshot 2025-10-01 at 23 20 16" src="https://github.com/user-attachments/assets/59a63fa3-a57f-45af-96ee-05e1c82c4000" />



