### PR TITLE
Remove some useless #initializeSlots:

### DIFF
--- a/src/Spec2-Core/SpAbstractPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractPresenter.class.st
@@ -313,7 +313,6 @@ SpAbstractPresenter >> hasWindow [
 { #category : 'initialization' }
 SpAbstractPresenter >> initialize [ 
 
-	self class initializeSlots: self.
 	super initialize.
 	needRebuild := true.
 	"in the future we could use a trait TProperties"

--- a/src/Spec2-Core/SpFixedProgressBarState.class.st
+++ b/src/Spec2-Core/SpFixedProgressBarState.class.st
@@ -36,8 +36,7 @@ SpFixedProgressBarState class >> value: aNumber [
 
 { #category : 'initialization' }
 SpFixedProgressBarState >> initialize [
-	
-	self class initializeSlots: self.
+
 	super initialize.
 	value := 0
 ]

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -566,7 +566,8 @@ SpPresenter >> initialExtent [
 
 { #category : 'initialization' }
 SpPresenter >> initialize [
-
+	
+	self class initializeSlots: self.
 	super initialize.
 
 	visible := true.

--- a/src/Spec2-Core/SpProgressingProgressBarState.class.st
+++ b/src/Spec2-Core/SpProgressingProgressBarState.class.st
@@ -53,7 +53,7 @@ SpProgressingProgressBarState >> currentValue: aNumber [
 
 { #category : 'initialization' }
 SpProgressingProgressBarState >> initialize [
-	self class initializeSlots: self.
+
 	super initialize.
 	currentValue := 0
 ]


### PR DESCRIPTION
This speeds up a little the creation of the instances and is not needed on some classes that have no slot needing initialization