### PR TITLE
Compiler api

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
@@ -470,32 +470,31 @@ SpAbstractMorphicAdapter >> keyDown: keyCode shift: shiftBoolean meta: metaBoole
 
 { #category : 'emulating' }
 SpAbstractMorphicAdapter >> keyEvent: type code: keyCode shift: shiftBoolean meta: metaBoolean control: controlBoolean option: optionBoolean [
+
 	| evt modifiers |
-	
 	modifiers := 0.
 	shiftBoolean ifTrue: [ modifiers := modifiers | 8 ].
-	metaBoolean ifTrue: [ modifiers := modifiers |
-		(Smalltalk os isWindows | Smalltalk os isUnix
-			ifTrue: [ 2r00010000 ]
-			ifFalse: [ 2r01000000 ]) ].
+	metaBoolean ifTrue: [
+			modifiers := modifiers | (OSPlatform current isWindows | OSPlatform current isUnix
+				              ifTrue: [ 2r00010000 ]
+				              ifFalse: [ 2r01000000 ]) ].
 	controlBoolean ifTrue: [ modifiers := modifiers | 2r00010000 ].
-	optionBoolean ifTrue: [ modifiers := modifiers |
-		(Smalltalk os isWindows | Smalltalk os isUnix
-			ifTrue: [ 2r01000000 ]
-			ifFalse: [ 2r00100000 ]) ].
-		
+	optionBoolean ifTrue: [
+			modifiers := modifiers | (Smalltalk os isWindows | Smalltalk os isUnix
+				              ifTrue: [ 2r01000000 ]
+				              ifFalse: [ 2r00100000 ]) ].
+
 	evt := KeyboardEvent new
-		setType: type
-		buttons: modifiers
-		position: self widget position + (1 @ 1)
-		keyValue: keyCode
-		charCode: keyCode
-		hand: self currentWorld activeHand
-		stamp: Time millisecondClockValue.
+		       setType: type
+		       buttons: modifiers
+		       position: self widget position + (1 @ 1)
+		       keyValue: keyCode
+		       charCode: keyCode
+		       hand: self currentWorld activeHand
+		       stamp: Time millisecondClockValue.
 
 	evt key: (KeyboardKey fromCharacter: keyCode asCharacter).
-	evt sentTo: self widgetEventReceiver.
-	"Some time to allow things to happen?"
+	evt sentTo: self widgetEventReceiver. "Some time to allow things to happen?"
 	10 milliSeconds wait
 ]
 

--- a/src/Spec2-Backend-Tests/SpScrollableLayoutAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpScrollableLayoutAdapterTest.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : 'accessing' }
 SpScrollableLayoutAdapterTest >> newClassFactory [
 
-	^ ClassFactoryForTestCase new
+	^ ClassFactoryForTestCase environment: SystemEnvironment new
 ]
 
 { #category : 'accessing' }

--- a/src/Spec2-Code-Commands/SpCodeSelectionCommand.class.st
+++ b/src/Spec2-Code-Commands/SpCodeSelectionCommand.class.st
@@ -49,16 +49,16 @@ SpCodeSelectionCommand >> compile: aStream for: anObject in: evalContext [
 		            source: aStream;
 		            yourself.
 
-	evalContext
-		ifNil: [ compiler receiver: anObject ]
-		ifNotNil: [ compiler context: evalContext ].
+	evalContext ifNil: [ compiler receiver: anObject ] ifNotNil: [ compiler context: evalContext ].
 
-	^ compiler
-		  requestor: context;
-		  "it should enable a visibility of current tool variables in new debugger"
-		  isScripting: true;
-		  failBlock: [ ^ nil ];
-		  compile
+	^ [
+		  compiler
+			  requestor: context;
+			  "it should enable a visibility of current tool variables in new debugger"
+			  isScripting: true;
+			  compile ]
+		  on: OCRuntimeSyntaxError , OCUndeclaredVariableWarning
+		  do: [ nil ]
 ]
 
 { #category : 'private' }

--- a/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
@@ -33,6 +33,12 @@ SpMorphicCodeAdapter >> bindingOf: aString [
 	^ self presenter bindingOf: aString
 ]
 
+{ #category : 'accessing' }
+SpMorphicCodeAdapter >> bindings [
+
+	^ self presenter bindings
+]
+
 { #category : 'factory' }
 SpMorphicCodeAdapter >> buildWidget [
 	| newWidget |

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -371,7 +371,7 @@ SpCodePresenter >> environment: anEnvironment [
 ]
 
 { #category : 'command support' }
-SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: errorBlock [ 
+SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: errorBlock [
 	"evaluate aString. 
 	 evaluate compileErrorBlock if there are compilation errors. 
 	 evaluate errorBlock is anything happens *during* evaluation (code compiled, but it does not 
@@ -384,28 +384,27 @@ SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: 
 	 anything. 
 	 Instead, the on:do: will catch all errors happening while executing the code once it is 
 	 compiled. "
+
 	| result oldBindings |
-	
 	^ [
-		self announcer announce: (SpCodeWillBeEvaluatedAnnouncement newContent: aString).
-		oldBindings := self interactionModel bindings copy.
-		result := self interactionModel compiler
-			source: aString;
-			environment: self environment;
-			failBlock:  [ 
-				self announcer announce: (SpCodeEvaluationFailedAnnouncement newContent: aString).
-				^ compileErrorBlock value ];
-			evaluate.
-		oldBindings size = self interactionModel bindings size 
-			ifFalse: [ self refreshStyling ].
-		self announcer announce: (SpCodeEvaluationSucceedAnnouncement newContent: aString).
-		result ]
-	on: Error 
-	do: [ :e |
-		self announcer announce: (SpCodeEvaluationFailedAnnouncement 
-			newContent: aString
-			error: e).
-		errorBlock value: e ]
+		  self announcer announce: (SpCodeWillBeEvaluatedAnnouncement newContent: aString).
+		  oldBindings := self interactionModel bindings copy.
+		  [
+			  result := self interactionModel compiler
+				            source: aString;
+				            environment: self environment;
+				            evaluate ]
+			  on: OCRuntimeSyntaxError , OCUndeclaredVariableWarning
+			  do: [ :err |
+					  self announcer announce: (SpCodeEvaluationFailedAnnouncement newContent: aString).
+					  ^ compileErrorBlock value ].
+		  oldBindings size = self interactionModel bindings size ifFalse: [ self refreshStyling ].
+		  self announcer announce: (SpCodeEvaluationSucceedAnnouncement newContent: aString).
+		  result ]
+		  on: Error
+		  do: [ :e |
+				  self announcer announce: (SpCodeEvaluationFailedAnnouncement newContent: aString error: e).
+				  errorBlock value: e ]
 ]
 
 { #category : 'private - bindings' }

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -203,6 +203,12 @@ SpCodePresenter >> bindingOf: aString [
 	^ nil
 ]
 
+{ #category : 'accessing' }
+SpCodePresenter >> bindings [
+	
+	^ self interactionModel bindings
+]
+
 { #category : 'testing' }
 SpCodePresenter >> canAddBindingOf: name [
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -400,7 +400,7 @@ SpCodePresenter >> evaluate: aString onCompileError: compileErrorBlock onError: 
 				            source: aString;
 				            environment: self environment;
 				            evaluate ]
-			  on: OCRuntimeSyntaxError , OCUndeclaredVariableWarning
+			  on: OCCodeError, OCRuntimeSyntaxError , OCUndeclaredVariableWarning
 			  do: [ :err |
 					  self announcer announce: (SpCodeEvaluationFailedAnnouncement newContent: aString).
 					  ^ compileErrorBlock value ].

--- a/src/Spec2-Tests/SpGridLayoutBuilderTest.class.st
+++ b/src/Spec2-Tests/SpGridLayoutBuilderTest.class.st
@@ -48,7 +48,7 @@ SpGridLayoutBuilderTest >> testBuilderCanAddElementsOnMultipleRaws [
 	self assert: (layout atPoint: 1 @ 1) equals: presenters first.
 	self assert: (layout atPoint: 2 @ 1) equals: presenters second.
 	self assert: (layout atPoint: 1 @ 2) equals: presenters third.
-	self assert: (layout at: 1 @ 3) equals: presenters fourth.
+	self assert: (layout atPoint: 1 @ 3) equals: presenters fourth.
 	self assert: (layout at: 2 @ 3) equals: presenters fifth
 ]
 


### PR DESCRIPTION
Cleanup usage of compiler API
 - do not use failBlock but exceptions
 - use bindings instead of requestor when possible (i.e., when only using requestor bindings, e.g., for syntax highlight)
 - expose code presenter bindings

In addition:
  - compile some deprecation rewrites