### PR TITLE
Improve name of SpBrowseMethodsMatchingString(In)sensitiveCommand

### DIFF
--- a/src/Spec2-Commands/SpBrowseMethodsMatchingStringInsensitiveCommand.class.st
+++ b/src/Spec2-Commands/SpBrowseMethodsMatchingStringInsensitiveCommand.class.st
@@ -18,7 +18,7 @@ SpBrowseMethodsMatchingStringInsensitiveCommand class >> defaultDescription [
 { #category : 'default' }
 SpBrowseMethodsMatchingStringInsensitiveCommand class >> defaultName [
 
-	^ 'Case insensitive method literal strings with it'
+	^ 'Strings with it (case insensitive)'
 ]
 
 { #category : 'defaults' }

--- a/src/Spec2-Commands/SpBrowseMethodsMatchingStringSensitiveCommand.class.st
+++ b/src/Spec2-Commands/SpBrowseMethodsMatchingStringSensitiveCommand.class.st
@@ -17,7 +17,7 @@ SpBrowseMethodsMatchingStringSensitiveCommand class >> defaultDescription [
 { #category : 'default' }
 SpBrowseMethodsMatchingStringSensitiveCommand class >> defaultName [
 
-	^ 'Case sensitive method literal strings with it'
+	^ 'Strings with it'
 ]
 
 { #category : 'defaults' }
@@ -29,7 +29,7 @@ SpBrowseMethodsMatchingStringSensitiveCommand class >> defaultShortcutKey [
 { #category : 'default' }
 SpBrowseMethodsMatchingStringSensitiveCommand class >> shortName [
 
-	^ 'methods literal strings (case-sensitive)'
+	^ 'Strings with it'
 ]
 
 { #category : 'executing' }


### PR DESCRIPTION
I'm proposing a simpler name for those 2 commands because I find the previous names not really intuitive.

'Case sensitive method literal strings with it' -> 'Strings with it'
 'Case insensitive method literal strings with it' -> 'Strings with it (case insensitive)'