### PR TITLE
add Struck Out to morphic adapters

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicLabelAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicLabelAdapter.class.st
@@ -20,6 +20,9 @@ SpMorphicLabelAdapter >> applyDecorationsTo: aString [
 	self presenter displayBold ifNotNil: [ :block |
 		(block cull: aString) ifTrue: [ 
 			text addAttribute: TextEmphasis bold ] ].
+	self presenter displayStruckOut ifNotNil: [ :block |
+		(block cull: aString) ifTrue: [ 
+			text addAttribute: TextEmphasis struckOut ] ].
 	self presenter displayItalic ifNotNil: [ :block |
 		(block cull: aString) ifTrue: [ 
 			text addAttribute: TextEmphasis italic ] ].

--- a/src/Spec2-Adapters-Morphic/SpMorphicListAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicListAdapter.class.st
@@ -123,6 +123,8 @@ SpMorphicListAdapter >> newListColumn [
 		ifNotNil: [ :aBlock | column displayUnderline: aBlock ].
 	self presenter displayBackgroundColor 
 		ifNotNil: [ :aBlock | column displayBackgroundColor: aBlock ].
+	self presenter displayStruckOut 
+		ifNotNil: [ :aBlock | column displayStruckOut: aBlock ].
 	
 	^ SpMorphicTableColumn new 
 		model: column;

--- a/src/Spec2-Adapters-Morphic/SpMorphicTableCellBuilder.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableCellBuilder.class.st
@@ -129,6 +129,17 @@ SpMorphicTableCellBuilder >> addItalicColumn: aTableColumn item: item to: conten
 ]
 
 { #category : 'private' }
+SpMorphicTableCellBuilder >> addStruckOutColumn: aTableColumn item: item to: content [
+
+	aTableColumn displayStruckOut ifNotNil: [ :block |
+		(block cull: item) ifTrue: [ 
+			^ content asText addAttribute: TextEmphasis struckOut ] ].
+	
+	^ content
+	
+]
+
+{ #category : 'private' }
 SpMorphicTableCellBuilder >> addUnderlineColumn: aTableColumn item: item to: content [
 
 	aTableColumn displayUnderline ifNotNil: [ :block |

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeAdapter.class.st
@@ -30,6 +30,8 @@ SpMorphicTreeAdapter >> defaultColumn [
 		ifNotNil: [ :aBlock | column displayUnderline: aBlock ].
 	self presenter displayBackgroundColor 
 		ifNotNil: [ :aBlock | column displayBackgroundColor: aBlock ].
+	self presenter displayStruckOut 
+		ifNotNil: [ :aBlock | column displayStruckOut: aBlock ].
 
 	^ self presenter displayIcon 
 		ifNotNil: [ :iconBlock |

--- a/src/Spec2-Core/SpTDecoratedText.trait.st
+++ b/src/Spec2-Core/SpTDecoratedText.trait.st
@@ -11,7 +11,8 @@ Trait {
 		'backgroundColorAction',
 		'italicAction',
 		'boldAction',
-		'underlineAction'
+		'underlineAction',
+		'displayStruckOut'
 	],
 	#category : 'Spec2-Core-Widgets-Table',
 	#package : 'Spec2-Core',
@@ -73,6 +74,18 @@ SpTDecoratedText >> displayItalic: aBlock [
 	 `aBlock` receives one argument (the model element)."
 
 	italicAction := aBlock
+]
+
+{ #category : 'accessing' }
+SpTDecoratedText >> displayStruckOut [
+
+	^ displayStruckOut
+]
+
+{ #category : 'accessing' }
+SpTDecoratedText >> displayStruckOut: aBlock [
+
+	displayStruckOut := aBlock 
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
It was not implemented for Spec, would be great to have it to show deprecated methods for example