### PR TITLE
Make the height of the paginator in a SpMillerPaginatorPresenter 20 pixels high explicitly

### DIFF
--- a/src/Spec2-Core/SpMillerPaginatorPresenter.class.st
+++ b/src/Spec2-Core/SpMillerPaginatorPresenter.class.st
@@ -41,7 +41,7 @@ SpMillerPaginatorPresenter >> initializePresenters [
 		add: ((paginatorContainerLayout := SpBoxLayout newLeftToRight)
 				hAlignCenter; 
 				yourself)
-			expand: false;
+			height: 20;
 		yourself).
 
 	millerList withoutHorizontalScrollBar.

--- a/src/Spec2-Tests/SpMillerPaginatorPresenterTest.class.st
+++ b/src/Spec2-Tests/SpMillerPaginatorPresenterTest.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : 'SpMillerPaginatorPresenterTest',
+	#superclass : 'SpSpecTest',
+	#category : 'Spec2-Tests-Core-Widgets',
+	#package : 'Spec2-Tests',
+	#tag : 'Core-Widgets'
+}
+
+{ #category : 'accessing' }
+SpMillerPaginatorPresenterTest >> classToTest [
+
+	^ SpMillerPaginatorPresenter
+]
+
+{ #category : 'running' }
+SpMillerPaginatorPresenterTest >> tearDown [
+
+	presenter withWindowDo: [ :w | w close ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+SpMillerPaginatorPresenterTest >> testHeightOfSubpresenters [
+
+	| button layout container |
+	layout := SpBoxLayout newTopToBottom
+		add: presenter height: 300;
+		yourself.
+	presenter millerListPresenter presenterBlock: [ :page | SpButtonPresenter new label: '2'; yourself ].
+	button := SpButtonPresenter new label: '1'; yourself.
+	presenter millerListPresenter addPresenter: button.
+	container := SpPresenter new layout: layout; yourself.
+	container open.
+	button click. "Add a second page so that the paginator appears."
+	WorldMorph doOneCycle. "Ensure that the height below is updated."
+	self assert: presenter millerListPresenter adapter widget height equals: 280.
+	self assert: presenter paginatorPresenter adapter widget height equals: 20
+]


### PR DESCRIPTION
Fix for #1830.

Here is the result after the fix. See inside the green circle.

<img width="658" height="533" alt="Screenshot 2025-11-01 at 12 25 08" src="https://github.com/user-attachments/assets/cc6e4e30-d55c-4c18-a899-8fa7bac5767c" />

All Spec tests have been run:

<img width="800" height="600" alt="Screenshot 2025-11-01 at 12 18 12" src="https://github.com/user-attachments/assets/a0076dfe-fc71-417e-982e-9366d78beef1" />
