### PR TITLE
Morhic adapter: use #when:do:for: instead of #when:do:

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
@@ -717,12 +717,33 @@ SpAbstractMorphicAdapter >> vSpaceFill [
 ]
 
 { #category : 'protocol' }
-SpAbstractMorphicAdapter >> when: anAnnouncement do: aBlock [
+SpAbstractMorphicAdapter >> when: anAnnouncementClass do: aValuable [
 
-	self widgetDo: [ :w | 
-		w announcer
-			when: anAnnouncement 
-			do: aBlock ]
+	| subscriberForDeprecation |
+	aValuable receiver ifNil: [
+		self error:
+			'You must specify a subscriber object for this subscription. Please use #when:do:for: method.' ].
+
+	subscriberForDeprecation := thisContext sender receiver = aValuable receiver
+		                            ifTrue: [ 'self' ]
+		                            ifFalse: [ '`@arg2 receiver' ].
+	self
+		deprecated:
+			'Since there are some block closures (Clean and Constant) without a receiver, the API of announcements was changed to send the subscriber explicitly.
+			We are deprecating this method because it was asking for the receiver of the block to use it as the subscriber.'
+		transformWith: '`@receiver when: `@arg1 do: `@arg2'
+			->
+			('`@receiver when: `@arg1 do: `@arg2 for: '
+			 , subscriberForDeprecation).
+
+	self when: anAnnouncementClass do: aValuable for: aValuable receiver
+]
+
+{ #category : 'protocol' }
+SpAbstractMorphicAdapter >> when: anAnnouncement do: aBlock for: aSubscriber [
+
+	self widgetDo: [ :w |
+		w announcer when: anAnnouncement do: aBlock for: aSubscriber ]
 ]
 
 { #category : 'emulating' }


### PR DESCRIPTION
#when:do: has been removed.
Deprecation code copied from Roassal deprecations.