### PR TITLE
Wait end interaction on tree and list before asserting

### DIFF
--- a/src/Spec2-Backend-Tests/SpAbstractListAdapterMultipleSelectionTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractListAdapterMultipleSelectionTest.class.st
@@ -123,6 +123,7 @@ SpAbstractListAdapterMultipleSelectionTest >> testSelectWidgetIndexRaisesSelecti
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectIndex: 1.
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -132,6 +133,7 @@ SpAbstractListAdapterMultipleSelectionTest >> testSelectWidgetIndexRaisesSelecti
 	presenter selection
 		whenChangedDo: [ :selection | selectedIndex := selection selectedIndexes ].
 	self adapter selectIndex: 1.
+	backendForTest waitUntilUIRedrawed.
 	self assert: (selectedIndex includes: 1)
 ]
 
@@ -155,6 +157,7 @@ SpAbstractListAdapterMultipleSelectionTest >> testUnselectAllInWidgetRaisesEmpty
 	presenter selection
 		whenChangedDo: [ :selection | gotSelection := selection ].
 	self adapter selectIndex: 0.
+	backendForTest waitUntilUIRedrawed.
 	self assert: gotSelection isEmpty
 ]
 
@@ -166,5 +169,6 @@ SpAbstractListAdapterMultipleSelectionTest >> testUnselectAllInWidgetRaisesSelec
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectIndex: 0.
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]

--- a/src/Spec2-Backend-Tests/SpAbstractListAdapterSingleSelectionTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractListAdapterSingleSelectionTest.class.st
@@ -31,9 +31,10 @@ SpAbstractListAdapterSingleSelectionTest >> tearDown [
 
 { #category : 'tests - model-to-widget' }
 SpAbstractListAdapterSingleSelectionTest >> testSelectManyIndexesKeepsLastSelectionInWidget [
+
 	presenter selectIndex: 1.
 	presenter selectIndex: 2.
-	self assert: self adapter selectedIndexes equals: #(2)
+	self assert: self adapter selectedIndexes equals: #( 2 )
 ]
 
 { #category : 'tests - model-to-widget' }
@@ -110,6 +111,7 @@ SpAbstractListAdapterSingleSelectionTest >> testSelectWidgetIndexRaisesSelection
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectIndex: 1.
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -119,6 +121,7 @@ SpAbstractListAdapterSingleSelectionTest >> testSelectWidgetIndexRaisesSelection
 	presenter selection
 		whenChangedDo: [ :selection | selectedIndex := selection selectedIndex ].
 	self adapter selectIndex: 1.
+	backendForTest waitUntilUIRedrawed.
 	self assert: selectedIndex equals: 1
 ]
 
@@ -135,6 +138,7 @@ SpAbstractListAdapterSingleSelectionTest >> testUnselectAllInWidgetNotRaisesEmpt
 	presenter selection
 		whenChangedDo: [ :selection | gotSelection := selection ].
 	self adapter selectIndex: 0.
+	backendForTest waitUntilUIRedrawed.
 	self assert: gotSelection isNil
 ]
 
@@ -145,6 +149,7 @@ SpAbstractListAdapterSingleSelectionTest >> testUnselectAllInWidgetWithoutSelect
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectIndex: 0.
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 0
 ]
 
@@ -172,6 +177,7 @@ SpAbstractListAdapterSingleSelectionTest >> testUnselectWidgetIndexRaisesSelecti
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectIndex: 0.
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -182,5 +188,6 @@ SpAbstractListAdapterSingleSelectionTest >> testUnselectWidgetIndexRaisesSelecti
 	presenter selection
 		whenChangedDo: [ :selection | selectedIndex := selection selectedIndex ].
 	self adapter selectIndex: 0.
+	backendForTest waitUntilUIRedrawed.
 	self assert: selectedIndex equals: 0
 ]

--- a/src/Spec2-Backend-Tests/SpTreeAdapterSingleSelectionTest.class.st
+++ b/src/Spec2-Backend-Tests/SpTreeAdapterSingleSelectionTest.class.st
@@ -77,7 +77,7 @@ SpTreeAdapterSingleSelectionTest >> testSelectPresenterWithoutScrollingDoesNotSc
 	                verticalAlignment lastVisibleRowIndex.
 
 	presenter selectPath: { 150 } scrollToSelection: false.
-
+	backendForTest waitUntilUIRedrawed.
 	self
 		assert: (verticalAlignment firstVisibleRowIndex to:
 			 verticalAlignment lastVisibleRowIndex)
@@ -91,6 +91,7 @@ SpTreeAdapterSingleSelectionTest >> testSelectWidgetIndexRaisesSelectionIndexCha
 	counter := 0.
 	presenter selection whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #(1).
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -101,6 +102,7 @@ SpTreeAdapterSingleSelectionTest >> testSelectWidgetIndexRaisesSelectionIndexCha
 	presenter selection
 		whenChangedDo: [ :selection | selectedPath := selection ].
 	self adapter selectPath: #(1).
