### PR TITLE
Mark ignoreNotImplementedSelectors: in spec

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpTreeColumn.class.st
+++ b/src/Spec2-Adapters-Morphic/SpTreeColumn.class.st
@@ -20,6 +20,7 @@ SpTreeColumn >> bindKeyCombination: aKMCombination toAction: aBlock [
 SpTreeColumn >> rowMorphFor: aNode [ 
 	| node rowMorph |
 	
+	<ignoreNotImplementedSelectors: #( nodeModel )>
 	node := aNode nodeModel.
 	rowMorph := self rowMorphGetSelector
 		ifNil: [node rowMorphForColumn: self]

--- a/src/Spec2-Morphic-Backend-Tests/SpUIThemeDecoratorTest.class.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpUIThemeDecoratorTest.class.st
@@ -19,6 +19,8 @@ SpUIThemeDecoratorTest >> setUp [
 
 { #category : 'tests' }
 SpUIThemeDecoratorTest >> testDoesNotUnderstand [
+
+	<ignoreNotImplementedSelectors: #( fooBlock fooBlock: )>
 	| block |
 	themeDecorator
 		property: #foo returnsValueOf: 42.


### PR DESCRIPTION
This is to cleanup Pharo tests that list external methods with whitelists.

It looks, however, that `SpTreeColumn >> rowMorphFor: ` is broken.