### PR TITLE
latest changes

### DIFF
--- a/src/Spec2-Adapters-Morphic-ListView/SpMorphicColumnViewAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic-ListView/SpMorphicColumnViewAdapter.class.st
@@ -66,3 +66,20 @@ SpMorphicColumnViewAdapter >> newDataSource [
 		model: self presenter;
 		yourself
 ]
+
+{ #category : 'enumerating' }
+SpMorphicColumnViewAdapter >> traversePresentersDo: aBlock excluding: aSet [
+	| exposedRows |
+	
+	exposedRows := self widget container submorphs 
+		select: [ :each | each class = FTTableRowMorph ].
+	
+	(exposedRows
+		flatCollect: [ :each | 	
+			each submorphs collect: #presenter ])
+		do: [ :each | 
+			each ifNotNil: [
+				each 
+					traversePresentersDo: aBlock 
+					excluding: aSet ] ]
+]

--- a/src/Spec2-Adapters-Morphic-ListView/SpMorphicListViewAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic-ListView/SpMorphicListViewAdapter.class.st
@@ -72,3 +72,19 @@ SpMorphicListViewAdapter >> selectedRowPresenter [
 		ifFound: [ :aRow | aRow submorphs first submorphs last valueOfProperty: #presenter ]
 		ifNone: [ nil ] 
 ]
+
+{ #category : 'enumerating' }
+SpMorphicListViewAdapter >> traversePresentersDo: aBlock excluding: aSet [
+	| exposedRows |
+	
+	exposedRows := self widget container submorphs.
+	exposedRows
+		collect: [ :each | 	
+			(each submorphs first submorphs last 
+				valueOfProperty: #presenter 
+				ifAbsent: [ nil ]) ]
+		thenDo: [ :each | 
+			each 
+				traversePresentersDo: aBlock 
+				excluding: aSet ]
+]

--- a/src/Spec2-Adapters-Morphic-ListView/SpMorphicTreeColumnViewAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic-ListView/SpMorphicTreeColumnViewAdapter.class.st
@@ -42,3 +42,23 @@ SpMorphicTreeColumnViewAdapter >> selectedRowPresenter [
 		ifFound: [ :aRow | aRow submorphs first submorphs last presenter ]
 		ifNone: [ nil ] 
 ]
+
+{ #category : 'api - selection' }
+SpMorphicTreeColumnViewAdapter >> traversePresentersDo: aBlock excluding: aSet [
+	| exposedRows |
+	
+	exposedRows := self widget container submorphs 
+		select: [ :each | each class = FTTableRowMorph ].
+	
+	(exposedRows
+		flatCollect: [ :each | 	
+			"FTTableRowMorph, 
+			 FTIndentedCellMorph, 
+			 last morph = our morph"
+			each submorphs first submorphs collect: #presenter ])
+		do: [ :each | 
+			each ifNotNil: [
+				each 
+					traversePresentersDo: aBlock 
+					excluding: aSet ] ]
+]

--- a/src/Spec2-Adapters-Morphic-ListView/SpMorphicTreeListViewAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic-ListView/SpMorphicTreeListViewAdapter.class.st
@@ -102,3 +102,20 @@ SpMorphicTreeListViewAdapter >> selectedRowPresenter [
 		ifFound: [ :aRow | aRow content content valueOfProperty: #presenter ]
 		ifNone: [ nil ] 
 ]
+
+{ #category : 'api - selection' }
+SpMorphicTreeListViewAdapter >> traversePresentersDo: aBlock excluding: aSet [
+	| exposedRows |
+	
+	exposedRows := self widget container submorphs.
+	exposedRows
+		collect: [ :each | 	
+			(each submorphs first submorphs last 
+				valueOfProperty: #presenter 
+				ifAbsent: [ nil ]) ]
+		thenDo: [ :each | 
+			each ifNotNil: [
+				each 
+					traversePresentersDo: aBlock 
+					excluding: aSet ] ]
+]

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -67,49 +67,43 @@ SpMorphicTreeTableAdapter >> addModelTo: tableMorph [
 	self addColumnsFromPresenterTo: tableMorph.
 	self ensureAtLeastOneColumnIn: tableMorph.
 
-	self presenter selection isMultipleSelection ifTrue: [  
-		tableMorph beMultipleSelection ].
+	self presenter selection isMultipleSelection ifTrue: [ tableMorph beMultipleSelection ].
 
-	self isShowingColumnHeaders 
-		ifTrue: [ tableMorph showColumnHeaders ] 
+	self isShowingColumnHeaders
+		ifTrue: [ tableMorph showColumnHeaders ]
 		ifFalse: [ tableMorph hideColumnHeaders ].
 
-	self isResizable 
-		ifTrue: [ tableMorph beResizable ] 
+	self isResizable
+		ifTrue: [ tableMorph beResizable ]
 		ifFalse: [ tableMorph beNotResizable ].
-		
+
 	self isSearchEnabled
 		ifTrue: [ tableMorph enableSearch ]
 		ifFalse: [ tableMorph disableFunction ].
 
 	tableMorph setBalloonText: self model help.
-	
+
 	tableMorph dataSource: self newDataSource.
-	
-	self presenter selection isEmpty 
-		ifFalse: [ self updateSelectionOf: tableMorph ].
-	
-	self presenter whenSelectionChangedDo: [ 
-		self updateSelectionOf: tableMorph ].
-	
-	self presenter whenRootsChangedDo: [ 
-		tableMorph selectIndexes: #().
-		tableMorph dataSource: self newDataSource ].
-	
-	self presenter whenShowColumnHeadersChangedDo: [ 	
-		self isShowingColumnHeaders 
-			ifTrue: [ tableMorph showColumnHeaders ] 
-			ifFalse: [ tableMorph hideColumnHeaders ] ].
-		
+
+	self presenter selection isEmpty ifFalse: [ self updateSelectionOf: tableMorph ].
+
+	self presenter whenSelectionChangedDo: [ self updateSelectionOf: tableMorph ].
+
+	self presenter whenRootsChangedDo: [
+			tableMorph selectIndexes: #(  ).
+			tableMorph dataSource: self newDataSource ].
+
+	self presenter whenShowColumnHeadersChangedDo: [
+			self isShowingColumnHeaders
+				ifTrue: [ tableMorph showColumnHeaders ]
+				ifFalse: [ tableMorph hideColumnHeaders ] ].
+
 	self registerColumnsChangedEventTo: tableMorph.
-	
+
 	tableMorph
-		onAnnouncement: FTSelectionChanged
-			send: #selectionChanged:
-			to: self;
-		onAnnouncement: FTStrongSelectionChanged
-			send: #strongSelectionChanged:
-			to: self
+		onAnnouncement: FTSelectionChanged send: #selectionChanged: to: self;
+		onAnnouncement: FTStrongSelectionChanged send: #strongSelectionChanged: to: self;
+		onAnnouncement: FTTreeExpansionChanged send: #treeExpansionChanged: to: self
 ]
 
 { #category : 'drawing' }
@@ -492,6 +486,15 @@ SpMorphicTreeTableAdapter >> transferFrom: aTransferMorph event: anEvent [
 		column: (rowAndColumn second ifNil: [ 0 ]);
 		target: aTarget;
 		yourself
+]
+
+{ #category : 'private' }
+SpMorphicTreeTableAdapter >> treeExpansionChanged: anAnnouncement [
+
+	self presenter announce: (SpTreeExpansionChanged new
+			 item: anAnnouncement item;
+			 expanded: anAnnouncement expanded;
+			 yourself)
 ]
 
 { #category : 'private' }

--- a/src/Spec2-Commander2/SpAction.class.st
+++ b/src/Spec2-Commander2/SpAction.class.st
@@ -12,7 +12,8 @@ Class {
 		'actionVisible',
 		'id',
 		'dynamicName',
-		'state'
+		'state',
+		'actionState'
 	],
 	#category : 'Spec2-Commander2-Action',
 	#package : 'Spec2-Commander2',
@@ -78,6 +79,12 @@ SpAction >> action: aBlock [
 SpAction >> actionEnabled: aBlock [
 
 	actionEnabled := aBlock
+]
+
+{ #category : 'accessing' }
+SpAction >> actionState: aBlock [
+
+	actionState := aBlock
 ]
 
 { #category : 'accessing' }
@@ -149,7 +156,7 @@ SpAction >> execute [
 SpAction >> hasState [
 	"state can be true/false. If nil this is a regular menu."
 
-	^ state isNotNil
+	^ state isNotNil or: [ actionState isNotNil ]
 ]
 
 { #category : 'comparing' }
@@ -230,8 +237,9 @@ SpAction >> shortcut: aKeyCombination [
 { #category : 'accessing - state' }
 SpAction >> state [
 	"state can be true/false or nil. This will be used for check menu items (and toggleable buttons)"
+	actionState ifNotNil: [ ^ actionState cull: self context ].
 
-	^ state
+	^ state 
 ]
 
 { #category : 'accessing - state' }

--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -263,6 +263,12 @@ SpFilteringListPresenter >> reapplyOrResetFilter [
 	self items ifEmpty: [ self resetFilter ]
 ]
 
+{ #category : 'accessing' }
+SpFilteringListPresenter >> refresh [
+
+	listPresenter refresh
+]
+
 { #category : 'api' }
 SpFilteringListPresenter >> resetFilter [
 

--- a/src/Spec2-Core/SpCompositeIconProvider.class.st
+++ b/src/Spec2-Core/SpCompositeIconProvider.class.st
@@ -53,3 +53,9 @@ SpCompositeIconProvider >> providers [
 	
 	^ providers
 ]
+
+{ #category : 'initialization' }
+SpCompositeIconProvider >> reset [
+
+	providers do: #reset
+]

--- a/src/Spec2-Core/SpIconProvider.class.st
+++ b/src/Spec2-Core/SpIconProvider.class.st
@@ -32,3 +32,8 @@ SpIconProvider >> iconNamed: aName ifAbsent: aBlock [
 
 	self subclassResponsibility
 ]
+
+{ #category : 'initialization' }
+SpIconProvider >> reset [
+	
+]

--- a/src/Spec2-Core/SpLocationIconProvider.class.st
+++ b/src/Spec2-Core/SpLocationIconProvider.class.st
@@ -119,6 +119,12 @@ SpLocationIconProvider >> menuIconNamed: aName [
 	^ self iconNamed: aName
 ]
 
+{ #category : 'initialization' }
+SpLocationIconProvider >> reset [
+
+	icons := Dictionary new
+]
+
 { #category : 'accessing' }
 SpLocationIconProvider >> setBlankIcon: aForm [
 	"To be able to specify the form that represents a missing icon."

--- a/src/Spec2-ListView/SpAbstractEasyTreeListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpAbstractEasyTreeListViewPresenter.class.st
@@ -306,6 +306,16 @@ SpAbstractEasyTreeListViewPresenter >> verticalAlignment [
 	^ contentView verticalAlignment
 ]
 
+{ #category : 'events' }
+SpAbstractEasyTreeListViewPresenter >> whenExpandChangedDo: aBlock [
+	"Inform when notification of expand happens."
+
+	self announcer 
+		when: SpTreeExpansionChanged 
+		do: aBlock 
+		for: aBlock receiver
+]
+
 { #category : 'api - events' }
 SpAbstractEasyTreeListViewPresenter >> whenMenuChangedDo: aBlock [
 

--- a/src/Spec2-ListView/SpColumnViewPresenter.class.st
+++ b/src/Spec2-ListView/SpColumnViewPresenter.class.st
@@ -254,6 +254,16 @@ SpColumnViewPresenter >> showColumnHeaders [
 	showColumnHeaders := true
 ]
 
+{ #category : 'private - traversing' }
+SpColumnViewPresenter >> traversePresentersDo: aBlock excluding: aSet [
+
+	super traversePresentersDo: aBlock excluding: aSet.
+	self withAdapterDo: [ :anAdapter | 
+		anAdapter 
+			traversePresentersDo: aBlock 
+			excluding: aSet ]
+]
+
 { #category : 'api - events' }
 SpColumnViewPresenter >> whenColumnsChangedDo: aBlock [
 	"Inform when columns have changed. 

--- a/src/Spec2-ListView/SpListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpListViewPresenter.class.st
@@ -317,3 +317,13 @@ SpListViewPresenter >> setupAction [
 
 	^ setupAction
 ]
+
+{ #category : 'private - traversing' }
+SpListViewPresenter >> traversePresentersDo: aBlock excluding: aSet [
+
+	super traversePresentersDo: aBlock excluding: aSet.
+	self withAdapterDo: [ :anAdapter | 
+		anAdapter 
+			traversePresentersDo: aBlock 
+			excluding: aSet ]
+]

--- a/src/Spec2-ListView/SpTreeColumnViewPresenter.class.st
+++ b/src/Spec2-ListView/SpTreeColumnViewPresenter.class.st
@@ -271,6 +271,17 @@ SpTreeColumnViewPresenter >> whenColumnsChangedDo: aBlock [
 	self property: #columns whenChangedDo: aBlock
 ]
 
+{ #category : 'events' }
+SpTreeColumnViewPresenter >> whenExpandChangedDo: aBlock [
+	"Inform when a tree node has been expanded or collapsed.
+	 `aBlock` receives one optional argument (an instance of `SpTreeExpansionChanged`)."
+
+	self announcer 
+		when: SpTreeExpansionChanged 
+		do: aBlock 
+		for: aBlock receiver
+]
+
 { #category : 'api - events' }
 SpTreeColumnViewPresenter >> whenIsResizableChangedDo: aBlock [
 	"Inform when resizable property has changed. 

--- a/src/Spec2-ListView/SpTreeColumnViewPresenter.class.st
+++ b/src/Spec2-ListView/SpTreeColumnViewPresenter.class.st
@@ -250,6 +250,16 @@ SpTreeColumnViewPresenter >> showColumnHeaders [
 	showColumnHeaders := true
 ]
 
+{ #category : 'private - traversing' }
+SpTreeColumnViewPresenter >> traversePresentersDo: aBlock excluding: aSet [
+
+	super traversePresentersDo: aBlock excluding: aSet.
+	self withAdapterDo: [ :anAdapter | 
+		anAdapter 
+			traversePresentersDo: aBlock 
+			excluding: aSet ]
+]
+
 { #category : 'api - events' }
 SpTreeColumnViewPresenter >> whenColumnsChangedDo: aBlock [
 	"Inform when columns have changed. 

--- a/src/Spec2-ListView/SpTreeExpansionChanged.class.st
+++ b/src/Spec2-ListView/SpTreeExpansionChanged.class.st
@@ -1,0 +1,40 @@
+"
+An announcement emitted when a tree node is expanded or collapsed.
+
+It carries the tree item that was expanded/collapsed and a boolean indicating whether it is now expanded.
+"
+Class {
+	#name : 'SpTreeExpansionChanged',
+	#superclass : 'Announcement',
+	#instVars : [
+		'item',
+		'expanded'
+	],
+	#category : 'Spec2-ListView-Widget',
+	#package : 'Spec2-ListView',
+	#tag : 'Widget'
+}
+
+{ #category : 'accessing' }
+SpTreeExpansionChanged >> expanded [
+
+	^ expanded
+]
+
+{ #category : 'accessing' }
+SpTreeExpansionChanged >> expanded: aBoolean [
+
+	expanded := aBoolean
+]
+
+{ #category : 'accessing' }
+SpTreeExpansionChanged >> item [
+
+	^ item
+]
+
+{ #category : 'accessing' }
+SpTreeExpansionChanged >> item: anObject [
+
+	item := anObject
+]

--- a/src/Spec2-ListView/SpTreeListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpTreeListViewPresenter.class.st
@@ -293,3 +293,13 @@ SpTreeListViewPresenter >> setupAction [
 
 	^ setupAction
 ]
+
+{ #category : 'private - traversing' }
+SpTreeListViewPresenter >> traversePresentersDo: aBlock excluding: aSet [
+
+	super traversePresentersDo: aBlock excluding: aSet.
+	self withAdapterDo: [ :anAdapter | 
+		anAdapter 
+			traversePresentersDo: aBlock 
+			excluding: aSet ]
+]

--- a/src/Spec2-ListView/SpTreeListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpTreeListViewPresenter.class.st
@@ -303,3 +303,14 @@ SpTreeListViewPresenter >> traversePresentersDo: aBlock excluding: aSet [
 			traversePresentersDo: aBlock 
 			excluding: aSet ]
 ]
+
+{ #category : 'events' }
+SpTreeListViewPresenter >> whenExpandChangedDo: aBlock [
+	"Inform when a tree node has been expanded or collapsed.
+	 `aBlock` receives one optional argument (an instance of `SpTreeExpansionChanged`)."
+
+	self announcer 
+		when: SpTreeExpansionChanged 
+		do: aBlock 
+		for: aBlock receiver
+]

--- a/src/Spec2-Tests/SpAbstractTreePresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractTreePresenterTest.class.st
@@ -208,6 +208,48 @@ SpAbstractTreePresenterTest >> testUpdateRootsKeepingSelection [
 ]
 
 { #category : 'tests' }
+SpAbstractTreePresenterTest >> testWhenExpandChangedDoIsRaised [
+	| called |
+	
+	called := false.
+	presenter whenExpandChangedDo: [ :ann | called := true ].
+	presenter announce: (SpTreeExpansionChanged new
+		item: 1;
+		expanded: true;
+		yourself).
+	
+	self assert: called
+]
+
+{ #category : 'tests' }
+SpAbstractTreePresenterTest >> testWhenExpandChangedDoReceivesExpandedFlag [
+	| receivedExpanded |
+	
+	receivedExpanded := nil.
+	presenter whenExpandChangedDo: [ :ann | receivedExpanded := ann expanded ].
+	presenter announce: (SpTreeExpansionChanged new
+		item: 1;
+		expanded: false;
+		yourself).
+			 
+	self deny: receivedExpanded
+]
+
+{ #category : 'tests' }
+SpAbstractTreePresenterTest >> testWhenExpandChangedDoReceivesItem [
+	| receivedItem |
+	
+	receivedItem := nil.
+	presenter whenExpandChangedDo: [ :ann | receivedItem := ann item ].
+	presenter announce: (SpTreeExpansionChanged new
+		item: #test;
+		expanded: true;
+		yourself).
+			 
+	self assert: receivedItem equals: #test
+]
+
+{ #category : 'tests' }
 SpAbstractTreePresenterTest >> testWhenSelectedItemChangedDo [
 	| selectedItem |
 


### PR DESCRIPTION
- expand/collapse of tree presenters
- state of actions now can be controlled trough a block (`actionState:`)
- other minor changes