### PR TITLE
Open browsers on literal and not their names

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -299,7 +299,7 @@ SpCodePresenter >> doBrowseMethodReferences [
 
 	"the dialog sadly hard-codes 'senders'"
 	^ self systemNavigation
-		  openBrowserFor: variable name
+		  openBrowserFor: variable
 		  withMethods: usingMethods
 ]
 
@@ -334,7 +334,7 @@ SpCodePresenter >> doBrowseSenders [
 	variableOrClassName := self selectedSelector ifNil: [ ^ nil ].
 	variable := self lookupEnvironment lookupVar: variableOrClassName. "For global and class variables, sender-of shows intead the using methods"
 	(variable isNotNil and: [ variable isGlobalVariable or: [ variable isClassVariable ] ])
-		ifTrue: [ self systemNavigation openBrowserFor: variable name withMethods: variable usingMethods ]
+		ifTrue: [ self systemNavigation openBrowserFor: variable withMethods: variable usingMethods ]
 		ifFalse: [
 		(Smalltalk tools toolNamed: #messageList) browseSendersOfAll: { variableOrClassName } from: self interactionModel behavior ]
 ]


### PR DESCRIPTION
When opening a method browser, the reference is to a literal and not to its name or a string representation of it.

Otherwise, it does not allow proper refresh.

This is causing right now that refreshing removes elements from the method browser