### PR TITLE
Re-add `SpWindowPresenter>>#restore`.

### DIFF
--- a/src/Spec2-Core/SpWindowPresenter.class.st
+++ b/src/Spec2-Core/SpWindowPresenter.class.st
@@ -554,6 +554,13 @@ SpWindowPresenter >> resize: anExtent [
 ]
 
 { #category : 'api' }
+SpWindowPresenter >> restore [
+	"Restore the window"
+
+	self withAdapterDo: [ :anAdapter | anAdapter restore ]
+]
+
+{ #category : 'api' }
 SpWindowPresenter >> size [
 	"Answer current window size. 
 	 This message will return 0@0 is window is not opened."


### PR DESCRIPTION
It is not there anymore for some reason. I think it was already (re-)added twice??

Backport from similar PR