### PR TITLE
Compiler Requestors should implement correctFrom:to:with:

### DIFF
--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -56,6 +56,11 @@ SpCodeInteractionModel >> compiler [
 		yourself
 ]
 
+{ #category : 'interactive error protocol' }
+SpCodeInteractionModel >> correctFrom: start to: stop with: aString [ 
+	self owner adapter widget correctFrom: start to: stop with: aString 
+]
+
 { #category : 'accessing' }
 SpCodeInteractionModel >> doItContext [
 


### PR DESCRIPTION
Interaction models should implement requestor API for automatic reparations.

This method is just moved up from `StPlaygroundInteractionModel`.