### PR TITLE
Introduce refactoring commands for Spec

### DIFF
--- a/src/BaselineOfSpecCore/BaselineOfSpecCore.class.st
+++ b/src/BaselineOfSpecCore/BaselineOfSpecCore.class.st
@@ -25,8 +25,9 @@ BaselineOfSpecCore >> baseline: spec [
 			package: 'Spec2-Commander2' with: [ spec requires: #('Spec2-Core' 'Spec2-Interactions') ];
 			"ListView"
 			package: 'Spec2-ListView' with: [ spec requires: #('Spec2-Core') ];
-			"Code"
+			"Code" 
 			package: 'Spec2-Code' with: [ spec requires: #('Spec2-Core' 'Spec2-Commands') ];
+			package: 'Spec2-Refactoring-Commands' with: [ spec requires: #('Spec2-Core' 'Spec2-Commands') ];
 			package: 'Spec2-Code-Commands' with: [ spec requires: #('Spec2-Core' 'Spec2-Commands') ];
 			package: 'Spec2-Code-Diff' with: [ spec requires: #('Spec2-Code') ];
 			"Common widgets"
@@ -58,7 +59,7 @@ BaselineOfSpecCore >> baseline: spec [
 		'Spec2-ListView'  
 		'Spec2-Interactions' 
 		'Spec2-Commander2' ).
-	spec group: 'Code' with: #('Core' 'Spec2-Code-Commands' 'Spec2-Code' 'Spec2-Code-Diff').
+	spec group: 'Code' with: #('Core' 'Spec2-Code-Commands' 'Spec2-Code' 'Spec2-Code-Diff' 'Spec2-Refactoring-Commands').
 	spec group: 'CodeTests' with: #('Spec2-Code-Tests' 'Spec2-Code-Diff-Tests').
 	spec group: 'Support' with: #('Core' 'Spec2-Examples').
 	spec group: 'Tests' with: #('Core' 'Spec2-Tests' 'Spec2-Commander2-Tests' 'Spec2-ListView-Tests').

--- a/src/BaselineOfSpecCore/BaselineOfSpecCore.class.st
+++ b/src/BaselineOfSpecCore/BaselineOfSpecCore.class.st
@@ -7,68 +7,55 @@ Class {
 
 { #category : 'baseline' }
 BaselineOfSpecCore >> baseline: spec [
+
 	<baseline>
-	
-	spec for: #common do: [ 
-		self pillar: spec.
-		
-		spec
-			"Core"
-			package: 'Spec2-Layout';
-			package: 'Spec2-Core' with: [ spec requires: #('Spec2-Layout') ];
-			package: 'Spec2-Dialogs' with: [ spec requires: #('Spec2-Core') ];
-			package: 'Spec2-Dialogs-Tests' with: [ spec requires: #('Spec2-Dialogs') ];
-			package: 'Spec2-CommandLine' with: [ spec requires: #('Spec2-Core') ];
-			package: 'Spec2-Commands';
-			package: 'Spec2-Transmission' with: [ spec requires: #('Spec2-Core') ];
-			package: 'Spec2-Interactions' with: [ spec requires: #('Spec2-Core') ];
-			package: 'Spec2-Commander2' with: [ spec requires: #('Spec2-Core' 'Spec2-Interactions') ];
-			"ListView"
-			package: 'Spec2-ListView' with: [ spec requires: #('Spec2-Core') ];
-			"Code" 
-			package: 'Spec2-Code' with: [ spec requires: #('Spec2-Core' 'Spec2-Commands') ];
-			package: 'Spec2-Refactoring-Commands' with: [ spec requires: #('Spec2-Core' 'Spec2-Commands') ];
-			package: 'Spec2-Code-Commands' with: [ spec requires: #('Spec2-Core' 'Spec2-Commands') ];
-			package: 'Spec2-Code-Diff' with: [ spec requires: #('Spec2-Code') ];
-			"Common widgets"
-			package: 'Spec2-CommonWidgets' with: [ spec requires: #('Spec2-Core' 'Spec2-Layout') ];
-			package: 'Spec2-CommonWidgets-Tests' with: [ spec requires: #('Spec2-CommonWidgets' 'Spec2-Tests') ];
-			"Tests"			
-			package: 'Spec2-Adapters-Stub' with: [ spec requires: #('Spec2-Core') ];
-			package: 'Spec2-Commander2-Tests' with: [ spec requires: #('Spec2-Commander2') ];
-			package: 'Spec2-Tests' with: [ spec requires: #('Spec2-Core' 'Spec2-Examples' 'Spec2-Dialogs-Tests') ];
-			package: 'Spec2-ListView-Tests' with: [ spec requires: #('Spec2-ListView' 'Spec2-Tests') ];
-			package: 'Spec2-Code-Tests' with: [ spec requires: #('Spec2-Tests' 'Spec2-Code') ];
-			package: 'Spec2-Code-Diff-Tests' with: [ spec requires: #('Spec2-Tests' 'Spec2-Code-Diff') ];
-			"Examples"
-			package: 'Spec2-Examples' with: [ spec requires: #('Spec2-CommonWidgets') ];
-			package: 'Spec2-Commander2-ContactBook' with: [ spec requires: #('Spec2-Commander2') ];
-			package: 'Spec2-Commander2-ContactBook-Extensions' with: [ spec requires: #('Spec2-Commander2-ContactBook') ];
-			"RichText -> Pillar"
-			package: 'Spec2-Pillar' with: [ spec requires: #('Spec2-Core' 'PillarCore') ] 
-	].
-	
-	spec group: 'Core' with: #(
-		'Spec2-Layout' 
-		'Spec2-Transmission'
-		'Spec2-Commands' 
-		'Spec2-Core' 
-		'Spec2-Dialogs' 
-		'Spec2-CommandLine' 
-		'Spec2-Adapters-Stub'
-		'Spec2-ListView'  
-		'Spec2-Interactions' 
-		'Spec2-Commander2' ).
-	spec group: 'Code' with: #('Core' 'Spec2-Code-Commands' 'Spec2-Code' 'Spec2-Code-Diff' 'Spec2-Refactoring-Commands').
-	spec group: 'CodeTests' with: #('Spec2-Code-Tests' 'Spec2-Code-Diff-Tests').
-	spec group: 'Support' with: #('Core' 'Spec2-Examples').
-	spec group: 'Tests' with: #('Core' 'Spec2-Tests' 'Spec2-Commander2-Tests' 'Spec2-ListView-Tests').
-	spec group: 'SupportTests' with: #('Support').
-	spec group: 'Pillar' with: #('Spec2-Pillar' ).
-	spec group: 'Base' with: #('Core' 'Support').
-	spec group: 'BaseTests' with: #('Spec2-Tests' 'SupportTests').
-	
-	spec group: 'default' with: #('Base' 'BaseTests' 'Code' 'CodeTests').
+	spec for: #common do: [
+			self pillar: spec.
+
+			spec
+				package: 'Spec2-Layout';
+				package: 'Spec2-Core' with: [ spec requires: #( 'Spec2-Layout' ) ];
+				package: 'Spec2-Dialogs' with: [ spec requires: #( 'Spec2-Core' ) ];
+				package: 'Spec2-Dialogs-Tests' with: [ spec requires: #( 'Spec2-Dialogs' ) ];
+				package: 'Spec2-CommandLine' with: [ spec requires: #( 'Spec2-Core' ) ];
+				package: 'Spec2-Commands';
+				package: 'Spec2-Transmission' with: [ spec requires: #( 'Spec2-Core' ) ];
+				package: 'Spec2-Interactions' with: [ spec requires: #( 'Spec2-Core' ) ];
+				package: 'Spec2-Commander2' with: [ spec requires: #( 'Spec2-Core' 'Spec2-Interactions' ) ];
+				"ListView"package: 'Spec2-ListView' with: [ spec requires: #( 'Spec2-Core' ) ];
+				"Code"package: 'Spec2-Code' with: [ spec requires: #( 'Spec2-Core' 'Spec2-Commands' ) ];
+				package: 'Spec2-Refactoring-Commands' with: [ spec requires: #( 'Spec2-Core' 'Spec2-Commands' ) ];
+				package: 'Spec2-Code-Commands' with: [ spec requires: #( 'Spec2-Core' 'Spec2-Commands' ) ];
+				package: 'Spec2-Code-Diff' with: [ spec requires: #( 'Spec2-Code' ) ];
+				"Common widgets"package: 'Spec2-CommonWidgets' with: [ spec requires: #( 'Spec2-Core' 'Spec2-Layout' ) ];
+				package: 'Spec2-CommonWidgets-Tests' with: [ spec requires: #( 'Spec2-CommonWidgets' 'Spec2-Tests' ) ];
+				"Tests"package: 'Spec2-Adapters-Stub' with: [ spec requires: #( 'Spec2-Core' ) ];
+				package: 'Spec2-Commander2-Tests' with: [ spec requires: #( 'Spec2-Commander2' ) ];
+				package: 'Spec2-Tests' with: [ spec requires: #( 'Spec2-Core' 'Spec2-Examples' 'Spec2-Dialogs-Tests' ) ];
+				package: 'Spec2-ListView-Tests' with: [ spec requires: #( 'Spec2-ListView' 'Spec2-Tests' ) ];
+				package: 'Spec2-Code-Tests' with: [ spec requires: #( 'Spec2-Tests' 'Spec2-Code' ) ];
+				package: 'Spec2-Code-Diff-Tests' with: [ spec requires: #( 'Spec2-Tests' 'Spec2-Code-Diff' ) ];
+				package: 'Spec2-Refactoring-Commands-Tests' with: [ spec requires: #( 'Spec2-Tests' 'Spec2-Refactoring-Commands' ) ];
+				"Examples"package: 'Spec2-Examples' with: [ spec requires: #( 'Spec2-CommonWidgets' ) ];
+				package: 'Spec2-Commander2-ContactBook' with: [ spec requires: #( 'Spec2-Commander2' ) ];
+				package: 'Spec2-Commander2-ContactBook-Extensions' with: [ spec requires: #( 'Spec2-Commander2-ContactBook' ) ];
+				"RichText -> Pillar"package: 'Spec2-Pillar' with: [ "Core" spec requires: #( 'Spec2-Core' 'PillarCore' ) ] ].
+
+	spec
+		group: 'Core'
+		with:
+			#( 'Spec2-Layout' 'Spec2-Transmission' 'Spec2-Commands' 'Spec2-Core' 'Spec2-Dialogs' 'Spec2-CommandLine' 'Spec2-Adapters-Stub'
+			   'Spec2-ListView' 'Spec2-Interactions' 'Spec2-Commander2' ).
+	spec group: 'Code' with: #( 'Core' 'Spec2-Code-Commands' 'Spec2-Code' 'Spec2-Code-Diff' 'Spec2-Refactoring-Commands' ).
+	spec group: 'CodeTests' with: #( 'Spec2-Code-Tests' 'Spec2-Code-Diff-Tests'  'Spec2-Refactoring-Commands-Tests' ).
+	spec group: 'Support' with: #( 'Core' 'Spec2-Examples' ).
+	spec group: 'Tests' with: #( 'Core' 'Spec2-Tests' 'Spec2-Commander2-Tests' 'Spec2-ListView-Tests' ).
+	spec group: 'SupportTests' with: #( 'Support' ).
+	spec group: 'Pillar' with: #( 'Spec2-Pillar' ).
+	spec group: 'Base' with: #( 'Core' 'Support' ).
+	spec group: 'BaseTests' with: #( 'Spec2-Tests' 'SupportTests' ).
+
+	spec group: 'default' with: #( 'Base' 'BaseTests' 'Code' 'CodeTests' )
 ]
 
 { #category : 'external projects' }

--- a/src/Spec2-Code/SpCodeEditorPresenter.class.st
+++ b/src/Spec2-Code/SpCodeEditorPresenter.class.st
@@ -115,6 +115,12 @@ SpCodeEditorPresenter >> codePresenter [
 	^ codePresenter
 ]
 
+{ #category : 'accessing' }
+SpCodeEditorPresenter >> codePresenter: aCodePresenter [
+
+	codePresenter := aCodePresenter
+]
+
 { #category : 'private' }
 SpCodeEditorPresenter >> conflict: aBoolean [
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -627,7 +627,9 @@ SpCodePresenter >> selectedMethod [
 SpCodePresenter >> selectedNode [
 
 	| ast |
+
 	ast := OpalCompiler new
+		       class: self behavior;
 		       isScripting: self isScripting;
 		       parse: self text.
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -625,16 +625,15 @@ SpCodePresenter >> selectedMethod [
 
 { #category : 'command support' }
 SpCodePresenter >> selectedNode [
-	"Return the AST node at the current cursor position, or nil."
 
-	| fullSource index ast |
-	fullSource := self text.
-	fullSource ifNil: [ ^ nil ].
-	index := self cursorPositionIndex ifNil: [ 1 ].
-	ast := self isScripting
-		       ifTrue: [ OpalCompiler new isScripting: true; parse: fullSource ]
-		       ifFalse: [ OpalCompiler new isScripting: false; parse: fullSource ].
-	^ ast bestNodeForPosition: index 
+	| ast |
+	ast := OpalCompiler new
+		       isScripting: self isScripting;
+		       parse: self text.
+
+	^ self selectionInterval isEmpty
+		  ifTrue: [ ast bestNodeForPosition: (self cursorPositionIndex ifNil: [ 1 ]) ]
+		  ifFalse: [ ast bestNodeFor: self selectionInterval ]
 ]
 
 { #category : 'command support' }

--- a/src/Spec2-Refactoring-Commands-Tests/ReConvertTemporaryToInstanceVariableCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReConvertTemporaryToInstanceVariableCommandTest.class.st
@@ -6,7 +6,7 @@ Class {
 }
 
 { #category : 'tests' }
-ReConvertTemporaryToInstanceVariableCommandTest >> testConvertTempCommandSucess [
+ReConvertTemporaryToInstanceVariableCommandTest >> testConvertTempCommandSuccess [
 
 	| driver command context |
 	command := StConvertTempToInstVarCommand new.

--- a/src/Spec2-Refactoring-Commands-Tests/ReConvertTemporaryToInstanceVariableCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReConvertTemporaryToInstanceVariableCommandTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'ReConvertTemporaryToInstanceVariableCommandTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Refactoring-Commands-Tests',
+	#package : 'Spec2-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReConvertTemporaryToInstanceVariableCommandTest >> testConvertTempCommandSucess [
+
+	| driver command context |
+	command := StConvertTempToInstVarCommand new.
+	context := StCommandContextMock new
+		           name: #temp;
+		           selectedMethod: ReClassToConvertTemporaryToInstanceVariable >> #doAction1.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 2
+]

--- a/src/Spec2-Refactoring-Commands-Tests/ReGenerateVariableAccessorCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReGenerateVariableAccessorCommandTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : 'ReGenerateVariableAccessorCommandTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Refactoring-Commands-Tests',
+	#package : 'Spec2-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReGenerateVariableAccessorCommandTest >> testGenerateAccessorCommandSuccess [
+
+	| driver command context |
+	command := StGenerateVariableAccessorCommand new.
+	context := StCommandContextMock new
+		           origin: RBTransformationRuleTestData;
+		           name: #builder.
+	context selectedMethod: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 2
+]

--- a/src/Spec2-Refactoring-Commands-Tests/ReInlineMethodCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReInlineMethodCommandTest.class.st
@@ -6,7 +6,7 @@ Class {
 }
 
 { #category : 'tests' }
-ReInlineMethodCommandTest >> testInlineMethodCommandSucess [
+ReInlineMethodCommandTest >> testInlineMethodCommandSuccess [
 
 	| driver command context |
 	command := StInlineMethodCommand new.

--- a/src/Spec2-Refactoring-Commands-Tests/ReInlineMethodCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReInlineMethodCommandTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'ReInlineMethodCommandTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Refactoring-Commands-Tests',
+	#package : 'Spec2-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReInlineMethodCommandTest >> testInlineMethodCommandSucess [
+
+	| driver command context |
+	command := StInlineMethodCommand new.
+	context := StCommandContextMock new
+		           sourceInterval: (63 to: 78);
+		           selector: #rewriteUsing:;
+		           origin: RBTransformationRuleTestData.
+	context selectedMethod: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/Spec2-Refactoring-Commands-Tests/ReRenameArgOrTempCommandCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReRenameArgOrTempCommandCommandTest.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : 'ReRenameArgOrTempCommandCommandTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Refactoring-Commands-Tests',
+	#package : 'Spec2-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRenameArgOrTempCommandCommandTest >> testRenameArgOrTempCommandSuccess [
+
+	| driver command context method ast node dialogMock |
+	method := ReClassToConvertTemporaryToInstanceVariable >> #doAction1.
+	ast := OpalCompiler new parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isVariable and: [ n name = 'temp' ] ].
+
+	command := StRenameArgOrTempCommand new.
+	context := StCommandContextMock new
+		           selectedMethod: method;
+		           selectedNode: node.
+	command context: context.
+	driver := command prepareDriver.
+	dialogMock := StRequestDialogMock new.
+	dialogMock response: 'tmp2'.
+	driver requestDialog: dialogMock.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/Spec2-Refactoring-Commands-Tests/ReRenameClassCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReRenameClassCommandTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'ReRenameClassCommandTest',
+	#superclass : 'TestCase',
+	#category : 'Spec2-Refactoring-Commands-Tests',
+	#package : 'Spec2-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRenameClassCommandTest >> testRenameClassCommandSucess [
+
+	| driver command context dialogMock |
+	command := StRenameClassCommand new.
+	context := StCommandContextMock new name: #ReClassToConvertTemporaryToInstanceVariable.
+	command context: context.
+	driver := command prepareDriver.
+	dialogMock := StRequestDialogMock new.
+	dialogMock response: 'NewClassNameForTest'.
+	driver requestDialog: dialogMock.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 5.
+
+]

--- a/src/Spec2-Refactoring-Commands-Tests/ReRenameClassCommandTest.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/ReRenameClassCommandTest.class.st
@@ -6,7 +6,7 @@ Class {
 }
 
 { #category : 'tests' }
-ReRenameClassCommandTest >> testRenameClassCommandSucess [
+ReRenameClassCommandTest >> testRenameClassCommandSuccess [
 
 	| driver command context dialogMock |
 	command := StRenameClassCommand new.
@@ -20,6 +20,6 @@ ReRenameClassCommandTest >> testRenameClassCommandSucess [
 		forTesting: true;
 		runRefactoring.
 
-	self assert: driver changes changes size equals: 5.
+	self assert: driver changes changes size equals: 6.
 
 ]

--- a/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -37,6 +37,12 @@ StCommandContextMock >> codePresenter [
 ^ self
 ]
 
+{ #category : 'testing' }
+StCommandContextMock >> isInstanceSide [
+
+	^ true
+]
+
 { #category : 'accessing' }
 StCommandContextMock >> name [
 

--- a/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -6,7 +6,8 @@ Class {
 		'name',
 		'sourceInterval',
 		'selector',
-		'origin'
+		'origin',
+		'selectedNode'
 	],
 	#category : 'Spec2-Refactoring-Commands-Tests',
 	#package : 'Spec2-Refactoring-Commands-Tests'
@@ -22,6 +23,12 @@ StCommandContextMock >> allScopes [
 StCommandContextMock >> application [
 
 	^ StPharoApplication new
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> codeEditor [
+
+	^ self
 ]
 
 { #category : 'accessing' }
@@ -69,7 +76,13 @@ StCommandContextMock >> selectedMethod: aCompiledMethod [
 { #category : 'accessing' }
 StCommandContextMock >> selectedNode [
 
-	^ self
+	^ selectedNode ifNil: [ self ]
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedNode: aNode [
+
+	selectedNode := aNode
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'selectedMethod',
-		'selectedNode',
 		'name'
 	],
 	#category : 'Spec2-Refactoring-Commands-Tests',

--- a/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : 'StCommandContextMock',
+	#superclass : 'Object',
+	#instVars : [
+		'selectedMethod',
+		'selectedNode',
+		'name'
+	],
+	#category : 'Spec2-Refactoring-Commands-Tests',
+	#package : 'Spec2-Refactoring-Commands-Tests'
+}
+
+{ #category : 'private - scopes' }
+StCommandContextMock >> allScopes [
+
+	^ { RBBrowserEnvironment default }
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> application [
+
+	^ StPharoApplication new
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> codePresenter [
+
+^ self
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> name [
+
+	^ name
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> name: aName [
+
+	name := aName
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedMethod [
+
+	^ selectedMethod
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedMethod: aCompiledMethod [
+
+	selectedMethod := aCompiledMethod
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedNode [
+
+	^ self
+]

--- a/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -3,7 +3,10 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'selectedMethod',
-		'name'
+		'name',
+		'sourceInterval',
+		'selector',
+		'origin'
 	],
 	#category : 'Spec2-Refactoring-Commands-Tests',
 	#package : 'Spec2-Refactoring-Commands-Tests'
@@ -40,6 +43,18 @@ StCommandContextMock >> name: aName [
 ]
 
 { #category : 'accessing' }
+StCommandContextMock >> origin [
+
+	^ origin
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> origin: aClass [
+
+	origin := aClass 
+]
+
+{ #category : 'accessing' }
 StCommandContextMock >> selectedMethod [
 
 	^ selectedMethod
@@ -55,6 +70,30 @@ StCommandContextMock >> selectedMethod: aCompiledMethod [
 StCommandContextMock >> selectedNode [
 
 	^ self
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selector [
+
+	^ selector
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selector: aSelector [
+
+	selector := aSelector
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> sourceInterval [
+
+	^ sourceInterval
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> sourceInterval: anInterval [
+
+	sourceInterval := anInterval
 ]
 
 { #category : 'evaluating' }

--- a/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/Spec2-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -56,3 +56,9 @@ StCommandContextMock >> selectedNode [
 
 	^ self
 ]
+
+{ #category : 'evaluating' }
+StCommandContextMock >> value [
+
+	^ self
+]

--- a/src/Spec2-Refactoring-Commands-Tests/package.st
+++ b/src/Spec2-Refactoring-Commands-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Spec2-Refactoring-Commands-Tests' }

--- a/src/Spec2-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
@@ -27,11 +27,11 @@ StConvertTempToInstVarCommand >> canBeExecuted [
 ]
 
 { #category : 'executing' }
-StConvertTempToInstVarCommand >> execute [ 
+StConvertTempToInstVarCommand >> prepareDriver [
 
-((ReConvertTemporaryToInstanceVariableDriver newApplication: self application)
-		   scopes: context allScopes
-		   class: context selectedMethod origin
-		   selector: context selectedMethod selector
-		   variable: self codePresenter selectedNode name) runRefactoring
+	^ (ReConvertTemporaryToInstanceVariableDriver newApplication: self application)
+		  scopes: context allScopes
+		  class: context selectedMethod origin
+		  selector: context selectedMethod selector
+		  variable: self codePresenter selectedNode name
 ]

--- a/src/Spec2-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
@@ -1,0 +1,37 @@
+"
+I am a command to convert a temp variable in instance variable.
+"
+Class {
+	#name : 'StConvertTempToInstVarCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StConvertTempToInstVarCommand class >> defaultIconName [
+
+	^ #smallRedo
+]
+
+{ #category : 'default' }
+StConvertTempToInstVarCommand class >> defaultName [
+
+	^ '(R) Convert to Instance Var'
+]
+
+{ #category : 'testing' }
+StConvertTempToInstVarCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isTempVariable
+]
+
+{ #category : 'executing' }
+StConvertTempToInstVarCommand >> execute [ 
+
+((ReConvertTemporaryToInstanceVariableDriver newApplication: self application)
+		   scopes: context allScopes
+		   class: context selectedMethod origin
+		   selector: context selectedMethod selector
+		   variable: self codePresenter selectedNode name) runRefactoring
+]

--- a/src/Spec2-Refactoring-Commands/StExtractTempCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StExtractTempCommand.class.st
@@ -23,13 +23,15 @@ StExtractTempCommand class >> defaultName [
 { #category : 'testing' }
 StExtractTempCommand >> canBeExecuted [
 
-	^ context selectedMethod isNotNil
+	^ self codePresenter selectionInterval isNotEmpty
 ]
 
 { #category : 'executing' }
 StExtractTempCommand >> execute [
 
 	(ReExtractTempDriver new
-		 extract: self codePresenter selectionInterval from: context selectedMethod selector in: context selectedMethod origin;
+		 extract: self codePresenter selectedNode sourceInterval
+		 from: context selectedMethod selector
+		 in: context selectedMethod origin;
 		 scopes: context allScopes) runRefactoring
 ]

--- a/src/Spec2-Refactoring-Commands/StExtractTempCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StExtractTempCommand.class.st
@@ -1,0 +1,35 @@
+"
+Extract selected interval into a temporary variable from a code presenter 
+"
+Class {
+	#name : 'StExtractTempCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StExtractTempCommand class >> defaultIconName [
+
+	^ #smallUpdate
+]
+
+{ #category : 'default' }
+StExtractTempCommand class >> defaultName [
+
+	^ 'Extract temp'
+]
+
+{ #category : 'testing' }
+StExtractTempCommand >> canBeExecuted [
+
+	^ context selectedMethod isNotNil
+]
+
+{ #category : 'executing' }
+StExtractTempCommand >> execute [
+
+	(ReExtractTempDriver new
+		 extract: self codePresenter selectionInterval from: context selectedMethod selector in: context selectedMethod origin;
+		 scopes: context allScopes) runRefactoring
+]

--- a/src/Spec2-Refactoring-Commands/StExtractTempCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StExtractTempCommand.class.st
@@ -27,11 +27,11 @@ StExtractTempCommand >> canBeExecuted [
 ]
 
 { #category : 'executing' }
-StExtractTempCommand >> execute [
+StExtractTempCommand >> prepareDriver [
 
-	(ReExtractTempDriver new
-		 extract: self codePresenter selectedNode sourceInterval
-		 from: context selectedMethod selector
-		 in: context selectedMethod origin;
-		 scopes: context allScopes) runRefactoring
+	^ (ReExtractTempDriver newApplication: self application)
+		  extract: self codePresenter selectedNode sourceInterval
+		  from: context selectedMethod selector
+		  in: context selectedMethod origin;
+		  scopes: context allScopes
 ]

--- a/src/Spec2-Refactoring-Commands/StGenerateVariableAccessorCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StGenerateVariableAccessorCommand.class.st
@@ -1,0 +1,37 @@
+"
+I am a command to generate accessors for given variables
+"
+Class {
+	#name : 'StGenerateVariableAccessorCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StGenerateVariableAccessorCommand class >> defaultIconName [
+
+	^ #smallAdd
+]
+
+{ #category : 'default' }
+StGenerateVariableAccessorCommand class >> defaultName [
+
+	^ ' (T) Generate accessors'
+]
+
+{ #category : 'testing' }
+StGenerateVariableAccessorCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isInstanceVariable and: [ self codePresenter selectedNode isGlobalVariable not ]
+]
+
+{ #category : 'executing' }
+StGenerateVariableAccessorCommand >> prepareDriver [
+
+	^ (ReGenerateAccessorsDriver newApplication: self application)
+		  targetClass: context selectedMethod origin;
+		  scopes: context allScopes
+		  scopeInstanceSide: context selectedMethod origin isInstanceSide
+		  selectedVariables: { self codePresenter selectedNode name }
+]

--- a/src/Spec2-Refactoring-Commands/StInlineMethodCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StInlineMethodCommand.class.st
@@ -13,7 +13,7 @@ StInlineMethodCommand class >> defaultIconName [
 	^ #smallRightFlush
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'default' }
 StInlineMethodCommand class >> defaultName [
 
 	^ 'Inline method'

--- a/src/Spec2-Refactoring-Commands/StInlineMethodCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StInlineMethodCommand.class.st
@@ -1,0 +1,36 @@
+"
+I am a command to inline ""self send"" method directly into sender method
+"
+Class {
+	#name : 'StInlineMethodCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StInlineMethodCommand class >> defaultIconName [
+	^ #smallRightFlush
+]
+
+{ #category : 'as yet unclassified' }
+StInlineMethodCommand class >> defaultName [
+
+	^ 'Inline method'
+]
+
+{ #category : 'testing' }
+StInlineMethodCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isMessage
+]
+
+{ #category : 'executing' }
+StInlineMethodCommand >> prepareDriver [
+
+	^ (ReInlineMethodDriver newApplication: self application)
+		  scopes: context allScopes
+		  interval: self codePresenter selectedNode sourceInterval
+		  selector: context selectedMethod selector
+		  class: context selectedMethod origin
+]

--- a/src/Spec2-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRefactoringCommand.class.st
@@ -14,3 +14,15 @@ StRefactoringCommand >> codePresenter [
 
 	^ context codePresenter
 ]
+
+{ #category : 'executing' }
+StRefactoringCommand >> execute [
+
+	self prepareDriver runRefactoring
+]
+
+{ #category : 'executing' }
+StRefactoringCommand >> prepareDriver [
+
+	^ self subclassResponsibility
+]

--- a/src/Spec2-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRefactoringCommand.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : 'accessing' }
 StRefactoringCommand >> codePresenter [
 
-	^ context codePresenter
+	^ context codeEditor codePresenter
 ]
 
 { #category : 'executing' }

--- a/src/Spec2-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRefactoringCommand.class.st
@@ -1,0 +1,16 @@
+"
+I'm a base command for refactorings. 
+My children will define commands for refactoring support in spec
+"
+Class {
+	#name : 'StRefactoringCommand',
+	#superclass : 'StCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StRefactoringCommand >> codePresenter [
+
+	^ context codePresenter
+]

--- a/src/Spec2-Refactoring-Commands/StRenameArgOrTempCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRenameArgOrTempCommand.class.st
@@ -1,0 +1,39 @@
+"
+I am a command to rename temp variable in given method.
+ 
+
+"
+Class {
+	#name : 'StRenameArgOrTempCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StRenameArgOrTempCommand class >> defaultIconName [
+
+	^ #edit
+]
+
+{ #category : 'default' }
+StRenameArgOrTempCommand class >> defaultName [
+
+	^ '(R) Rename temp'
+]
+
+{ #category : 'testing' }
+StRenameArgOrTempCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isTempVariable or: [ self codePresenter selectedNode isArgumentVariable ]
+]
+
+{ #category : 'executing' }
+StRenameArgOrTempCommand >> prepareDriver [
+
+	^ ReRenameArgumentOrTemporaryDriver new
+		  sourceNode: self codePresenter selectedNode;
+		  method: context selectedMethod;
+		  scopes: context allScopes;
+		  yourself
+]

--- a/src/Spec2-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRenameClassCommand.class.st
@@ -35,10 +35,9 @@ StRenameClassCommand >> canBeExecuted [
 ]
 
 { #category : 'executing' }
-StRenameClassCommand >> execute [
+StRenameClassCommand >> prepareDriver [
 
-	(ReRenameClassDriver rename: context codePresenter selectedNode value name)
-		model: RBBrowserEnvironment new;
-		scopes: context allScopes;
-		runRefactoring
+	^ (ReRenameClassDriver rename: context codePresenter selectedNode value name)
+		  model: RBBrowserEnvironment new;
+		  scopes: context allScopes
 ]

--- a/src/Spec2-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRenameClassCommand.class.st
@@ -37,7 +37,7 @@ StRenameClassCommand >> canBeExecuted [
 { #category : 'executing' }
 StRenameClassCommand >> prepareDriver [
 
-	^ (ReRenameClassDriver rename: context codePresenter selectedNode value name)
+	^ (ReRenameClassDriver rename: self codePresenter selectedNode value name)
 		  model: RBBrowserEnvironment new;
 		  scopes: context allScopes
 ]

--- a/src/Spec2-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/Spec2-Refactoring-Commands/StRenameClassCommand.class.st
@@ -1,0 +1,44 @@
+"
+Rename selected class from a code presenter
+"
+Class {
+	#name : 'StRenameClassCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'Spec2-Refactoring-Commands',
+	#package : 'Spec2-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRenameClassCommand class >> defaultDescription [
+
+	^ 'Rename selected class'
+]
+
+{ #category : 'accessing' }
+StRenameClassCommand class >> defaultIconName [
+
+	^ #edit 
+]
+
+{ #category : 'default' }
+StRenameClassCommand class >> defaultName [
+
+	^ '(R) Rename'
+]
+
+{ #category : 'testing' }
+StRenameClassCommand >> canBeExecuted [
+
+	| node |
+	node := self codePresenter selectedNode.
+	^ node isGlobalVariable and: [ node binding value isClass ]
+]
+
+{ #category : 'executing' }
+StRenameClassCommand >> execute [
+
+	(ReRenameClassDriver rename: context codePresenter selectedNode value name)
+		model: RBBrowserEnvironment new;
+		scopes: context allScopes;
+		runRefactoring
+]

--- a/src/Spec2-Refactoring-Commands/package.st
+++ b/src/Spec2-Refactoring-Commands/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Spec2-Refactoring-Commands' }


### PR DESCRIPTION
This is the start of the migration of refactoring commands, used now for the method browser. 

For now I implemented : 
-`Rename Class`
-`Extract Temp`
-`Convert temp to inst var`

We could use these for other places that deal with the code presenter (Playground,...) but we will need an unified API.

I also added test for the commands to check if the navigation through AST is well plugged to drivers.
Created a mock context for the tests, also need a special PR for the driver in pharo repo