### PR TITLE
Fix test resize

### DIFF
--- a/src/Spec2-Tests/SpWindowPresenterTest.class.st
+++ b/src/Spec2-Tests/SpWindowPresenterTest.class.st
@@ -81,9 +81,13 @@ SpWindowPresenterTest >> testResize [
 	
 	self openInstance.
 
+	"Let's not assume a default size ~= 600@600.
+	Instead, initially resize the window to 500@500, and then to 600@600.
+	Each resize should be observable."
+	presenter resize: 500@500.
 	self 
-		deny: presenter adapter windowSize 
-		equals: 600@600.
+		assert: presenter adapter windowSize 
+		equals: 500@500.
 	presenter resize: 600@600.
 	self 
 		assert: presenter adapter windowSize


### PR DESCRIPTION
Since cavrois introduction, resizing a window has a side effect, so this test becomes unrepeatable. Instead of assuming an initial size ~= 600@600, set it manually to a different one.