### PR TITLE
Update paginator when switching themes

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpPaginatorPageMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpPaginatorPageMorph.class.st
@@ -81,6 +81,16 @@ SpPaginatorPageMorph >> newContentMorph [
 		yourself
 ]
 
+{ #category : 'theme' }
+SpPaginatorPageMorph >> themeChanged [
+
+	self submorphsDo: [ :submorph |
+			submorph
+				color: self theme backgroundColor;
+				borderColor: self theme borderColor ].
+	super themeChanged
+]
+
 { #category : 'events' }
 SpPaginatorPageMorph >> whenSelectedDo: aBlock [
 

--- a/src/Spec2-Adapters-Morphic/SpPaginatorSelectionMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpPaginatorSelectionMorph.class.st
@@ -159,6 +159,12 @@ SpPaginatorSelectionMorph >> resetPosition [
 	lastX := nil
 ]
 
+{ #category : 'theme' }
+SpPaginatorSelectionMorph >> themeChanged [
+
+	self color: self defaultColor
+]
+
 { #category : 'accessing' }
 SpPaginatorSelectionMorph >> updateSizePages: pages pageWidth: pageWidth [ 
 	


### PR DESCRIPTION
Adding #themeChange to Paginator morphs.
This should fix the black boxes when switching from dark to light: 
<img width="766" height="572" alt="Capture d’écran 2025-10-23 à 18 10 04" src="https://github.com/user-attachments/assets/be077988-00bc-486b-91b9-56c8be1313ce" />

Backport to P13 would be nice but not absolutely necessary.