### PR TITLE
make SpStringTableColumn sortable by default

### DIFF
--- a/src/Spec2-Core/SpStringTableColumn.class.st
+++ b/src/Spec2-Core/SpStringTableColumn.class.st
@@ -93,7 +93,7 @@ SpStringTableColumn >> initialize [
 
 	super initialize.
 	editable := false.
-	sortable := false
+	sortable := true.
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
make SPStringTable sortable by default