### PR TITLE
Change deprecation to make those tests use the right API

### DIFF
--- a/src/Spec2-Core/SpApplication.class.st
+++ b/src/Spec2-Core/SpApplication.class.st
@@ -263,7 +263,7 @@ SpApplication >> newPresenter: aPresenterClass [
 
 	self 
 		deprecated: 'Use #instantiate: which is the polymorphic name' 
-		transformWith: '`@receiver new: `@arg' -> '`@receiver instantiate: `@arg'.
+		transformWith: '`@receiver newPresenter: `@arg' -> '`@receiver instantiate: `@arg'.
 
 	^ self instantiate: aPresenterClass
 ]

--- a/src/Spec2-Morphic-Backend-Tests/SpApplicationWithLocaleTest.class.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpApplicationWithLocaleTest.class.st
@@ -14,7 +14,7 @@ SpApplicationWithLocaleTest >> testLabel [
 	app locale: (Locale isoLanguage: 'en' isoCountry: 'US').
 	app useBackend: #Morphic.
 	string := SpTestLocalizedString from: 'string'.
-	label := app newPresenter: SpLabelPresenter.
+	label := app instantiate: SpLabelPresenter.
 	label label: string.
 	label open.
 	self assert: label adapter widget contents equals: 'string[en-US](1)'.

--- a/src/Spec2-Tests/SpApplicationTest.class.st
+++ b/src/Spec2-Tests/SpApplicationTest.class.st
@@ -28,7 +28,7 @@ SpApplicationTest >> testCloseDialogWindowRemovesItFromWindowCollection [
 
 	| window |
 	application := SpApplication new.
-	window := (application newPresenter: SpButtonPresenter) openDialog.
+	window := (application instantiate: SpButtonPresenter) openDialog.
 	window close.
 	self deny: (application windows includes: window)
 ]
@@ -38,7 +38,7 @@ SpApplicationTest >> testCloseWindowRemovesItFromWindowCollection [
 
 	| window |
 	application := SpApplication new.
-	window := (application newPresenter: SpButtonPresenter) open.
+	window := (application instantiate: SpButtonPresenter) open.
 	window close.
 	self deny: (application windows includes: window)
 ]
@@ -51,9 +51,9 @@ SpApplicationTest >> testIsPresenter [
 
 { #category : 'tests' }
 SpApplicationTest >> testNewPresenter [
-	| presenter |
 
-	presenter := application newPresenter: SpButtonPresenter.
+	| presenter |
+	presenter := application instantiate: SpButtonPresenter.
 	self assert: presenter application equals: application
 ]
 
@@ -61,7 +61,7 @@ SpApplicationTest >> testNewPresenter [
 SpApplicationTest >> testOpenDialogWindowAddsItToWindowCollection [
 
 	| window |
-	window := (application newPresenter: SpButtonPresenter) openDialog.
+	window := (application instantiate: SpButtonPresenter) openDialog.
 
 	self assert: (application windows includes: window)
 ]
@@ -70,7 +70,7 @@ SpApplicationTest >> testOpenDialogWindowAddsItToWindowCollection [
 SpApplicationTest >> testOpenWindowAddsItToWindowCollection [
 
 	| window |
-	window := (application newPresenter: SpButtonPresenter) open.
+	window := (application instantiate: SpButtonPresenter) open.
 
 	self assert: (application windows includes: window)
 ]


### PR DESCRIPTION
Change deprecation to make those tests use the right API