### PR TITLE
making list family behave a bit better when disabling/enabling activation/selection

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicImageAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicImageAdapter.class.st
@@ -11,8 +11,8 @@ Class {
 
 { #category : 'factory' }
 SpMorphicImageAdapter >> buildWidget [
-
 	| alphaImage |
+	
 	alphaImage := AlphaImageMorph new.
 	alphaImage model: self.
 	alphaImage
@@ -25,9 +25,8 @@ SpMorphicImageAdapter >> buildWidget [
 		setBalloonText: self help;
 		update: #getImage.
 
-	self model
-		whenImageChangeDo: [ alphaImage image: (self getImage ifNil: [ Form extent: 1 @ 1 depth: 32 ]) ];
-		whenAutoScaleChangeDo: [ widget layout: self layoutValue ].
+	self presenter whenImageChangeDo: [ 
+		alphaImage image: (self getImage ifNil: [ Form extent: 1 @ 1 depth: 32 ]) ].
 
 	^ alphaImage
 ]
@@ -53,13 +52,7 @@ SpMorphicImageAdapter >> image [
 { #category : 'widget protocol' }
 SpMorphicImageAdapter >> layoutValue [
 
-	^ self model autoScale
+	^ self presenter isAutoScale
 		  ifTrue: [ #scaledAspect ]
 		  ifFalse: [ #center ]
-]
-
-{ #category : 'widget protocol' }
-SpMorphicImageAdapter >> switchAutoscale [
-
-	self widgetDo: [ :w | w layout: self layoutValue ]
 ]

--- a/src/Spec2-Code/SpCodeBehaviorInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeBehaviorInteractionModel.class.st
@@ -36,8 +36,14 @@ SpCodeBehaviorInteractionModel >> bindingOf: aString [
 SpCodeBehaviorInteractionModel >> compiler [
 
 	^ super compiler
-		class: self behavior;
+		"class: self behavior;"
 		yourself
+]
+
+{ #category : 'accessing' }
+SpCodeBehaviorInteractionModel >> doItReceiver [
+
+	^ self behavior instanceSide
 ]
 
 { #category : 'testing' }

--- a/src/Spec2-Code/SpCodeMethodInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeMethodInteractionModel.class.st
@@ -18,7 +18,7 @@ SpCodeMethodInteractionModel class >> on: aMethod [
 { #category : 'accessing' }
 SpCodeMethodInteractionModel >> behavior [
 
-	^ self method ifNotNil: [ self method methodClass ]
+	^ self method ifNotNil: [ self method methodClass instanceSide ]
 ]
 
 { #category : 'accessing' }
@@ -31,7 +31,7 @@ SpCodeMethodInteractionModel >> bindingOf: aString [
 SpCodeMethodInteractionModel >> compiler [
 
 	^ super compiler
-		class: self behavior;
+		"class: self behavior;"
 		yourself
 ]
 

--- a/src/Spec2-Commander2/CmUICommand.extension.st
+++ b/src/Spec2-Commander2/CmUICommand.extension.st
@@ -4,14 +4,12 @@ Extension { #name : 'CmUICommand' }
 CmUICommand >> id [
 
 	^ String streamContents: [ :stream |
-		| parts name |
-		
-		name := self name 
-			ifNil: [ 
-				self shortcutKey
-					ifNotNil: [ 'shortcut ', (KMShortcutPrinter toString: self shortcutKey) ]
-					ifNil: [ 'unknown' ] ].
-		parts := name substrings.
+		| parts name |		
+		name := self name ifNil: [ 
+			self shortcutKey
+				ifNotNil: [ 'shortcut ', (KMShortcutPrinter toString: self shortcutKey) ]
+				ifNil: [ 'unknown' ] ].
+		parts := name substrings: ' :'.
 		stream << parts first asLowercase.
 		parts allButFirstDo: [ :each | stream << each capitalized ] ]
 ]

--- a/src/Spec2-Commander2/SpAction.class.st
+++ b/src/Spec2-Commander2/SpAction.class.st
@@ -162,6 +162,19 @@ SpAction >> isVisible [
 		and: [ actionVisible isNil or: [ actionVisible cull: self context ] ]
 ]
 
+{ #category : 'accessing' }
+SpAction >> presenterClass: aClass [
+	"this is an easy way to to define a special presenter that will be responsible of the UI
+	 of the action. The only condition of this presenter is that it has to be able to receive 
+	 a model."
+	
+	self flag: #CHECK. "Maybe I need to keep the presenter class?" 
+	 self buildPresenterBlock: [ :aCommand | 
+	 	self context 
+	 		instantiate: aClass 
+	 		on: aCommand ]
+]
+
 { #category : 'printing' }
 SpAction >> printOn: stream [
 

--- a/src/Spec2-Commander2/SpAction.class.st
+++ b/src/Spec2-Commander2/SpAction.class.st
@@ -180,9 +180,9 @@ SpAction >> printOn: stream [
 
 	stream << 'a SpAction('.
 	stream << 'Name: ' << (self name ifNil: [ 'No name' ]).
-	stream << ' Shortcut: ' << (self shortcutKey 
-		ifNotNil: [ :key | key asString ] 
-		ifNil: [ 'No shortcut' ]).
+	stream << ' Shortcut: ' << (self hasShortcutKey 
+		ifTrue: [ self shortcutKey asString ] 
+		ifFalse: [ 'No shortcut' ]).
 	stream << ')'
 ]
 

--- a/src/Spec2-Commander2/SpAction.class.st
+++ b/src/Spec2-Commander2/SpAction.class.st
@@ -176,7 +176,7 @@ SpAction >> printOn: stream [
 { #category : 'accessing' }
 SpAction >> priority [
 
-	^ priority
+	^ priority ifNil: [ priority := 1 ]
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Commander2/SpActionGroup.class.st
+++ b/src/Spec2-Commander2/SpActionGroup.class.st
@@ -66,6 +66,27 @@ SpActionGroup >> addAll: aCollection [
 ]
 
 { #category : 'accessing' }
+SpActionGroup >> addDynamicGroup: anId with: aBlock [
+	| group |
+
+	group := self findGroupWithId: anId.
+	group ifNil: [
+		group := SpDynamicActionGroup new.
+		group id: anId.
+		group with: aBlock.
+		self add: group ]
+]
+
+{ #category : 'accessing' }
+SpActionGroup >> addDynamicGroupWith: aBlock [
+	| action |
+	
+	action := SpDynamicActionGroup new.
+	action with: aBlock.
+	self add: action
+]
+
+{ #category : 'accessing' }
 SpActionGroup >> addGroup: anId with: aBlock [
 	| group |
 

--- a/src/Spec2-Commander2/SpActionGroup.class.st
+++ b/src/Spec2-Commander2/SpActionGroup.class.st
@@ -143,7 +143,7 @@ SpActionGroup >> initialize [
 { #category : 'accessing' }
 SpActionGroup >> priority [
 
-	^ priority
+	^ priority ifNil: [ priority := 1 ]
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Commander2/SpBaseActionGroup.class.st
+++ b/src/Spec2-Commander2/SpBaseActionGroup.class.st
@@ -22,9 +22,3 @@ SpBaseActionGroup >> ensureNotDuplicated: aCommandOrGroup [
 			aCommandOrGroup assignUniqueName ].
 	super ensureNotDuplicated: aCommandOrGroup
 ]
-
-{ #category : 'private' }
-SpBaseActionGroup >> entries: aCollection [
-
-	entries := aCollection
-]

--- a/src/Spec2-Commander2/SpCommand.class.st
+++ b/src/Spec2-Commander2/SpCommand.class.st
@@ -106,6 +106,15 @@ SpCommand >> configureAsToolbarButton [
 	self configureAsButtonOfClass: SpToolbarButtonPresenter
 ]
 
+{ #category : 'copying' }
+SpCommand >> copyWithContext: aContext [
+
+	^ self copy 
+		decoratedCommand: self decoratedCommand copy;
+		context: aContext;
+		yourself
+]
+
 { #category : 'displaying' }
 SpCommand >> displayIn: aMenuGroupOrPresenter do: aBlock [
 

--- a/src/Spec2-Commander2/SpDynamicActionGroup.class.st
+++ b/src/Spec2-Commander2/SpDynamicActionGroup.class.st
@@ -77,11 +77,27 @@ SpDynamicActionGroup >> id [
 	^ id ifNil: [ id := super id ]
 ]
 
+{ #category : 'accessing' }
+SpDynamicActionGroup >> id: anId [
+
+	id := anId
+]
+
 { #category : 'initialization' }
 SpDynamicActionGroup >> initialize [
 
 	decoratedGroup := SpBaseActionGroup new.
 	super initialize
+]
+
+{ #category : 'resolving' }
+SpDynamicActionGroup >> resolve [
+	| group |
+	
+	group := SpActionGroup new.
+	group id: self id.
+	self dynamicBuilder value: group.
+	^ group
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -125,6 +125,12 @@ SpFilteringListPresenter >> displayIcon: aBlock [
 	self listPresenter displayIcon: aBlock
 ]
 
+{ #category : 'api' }
+SpFilteringListPresenter >> enableSearch [
+
+	listPresenter enableSearch
+]
+
 { #category : 'private - actions' }
 SpFilteringListPresenter >> ensureActions [
 

--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -101,6 +101,12 @@ SpFilteringListPresenter >> defaultOutputPort [
 	^ self outputSelectionPort
 ]
 
+{ #category : 'private' }
+SpFilteringListPresenter >> disableActivationDuring: aBlock [
+
+	listPresenter disableActivationDuring: aBlock
+]
+
 { #category : 'api' }
 SpFilteringListPresenter >> display [ 
 
@@ -265,6 +271,12 @@ SpFilteringListPresenter >> rowPresenterClass: aPresenterClass [
 	listPresenter rowPresenterClass: aPresenterClass
 ]
 
+{ #category : 'api' }
+SpFilteringListPresenter >> searchMatching: aBlock [
+
+	listPresenter searchMatching: aBlock
+]
+
 { #category : 'api - selection' }
 SpFilteringListPresenter >> selectIndex: index [
 
@@ -283,6 +295,14 @@ SpFilteringListPresenter >> selectItem: anObject [
 	listPresenter selectItem: anObject
 ]
 
+{ #category : 'api - selection' }
+SpFilteringListPresenter >> selectItem: anObject scrollToSelection: aBoolean [ 
+	
+	listPresenter
+		selectItem: anObject 
+		scrollToSelection: aBoolean
+]
+
 { #category : 'selection' }
 SpFilteringListPresenter >> selectLast [
 	listPresenter selectLast
@@ -299,6 +319,12 @@ SpFilteringListPresenter >> selectedItems [
 	"Answer a <Collection> of receiver's selected objects"
 
 	^ listPresenter selectedItems
+]
+
+{ #category : 'api - selection' }
+SpFilteringListPresenter >> selectedRowPresenter [
+
+	^ listPresenter selectedRowPresenter
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-CommonWidgets/SpFilteringSelectableListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringSelectableListPresenter.class.st
@@ -136,7 +136,8 @@ SpFilteringSelectableListPresenter >> newListToFilter [
 	table := self newTable. 
 	table hideColumnHeaders.
 	table columns: self listColumns.
-	^ table
+	
+^ table
 ]
 
 { #category : 'api' }

--- a/src/Spec2-Core/ObservableValueHolder.extension.st
+++ b/src/Spec2-Core/ObservableValueHolder.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'ObservableValueHolder' }
 
 { #category : '*Spec2-Core' }
+ObservableValueHolder >> suspendChangedDuring: aBlock [
+
+	aBlock value
+]
+
+{ #category : '*Spec2-Core' }
 ObservableValueHolder >> unsubscribe: anObject [ 
 
 	subscriptions := subscriptions reject: [ :each | each receiver = anObject ].

--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -10,7 +10,8 @@ Class {
 		'#activationBlock',
 		'#activateOnSingleClick',
 		'#model',
-		'#verticalAlignment'
+		'#verticalAlignment',
+		'#activationCount'
 	],
 	#category : 'Spec2-Core-Widgets-Table',
 	#package : 'Spec2-Core',
@@ -92,12 +93,10 @@ SpAbstractListPresenter >> clickItem: anInteger [
 
 { #category : 'private' }
 SpAbstractListPresenter >> disableActivationDuring: aBlock [
-	| oldActivate |
-	
-	oldActivate := activationBlock.
-	activationBlock := [ ].
-	aBlock ensure: [ 
-		activationBlock := oldActivate ]
+
+	activationCount := activationCount + 1.
+	aBlock ensure: [
+		activationCount := activationCount - 1 ]
 ]
 
 { #category : 'private' }
@@ -118,7 +117,7 @@ SpAbstractListPresenter >> disableSelectionDuring: aBlock [
 SpAbstractListPresenter >> doActivateAtIndex: anIndex [
 
 	"Activate only if there is an item at that position"
-	activationBlock ifNil: [ ^ self ].
+	(activationBlock isNil or: [ activationCount > 0 ]) ifTrue: [ ^ self ].
 	self model at: anIndex ifAbsent: [ ^ self ].
 	
 	activationBlock cull: ((SpSingleSelectionMode on: self)
@@ -141,6 +140,7 @@ SpAbstractListPresenter >> initialize [
 	self initializeTHaveWrappingScrollBars.
 	self initializeTSearchable.
 	
+	activationCount := 0.
 	activationBlock := [ ].
 	verticalAlignment := SpVerticalAlignment new.
 
@@ -323,6 +323,7 @@ SpAbstractListPresenter >> whenActivatedDo: aBlock [
 	"Inform when an element has been 'activated'. 
 	 `aBlock` receives one argument (a selection object, see `SpAbstractSelectionMode`)"
 	
+	activationCount := 0.
 	activationBlock := aBlock
 ]
 

--- a/src/Spec2-Core/SpAbstractPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractPresenter.class.st
@@ -41,7 +41,7 @@ SpAbstractPresenter class >> buttonWidth [
 { #category : 'TOREMOVE' }
 SpAbstractPresenter class >> defaultFont [ 
 
-	self flag: #TODO. "This is so wrong. All this needs to be in the theme and in the 
+	self flag: #TOREMOVE. "This is so wrong. All this needs to be in the theme and in the 
 	application"
 		
 	self class environment at: #StandardFonts ifPresent: [ :standardFonts | 
@@ -53,7 +53,6 @@ SpAbstractPresenter class >> defaultFont [
 		stretchValue: 5
 		weightValue: 400
 		slantValue: 0
-
 ]
 
 { #category : 'layout' }

--- a/src/Spec2-Core/SpAbstractSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractSelectionMode.class.st
@@ -114,6 +114,18 @@ SpAbstractSelectionMode >> model [
 	^ widget model
 ]
 
+{ #category : 'events' }
+SpAbstractSelectionMode >> observablePropertyNamed: aName [
+	| slot |
+
+	slot := self class slotNamed: aName.
+	slot isObservableSlot ifFalse: [ NonObservableSlotError signal: aName ].
+
+	"Obtain the raw value.
+	We need to access the underlying value holder to subscribe to it"
+	^ slot rawRead: self
+]
+
 { #category : 'api - selection' }
 SpAbstractSelectionMode >> selectAll [
 	"Select all items."

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -11,6 +11,7 @@ Class {
 		'#childrenBlock',
 		'#activateOnSingleClick',
 		'#activationBlock',
+		'#activationCount',
 		'#selectionMode',
 		'#verticalAlignment'
 	],
@@ -132,12 +133,18 @@ SpAbstractTreePresenter >> collapsePath: aPath [
 
 { #category : 'private' }
 SpAbstractTreePresenter >> disableActivationDuring: aBlock [
-	| oldActivate |
-	
-	oldActivate := activationBlock.
-	activationBlock := [ ].
+
+	"since in a multithread context we can call several times this function
+	 I cannot just replace the activation block (as in older versions of this method).
+	 Instead, I will just keep an activationCount variable that will change value 
+	 while entering here... this will allow us to later suspend the activation (see 
+	 #doActivateAtPath:) without changing the block at all.
+	 This will fix two different cases: 
+	 - I may be updating something *elsewere* that should trigger an activation.
+	 - I can run the deactivation in different threads, and I will be sure they will be correctly deactivated."
+	activationCount := activationCount + 1.
 	aBlock ensure: [ 
-		activationBlock := oldActivate ]
+		activationCount := activationCount - 1 ]
 ]
 
 { #category : 'private' }
@@ -157,8 +164,8 @@ SpAbstractTreePresenter >> disableSelectionDuring: aBlock [
 { #category : 'private' }
 SpAbstractTreePresenter >> doActivateAtPath: aPath [
 	"Activate only if there is an item at that position"
-
-	activationBlock  ifNil: [ ^ self ].
+	
+	(activationBlock isNil or: [ activationCount > 0 ]) ifTrue: [ ^ self ].
 	self itemAtPath: aPath ifAbsent: [ ^ self ].
 	activationBlock cull: ((SpTreeSingleSelectionMode on: self)
 		selectPath: aPath;
@@ -170,7 +177,7 @@ SpAbstractTreePresenter >> doActivateSelected [
 	"Activate only if there is an item at that position"
 	| selectedPath |
 
-	activationBlock ifNil: [ ^ self ].
+	(activationBlock isNil or: [ activationCount > 0 ]) ifTrue: [ ^ self ].
 	selectedPath := self selection selectedPath.
 	selectedPath ifNil:  [ ^ self ].
 	activationBlock cull: ((SpTreeSingleSelectionMode on: self)
@@ -220,6 +227,8 @@ SpAbstractTreePresenter >> initialize [
 	self initializeTHaveWrappingScrollBars.
 	
 	verticalAlignment := SpVerticalAlignment new.
+	activationCount := 0.
+	activationBlock := [].
 
 	self withScrollBars.
 	self registerActions.
@@ -580,6 +589,7 @@ SpAbstractTreePresenter >> whenActivatedDo: aBlock [
 	"Inform when an element has been 'activated'. 
 	 `aBlock` receives one argument (a selection object, see `SpAbstractSelectionMode`)"
  
+ 	activationCount := 0.
 	activationBlock := aBlock
 ]
 

--- a/src/Spec2-Core/SpAbstractTreeSelectionMode.class.st
+++ b/src/Spec2-Core/SpAbstractTreeSelectionMode.class.st
@@ -26,6 +26,14 @@ SpAbstractTreeSelectionMode >> clearSelection [
 	selection := #()
 ]
 
+{ #category : 'private' }
+SpAbstractTreeSelectionMode >> disableChangedDuring: aBlock [
+	| holder |
+
+	holder := self observablePropertyNamed: #selection.
+	holder disableChangedDuring: aBlock
+]
+
 { #category : 'initialization' }
 SpAbstractTreeSelectionMode >> initialize [
 	self class initializeSlots: self.

--- a/src/Spec2-Core/SpApplication.class.st
+++ b/src/Spec2-Core/SpApplication.class.st
@@ -15,7 +15,6 @@ It is  important that after you initiate your application, you ==run== it.
 The following example shows how to change the backend of an application. 
 
 ```
-
 | app |
 ""You want to subclass SpApplication to create your app""
 app := SpApplication new.

--- a/src/Spec2-Core/SpImagePresenter.class.st
+++ b/src/Spec2-Core/SpImagePresenter.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'#image => ObservableSlot',
 		'#action => ObservableSlot',
-		'#autoScale => ObservableSlot'
+		'#autoScale'
 	],
 	#category : 'Spec2-Core-Widgets',
 	#package : 'Spec2-Core',
@@ -44,7 +44,11 @@ SpImagePresenter >> action: aBlock [
 SpImagePresenter >> autoScale [
 	"Answer if image has autoscale activated."
 
-	^ autoScale
+	self 
+		deprecated: 'Use #isAutoScale' 
+		transformWith: '`@receiver autoScale' -> '`@receiver isAutoScale'.	
+
+	^ self isAutoScale
 ]
 
 { #category : 'api' }
@@ -76,23 +80,10 @@ SpImagePresenter >> initialize [
 	autoScale := false
 ]
 
-{ #category : 'api' }
-SpImagePresenter >> switchAutoscale [
-	"Toggles autoscale state."
-	
-	autoScale := autoScale not
-
-]
-
-{ #category : 'api - events' }
-SpImagePresenter >> whenAutoScaleChangeDo: aBlockClosure [
-	"Inform when autoScale state has changed. 
-	 `aBlock` has three optional arguments: 
-	 - new value
-	 - old value
-	 - the announcement triggering this action"
-
-	self property: #autoScale whenChangedDo: aBlockClosure
+{ #category : 'testing' }
+SpImagePresenter >> isAutoScale [
+	"Answer if image has autoscale activated."
+	^ autoScale
 ]
 
 { #category : 'api - events' }

--- a/src/Spec2-Core/SpLabeledPresenter.class.st
+++ b/src/Spec2-Core/SpLabeledPresenter.class.st
@@ -68,6 +68,7 @@ SpLabeledPresenter >> descriptionPresenter: anObject [
 
 { #category : 'initialization' }
 SpLabeledPresenter >> initializePresenters [
+
 	labelPresenter := self newLabel.
 	descriptionPresenter :=  self newNullPresenter. "By default it is null"
 ]

--- a/src/Spec2-Core/SpMultipleSelectionMode.class.st
+++ b/src/Spec2-Core/SpMultipleSelectionMode.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : 'SpMultipleSelectionMode',
 	#superclass : 'SpAbstractSelectionMode',
 	#instVars : [
-		'#selectedIndexes => ObservableSlot'
+		'#selectedIndexes => SpSuspendableSlot'
 	],
 	#category : 'Spec2-Core-Widgets-Table',
 	#package : 'Spec2-Core',
@@ -23,13 +23,10 @@ SpMultipleSelectionMode >> basicSelectIndex: indexToSelect [
 
 { #category : 'private' }
 SpMultipleSelectionMode >> disableChangedDuring: aBlock [
-	| holder oldSubscriptions |
+	| holder |
 	
 	holder := self observablePropertyNamed: #selectedIndexes.
-	oldSubscriptions := holder subscriptions.
-	holder subscriptions: #().
-	aBlock ensure: [ 
-		holder subscriptions: oldSubscriptions ]
+	holder suspendChangedDuring: aBlock
 ]
 
 { #category : 'testing' }

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -35,7 +35,6 @@ Be careful about code order if you are overriding initialize method.
 Normally in Spec initializing instance variables should be done BEFORE calling `super initialize` (so the opposite of the normal approach), because super initialize calls `initalizePresenters` and `connectPresenters` that normally would make use of those variables.
 
 ## Layout
-
 As a general principle refer to the subclasses of`SpExecutableLayout`.
 
 `defaultLayout` must be defined in the class side of my subclasses.

--- a/src/Spec2-Core/SpSingleSelectionMode.class.st
+++ b/src/Spec2-Core/SpSingleSelectionMode.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : 'SpSingleSelectionMode',
 	#superclass : 'SpAbstractSelectionMode',
 	#instVars : [
-		'#selectedIndex => ObservableSlot'
+		'#selectedIndex => SpSuspendableSlot'
 	],
 	#category : 'Spec2-Core-Widgets-Table',
 	#package : 'Spec2-Core',
@@ -19,13 +19,10 @@ SpSingleSelectionMode >> basicSelectIndex: indexToSelect [
 
 { #category : 'private' }
 SpSingleSelectionMode >> disableChangedDuring: aBlock [
-	| holder oldSubscriptions |
+	| holder |
 	
 	holder := self observablePropertyNamed: #selectedIndex.
-	oldSubscriptions := holder subscriptions.
-	holder subscriptions: #().
-	aBlock ensure: [ 
-		holder subscriptions: oldSubscriptions ]
+	holder suspendChangedDuring: aBlock 
 ]
 
 { #category : 'testing' }

--- a/src/Spec2-Core/SpSuspendableSlot.class.st
+++ b/src/Spec2-Core/SpSuspendableSlot.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'SpSuspendableSlot',
+	#superclass : 'ObservableSlot',
+	#instVars : [
+		'suspendedCount'
+	],
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
+}
+
+{ #category : 'initialization' }
+SpSuspendableSlot >> initialize: anObject [
+
+	^ self 
+		object: anObject 
+		instVarAt: index 
+		put: SpSuspendableValueHolder new
+]

--- a/src/Spec2-Core/SpSuspendableValueHolder.class.st
+++ b/src/Spec2-Core/SpSuspendableValueHolder.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'SpSuspendableValueHolder',
+	#superclass : 'ObservableValueHolder',
+	#instVars : [
+		'suspendedCount'
+	],
+	#category : 'Spec2-Core-Widgets-Table',
+	#package : 'Spec2-Core',
+	#tag : 'Widgets-Table'
+}
+
+{ #category : 'suspending' }
+SpSuspendableValueHolder >> suspendChangedDuring: aBlock [
+
+	suspendedCount ifNil: [ suspendedCount := 0 ].
+	suspendedCount := suspendedCount + 1.
+	aBlock ensure: [
+		suspendedCount := suspendedCount - 1 ]
+]
+
+{ #category : 'accessing' }
+SpSuspendableValueHolder >> valueChanged: oldValue [
+
+	(suspendedCount isNotNil and: [ suspendedCount > 0 ]) ifTrue: [ ^ self ].
+	super valueChanged: oldValue
+]

--- a/src/Spec2-Core/SpToggleButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToggleButtonPresenter.class.st
@@ -63,8 +63,10 @@ SpToggleButtonPresenter >> associatedToggleButtons: aCollection [
 	allElements do: [ :each | 
 		each basicAssociatedToggleButtons: allElements ].
 	
-	"self state: true."
-	aCollection do: [ :each | each state: false ]
+	((aCollection select: [ :each | each state ]) size > 1) ifTrue: [
+		"self state: true."
+		"there cannot be more than one true"
+		aCollection do: [ :each | each state: false ] ]
 ]
 
 { #category : 'private' }

--- a/src/Spec2-Core/String.extension.st
+++ b/src/Spec2-Core/String.extension.st
@@ -11,7 +11,7 @@ String >> asPresenter [
 { #category : '*Spec2-Core' }
 String >> asPresenterOn: aPresenter [
 
-	^ SpLabelPresenter new 
+	^ aPresenter newLabel 
 		label: self;
 		yourself
 ]

--- a/src/Spec2-Layout/SpScrollableLayout.class.st
+++ b/src/Spec2-Layout/SpScrollableLayout.class.st
@@ -4,7 +4,11 @@ Class {
 	#traits : 'SpTAlignable',
 	#classTraits : 'SpTAlignable classTrait',
 	#instVars : [
-		'singleChild'
+		'singleChild',
+		'propagateNaturalHeight',
+		'propagateNaturalWidth',
+		'hScrollbar',
+		'vScrollbar'
 	],
 	#category : 'Spec2-Layout-Scroll',
 	#package : 'Spec2-Layout',
@@ -48,6 +52,52 @@ SpScrollableLayout >> constraintsClass [
 	^ SpBoxConstraints
 ]
 
+{ #category : 'testing' }
+SpScrollableLayout >> hasHScrollbar [
+
+	^ hScrollbar
+]
+
+{ #category : 'testing' }
+SpScrollableLayout >> hasVScrollbar [
+
+	^ vScrollbar
+]
+
+{ #category : 'initialization' }
+SpScrollableLayout >> initialize [
+
+	super initialize.
+	self withVScrollbar.
+	self withHScrollbar.
+	self propagateNaturalHeight: false.
+	self propagateNaturalWidth: false.
+]
+
+{ #category : 'testing' }
+SpScrollableLayout >> isPropagateNaturalHeight [
+	
+	^ propagateNaturalHeight
+]
+
+{ #category : 'testing' }
+SpScrollableLayout >> isPropagateNaturalWidth [
+	
+	^ propagateNaturalWidth
+]
+
+{ #category : 'accessing' }
+SpScrollableLayout >> propagateNaturalHeight: aBoolean [
+
+	propagateNaturalHeight := aBoolean
+]
+
+{ #category : 'accessing' }
+SpScrollableLayout >> propagateNaturalWidth: aBoolean [
+
+	propagateNaturalWidth := aBoolean
+]
+
 { #category : 'accessing' }
 SpScrollableLayout >> remove: aPresenter [
 
@@ -61,4 +111,28 @@ SpScrollableLayout >> scrollTo: aPoint [
 
 	self withAdapterDo: [ :anAdapter |
 		anAdapter scrollTo: aPoint ]
+]
+
+{ #category : 'accessing' }
+SpScrollableLayout >> withHScrollbar [
+
+	hScrollbar := true
+]
+
+{ #category : 'accessing' }
+SpScrollableLayout >> withVScrollbar [
+
+	vScrollbar := true
+]
+
+{ #category : 'accessing' }
+SpScrollableLayout >> withoutHScrollbar [
+
+	hScrollbar := false
+]
+
+{ #category : 'accessing' }
+SpScrollableLayout >> withoutVScrollbar [
+
+	vScrollbar := false
 ]

--- a/src/Spec2-ListView/SpEasyColumnViewPresenter.class.st
+++ b/src/Spec2-ListView/SpEasyColumnViewPresenter.class.st
@@ -139,8 +139,7 @@ SpEasyColumnViewPresenter >> clickAtIndex: aNumber [
 { #category : 'api' }
 SpEasyColumnViewPresenter >> columns: aCollection [ 
 	
-	contentView columns: aCollection 
-
+	contentView columns: (aCollection collect: #asColumnViewColumn)
 ]
 
 { #category : 'api' }

--- a/src/Spec2-ListView/SpEasyListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpEasyListViewPresenter.class.st
@@ -283,6 +283,12 @@ SpEasyListViewPresenter >> initializePresenters [
 	headerPanel hide
 ]
 
+{ #category : 'accessing' }
+SpEasyListViewPresenter >> itemAt: aNumber [
+
+	^ contentView itemAt: aNumber
+]
+
 { #category : 'initialization' }
 SpEasyListViewPresenter >> registerEvents [
 

--- a/src/Spec2-Morphic-Tests/SpImageAdapterTest.class.st
+++ b/src/Spec2-Morphic-Tests/SpImageAdapterTest.class.st
@@ -20,19 +20,6 @@ SpImageAdapterTest >> imageForm [
 ]
 
 { #category : 'building' }
-SpImageAdapterTest >> testAutoscale [
-
-	self presenter image: self imageForm.
-
-	self presenter autoScale: false.
-	self deny: self adapter hasImageAutoscaled.
-
-	self presenter autoScale: true.
-	self assert: self adapter hasImageAutoscaled.
-
-]
-
-{ #category : 'building' }
 SpImageAdapterTest >> testSettingAnImageSetsTheImage [
 
 	self presenter image: self imageForm.

--- a/src/Spec2-Morphic/Form.extension.st
+++ b/src/Spec2-Morphic/Form.extension.st
@@ -9,7 +9,9 @@ Form >> asPresenter [
 ]
 
 { #category : '*Spec2-Morphic' }
-Form >> asPresenterOn: aSpPresenter [ 
+Form >> asPresenterOn: aPresenter [ 
 	
-	^ self asPresenter
+	^ aPresenter newImage 
+		image: self;
+		yourself
 ]

--- a/src/Spec2-Tests/SpImagePresenterTest.class.st
+++ b/src/Spec2-Tests/SpImagePresenterTest.class.st
@@ -19,19 +19,6 @@ SpImagePresenterTest >> tearDown [
 ]
 
 { #category : 'tests' }
-SpImagePresenterTest >> testAutoScale [
-	| count result |
-	count := 0.
-	presenter
-		whenAutoScaleChangeDo: [ :value | 
-			result := value.
-			count := count + 1 ].
-	presenter autoScale: true.
-	self assert: count equals: 1.
-	self assert: result
-]
-
-{ #category : 'tests' }
 SpImagePresenterTest >> testCanDefineImagePresenterFromAForm [
 	| title form windowPresenter presenterItems |
 	
@@ -46,12 +33,4 @@ SpImagePresenterTest >> testCanDefineImagePresenterFromAForm [
 	self assert: presenterItems first equals: title.
 	self assert: presenterItems second equals: form.
 	
-]
-
-{ #category : 'tests' }
-SpImagePresenterTest >> testSwitchAutoScale [
-	| autoState |
-	autoState := presenter autoScale.
-	presenter switchAutoscale.
-	self assert: presenter autoScale equals: autoState not
 ]


### PR DESCRIPTION
I took the solution from Pablo's https://github.com/pharo-project/pharo/pull/18902 that makes the same with announcements.

Then I was thinking this would make also sense to bind this to a process but in the case of, e.g. Spec-Gtk is completely useless (as each callback/event happens in a separated thread)...