### PR TITLE
Do not use StPharoApplication in Spec

### DIFF
--- a/src/Spec2-Commander2/CmCommand.extension.st
+++ b/src/Spec2-Commander2/CmCommand.extension.st
@@ -54,7 +54,7 @@ CmCommand class >> forSpecWithIconNamed: aSymbol shortcutKey: aKMKeyCombination 
 ]
 
 { #category : '*Spec2-Commander2' }
-CmCommand >> inform: aString [ 
+CmCommand >> inform: aString [
 
-	StPharoApplication current inform: aString
+	InformativeNotification signal: aString
 ]


### PR DESCRIPTION
This is just a quick fix. This method should not be added as extension by Spec at all. It'll get removed later from Spec

Fixes #1832