### PR TITLE
add `isVisible` for refactoring commands

### DIFF
--- a/src/Spec2-Commander2/SpCommand.class.st
+++ b/src/Spec2-Commander2/SpCommand.class.st
@@ -160,6 +160,12 @@ SpCommand >> isEnabled [
 	^ self canBeExecuted
 ]
 
+{ #category : 'testing' }
+SpCommand >> isVisible [
+
+	^ self canBeExecuted 
+]
+
 { #category : 'accessing' }
 SpCommand >> presenter [
 	^ presenter


### PR DESCRIPTION
So it is handled like the one is source code: if it can't be executed, then it is not shown