### PR TITLE
add expansion events to old trees 

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -492,9 +492,9 @@ SpMorphicTreeTableAdapter >> transferFrom: aTransferMorph event: anEvent [
 SpMorphicTreeTableAdapter >> treeExpansionChanged: anAnnouncement [
 
 	self presenter announce: (SpTreeExpansionChanged new
-			 item: anAnnouncement item;
-			 expanded: anAnnouncement expanded;
-			 yourself)
+		item: anAnnouncement item;
+		expanded: anAnnouncement expanded;
+		yourself)
 ]
 
 { #category : 'private' }

--- a/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
+++ b/src/Spec2-CommonWidgets/SpFilteringListPresenter.class.st
@@ -380,7 +380,14 @@ SpFilteringListPresenter >> whenActivatedDo: aBlock [
 
 { #category : 'api - events' }
 SpFilteringListPresenter >> whenFilterChangedDo: aBlock [
+
 	filterInputPresenter whenTextChangedDo: aBlock
+]
+
+{ #category : 'api - events' }
+SpFilteringListPresenter >> whenRowPresenterInstantiatedDo:  aBlock [
+
+	listPresenter whenRowPresenterInstantiatedDo:  aBlock
 ]
 
 { #category : 'api - events' }

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -595,6 +595,17 @@ SpAbstractTreePresenter >> whenActivatedDo: aBlock [
 ]
 
 { #category : 'api - events' }
+SpAbstractTreePresenter >> whenExpandChangedDo: aBlock [
+	"Inform when a tree node has been expanded or collapsed.
+	 `aBlock` receives one optional argument (an instance of `SpTreeExpansionChanged`)."
+
+	self announcer 
+		when: SpTreeExpansionChanged 
+		do: aBlock 
+		for: aBlock receiver
+]
+
+{ #category : 'api - events' }
 SpAbstractTreePresenter >> whenMultiSelectionChangedDo: aBlockClosure [ 
 	"Inform when selection mode has changed. 
 	 `aBlock` has three optional arguments: 

--- a/src/Spec2-Core/SpTableColumn.class.st
+++ b/src/Spec2-Core/SpTableColumn.class.st
@@ -174,6 +174,15 @@ SpTableColumn >> isEditable [
 ]
 
 { #category : 'testing' }
+SpTableColumn >> isExpand [
+	self 
+		deprecated: 'This was wrong from the start, but we carried of for too much time so now is everywhere.'
+		transformWith: '`@receiver isExpand' -> '`@receiver isExpandable'.
+
+	^ self isExpandable
+]
+
+{ #category : 'testing' }
 SpTableColumn >> isExpandable [
 	"Answer if this column is expandable"
 

--- a/src/Spec2-Examples/SpTreePresenter.extension.st
+++ b/src/Spec2-Examples/SpTreePresenter.extension.st
@@ -85,3 +85,16 @@ SpTreePresenter class >> exampleWithDecoratedString [
 		children: [ :aClass | aClass subclasses ];
 		open
 ]
+
+{ #category : '*Spec2-Examples' }
+SpTreePresenter class >> exampleWithExpansion [
+
+	<sampleInstance>
+	^ self new
+		  roots: { Object };
+		  children: [ :aClass | aClass subclasses ];
+		  displayIcon: [ :aClass | self iconNamed: aClass systemIconName ];
+		  display: [ :aClass | aClass name ];
+		  whenExpandChangedDo: [ :ann | (ann item -> ann expanded) crTrace ];
+		  open
+]

--- a/src/Spec2-Examples/SpTreeTablePresenter.extension.st
+++ b/src/Spec2-Examples/SpTreeTablePresenter.extension.st
@@ -112,6 +112,23 @@ SpTreeTablePresenter class >> exampleWithDecoratedString [
 ]
 
 { #category : '*Spec2-Examples' }
+SpTreeTablePresenter class >> exampleWithExpansion [
+
+	^ self new
+		addColumn: (SpCompositeTableColumn new
+			title: 'Classes';
+			addColumn: (SpImageTableColumn new 
+				evaluated: [ :aClass | self iconNamed: aClass systemIconName]; 
+				width: 20);
+			addColumn: (SpStringTableColumn evaluated: #name);
+			yourself);
+		roots: { Object };
+		children: [ :aClass | aClass subclasses ];
+		whenExpandChangedDo: [ :ann | (ann item -> ann expanded) crTrace ];
+		open
+]
+
+{ #category : '*Spec2-Examples' }
 SpTreeTablePresenter class >> exampleWithTwoColumns [ 
 
 	^ self  new

--- a/src/Spec2-ListView/SpTreeColumnViewPresenter.class.st
+++ b/src/Spec2-ListView/SpTreeColumnViewPresenter.class.st
@@ -271,17 +271,6 @@ SpTreeColumnViewPresenter >> whenColumnsChangedDo: aBlock [
 	self property: #columns whenChangedDo: aBlock
 ]
 
-{ #category : 'events' }
-SpTreeColumnViewPresenter >> whenExpandChangedDo: aBlock [
-	"Inform when a tree node has been expanded or collapsed.
-	 `aBlock` receives one optional argument (an instance of `SpTreeExpansionChanged`)."
-
-	self announcer 
-		when: SpTreeExpansionChanged 
-		do: aBlock 
-		for: aBlock receiver
-]
-
 { #category : 'api - events' }
 SpTreeColumnViewPresenter >> whenIsResizableChangedDo: aBlock [
 	"Inform when resizable property has changed. 

--- a/src/Spec2-ListView/SpTreeListViewPresenter.class.st
+++ b/src/Spec2-ListView/SpTreeListViewPresenter.class.st
@@ -303,14 +303,3 @@ SpTreeListViewPresenter >> traversePresentersDo: aBlock excluding: aSet [
 			traversePresentersDo: aBlock 
 			excluding: aSet ]
 ]
-
-{ #category : 'events' }
-SpTreeListViewPresenter >> whenExpandChangedDo: aBlock [
-	"Inform when a tree node has been expanded or collapsed.
-	 `aBlock` receives one optional argument (an instance of `SpTreeExpansionChanged`)."
-
-	self announcer 
-		when: SpTreeExpansionChanged 
-		do: aBlock 
-		for: aBlock receiver
-]


### PR DESCRIPTION
because they are still in use so...

also introduce a deprecated method #isExpand since I am permanently problems because they are not unified.