### PR TITLE
Extension cleanup

### DIFF
--- a/src/Spec2-Commander2/SpActionBarPresenter.extension.st
+++ b/src/Spec2-Commander2/SpActionBarPresenter.extension.st
@@ -1,18 +1,6 @@
 Extension { #name : 'SpActionBarPresenter' }
 
 { #category : '*Spec2-Commander2' }
-SpActionBarPresenter >> addItemLeft: anItem [
-
-	self add: anItem
-]
-
-{ #category : '*Spec2-Commander2' }
-SpActionBarPresenter >> addItemRight: anItem [
-
-	self addLast: anItem
-]
-
-{ #category : '*Spec2-Commander2' }
 SpActionBarPresenter >> fillWith: aCommandGroup [
 
 	items removeAll.

--- a/src/Spec2-Core/SpActionBarPresenter.class.st
+++ b/src/Spec2-Core/SpActionBarPresenter.class.st
@@ -40,6 +40,18 @@ SpActionBarPresenter >> add: aButtonPresenter [
 ]
 
 { #category : 'api' }
+SpActionBarPresenter >> addItemLeft: anItem [
+
+	self add: anItem
+]
+
+{ #category : 'api' }
+SpActionBarPresenter >> addItemRight: anItem [
+
+	self addLast: anItem
+]
+
+{ #category : 'api' }
 SpActionBarPresenter >> addLast: aButtonPresenter [
 	"Add a button presenter to be shown at the end of the action bar (at the right)."
 

--- a/src/Spec2-Morphic/PluggableButtonMorph.extension.st
+++ b/src/Spec2-Morphic/PluggableButtonMorph.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'PluggableButtonMorph' }
-
-{ #category : '*Spec2-Morphic' }
-PluggableButtonMorph >> getStateSelector: aSelector [
-
-	getStateSelector := aSelector
-]

--- a/src/Spec2-Morphic/PluggableButtonMorph.extension.st
+++ b/src/Spec2-Morphic/PluggableButtonMorph.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'PluggableButtonMorph' }
 
 { #category : '*Spec2-Morphic' }
-PluggableButtonMorph >> getStateSelector [
-
-	^ getStateSelector
-]
-
-{ #category : '*Spec2-Morphic' }
 PluggableButtonMorph >> getStateSelector: aSelector [
 
 	getStateSelector := aSelector


### PR DESCRIPTION
Move extensions to proper places:
 - to the defining classes if possible
 - to the user if (and very clear) there is only one
 - close to other similar extensions if possible

Related to https://github.com/pharo-project/pharo/pull/19150