### PR TITLE
senders should go through system navigation

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -331,11 +331,12 @@ SpCodePresenter >> doBrowseSenders [
 
 	| variableOrClassName variable |
 	variableOrClassName := self selectedSelector ifNil: [ ^ nil ].
-	variable := self lookupEnvironment lookupVar: variableOrClassName. "For global and class variables, sender-of shows intead the using methods"
+	variable := self lookupEnvironment lookupVar: variableOrClassName.
+	
+	"For global and class variables, sender-of shows intead the using methods"
 	(variable isNotNil and: [ variable isGlobalVariable or: [ variable isClassVariable ] ])
 		ifTrue: [ self systemNavigation openBrowserFor: variable withMethods: variable usingMethods ]
-		ifFalse: [
-		(Smalltalk tools toolNamed: #messageList) browseSendersOfAll: { variableOrClassName } from: self interactionModel behavior ]
+		ifFalse: [ self systemNavigation browseAllSendersOf: variableOrClassName ]
 ]
 
 { #category : 'private - bindings' }


### PR DESCRIPTION
Fix SpCodePresenter tests

Navigation should go through the presenter's system navigation and not short-circuit directly using Smalltalk tools.

Two other companion PRs arriving in newtools and Pharo