+	backendForTest waitUntilUIRedrawed.
 	self assert: selectedPath equals: #(1)
 ]
 
@@ -111,6 +113,7 @@ SpTreeAdapterSingleSelectionTest >> testUnselectAllInWidgetNotRaisesEmptySelecti
 	presenter selection
 		whenChangedDo: [ :selection | gotSelection := selection ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: gotSelection isNil
 ]
 
@@ -123,6 +126,7 @@ SpTreeAdapterSingleSelectionTest >> testUnselectAllInWidgetRaisesSelectionIndexC
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -134,6 +138,7 @@ SpTreeAdapterSingleSelectionTest >> testUnselectAllInWidgetWithoutSelectionDoesN
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 0
 ]
 
@@ -161,6 +166,7 @@ SpTreeAdapterSingleSelectionTest >> testUnselectWidgetIndexRaisesSelectionIndexC
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -172,5 +178,6 @@ SpTreeAdapterSingleSelectionTest >> testUnselectWidgetIndexRaisesSelectionIndexC
 	presenter selection 
 		whenChangedDo: [ :selection | selectedPath := selection ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assertEmpty: selectedPath
 ]

--- a/src/Spec2-Backend-Tests/SpTreeTableAdapterSingleSelectionTest.class.st
+++ b/src/Spec2-Backend-Tests/SpTreeTableAdapterSingleSelectionTest.class.st
@@ -61,6 +61,7 @@ SpTreeTableAdapterSingleSelectionTest >> testSelectPresenterWithScrollingMakeSel
 	presenter selectPath: { 150 } scrollToSelection: true.
 	visibleItems := presenter verticalAlignment firstVisibleRowIndex to:
 	                presenter verticalAlignment lastVisibleRowIndex.
+	backendForTest waitUntilUIRedrawed.
 
 	self assert:
 		(visibleItems includes: presenter selection selectedPath first)
@@ -78,6 +79,7 @@ SpTreeTableAdapterSingleSelectionTest >> testSelectPresenterWithoutScrollingDoes
 	                verticalAlignment lastVisibleRowIndex.
 
 	presenter selectPath: { 150 } scrollToSelection: false.
+	backendForTest waitUntilUIRedrawed.
 
 	self
 		assert: (verticalAlignment firstVisibleRowIndex to:
@@ -100,6 +102,7 @@ SpTreeTableAdapterSingleSelectionTest >> testSelectWhenSortedTransmitsCorrectEle
 	presenter adapter sortByColumn: presenter columns first.
 	"click last element, since they are inversed, it will be the same as before"
 	presenter clickAtPath: #(3).
+	backendForTest waitUntilUIRedrawed.
 	self assert: item equals: 10
 ]
 
@@ -110,6 +113,7 @@ SpTreeTableAdapterSingleSelectionTest >> testSelectWidgetIndexRaisesSelectionInd
 	counter := 0.
 	presenter selection whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #(1).
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -120,6 +124,7 @@ SpTreeTableAdapterSingleSelectionTest >> testSelectWidgetIndexRaisesSelectionInd
 	presenter selection
 		whenChangedDo: [ :selection | selectedPath := selection ].
 	self adapter selectPath: #(1).
+	backendForTest waitUntilUIRedrawed.
 	self assert: selectedPath equals: #(1)
 ]
 
@@ -130,6 +135,7 @@ SpTreeTableAdapterSingleSelectionTest >> testUnselectAllInWidgetNotRaisesEmptySe
 	presenter selection
 		whenChangedDo: [ :selection | gotSelection := selection ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: gotSelection isNil
 ]
 
@@ -142,6 +148,7 @@ SpTreeTableAdapterSingleSelectionTest >> testUnselectAllInWidgetRaisesSelectionI
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -153,6 +160,7 @@ SpTreeTableAdapterSingleSelectionTest >> testUnselectAllInWidgetWithoutSelection
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 0
 ]
 
@@ -180,6 +188,7 @@ SpTreeTableAdapterSingleSelectionTest >> testUnselectWidgetIndexRaisesSelectionI
 	presenter selection
 		whenChangedDo: [ :selection | counter := counter + 1 ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assert: counter equals: 1
 ]
 
@@ -191,5 +200,6 @@ SpTreeTableAdapterSingleSelectionTest >> testUnselectWidgetIndexRaisesSelectionI
 	presenter selection 
 		whenChangedDo: [ :selection | selectedPath := selection ].
 	self adapter selectPath: #().
+	backendForTest waitUntilUIRedrawed.
 	self assertEmpty: selectedPath
 ]


### PR DESCRIPTION
This PR is the following of https://github.com/pharo-spec/Spec/pull/1934
In complicated cases (selecting row in list and table), we need to wait the UI to end processing the action before checking the state of the system

So this PR aims to wait for backend.
I try to modify only necessary methods, others could be fixed by more generic changes such as the one here https://github.com/pharo-spec/Spec/pull/1935